### PR TITLE
node 10 required in engines

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,5 +56,8 @@
   "files": [
     "dist",
     "sql"
-  ]
+  ],
+  "engines": {
+    "node": ">=10.0.0"
+  }
 }


### PR DESCRIPTION
I began to debug the error 
```
TypeError: Promise.all(...).finally is not a function
``` 
after a worker shutdown, when I realized that Promise.finally had been introduce in Node 10. This PR documents this in the engines field.