### PR TITLE
make idle delay configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,9 +98,9 @@ If your database doesn't already include the `pgcrypto` and `uuid-ossp` extensio
 yarn add graphile-worker
 ```
 
-## Running:
+## Running
 
-`graphile-worker` manages it's own database schema (`graphile_worker`) just
+`graphile-worker` manages it's own database schema (`graphile_worker`). Just
 point graphile-worker at your database and we handle our own migrations:
 
 ```
@@ -109,6 +109,21 @@ npx graphile-worker -c "postgres://localhost/mydb"
 
 (`npx` looks for the `graphile-worker` binary locally; it's often better to
 use the `"scripts"` entry in `package.json` instead.)
+
+The following cli options are available:
+
+```
+  --connection, -c  Database connection string, defaults to the 'DATABASE_URL'
+                    envvar                                         
+  --once, -1        Run until there are no runnable jobs left, then exit
+  
+  --watch, -w       [EXPERIMENTAL] Watch task files for changes, automatically
+                    reloading the task code without restarting worker
+                      
+  --jobs, -j        number of jobs to run concurrently 
+
+  --idle-delay      how long to wait between polling for jobs in milliseconds
+```
 
 ## Creating task executors
 

--- a/README.md
+++ b/README.md
@@ -110,19 +110,22 @@ npx graphile-worker -c "postgres://localhost/mydb"
 (`npx` looks for the `graphile-worker` binary locally; it's often better to
 use the `"scripts"` entry in `package.json` instead.)
 
-The following cli options are available:
+The following CLI options are available:
 
 ```
+Options:
+  --help            Show help                                          [boolean]
+  --version         Show version number                                [boolean]
   --connection, -c  Database connection string, defaults to the 'DATABASE_URL'
-                    envvar                                         
+                    envvar                                              [string]
   --once, -1        Run until there are no runnable jobs left, then exit
-  
+                                                      [boolean] [default: false]
   --watch, -w       [EXPERIMENTAL] Watch task files for changes, automatically
                     reloading the task code without restarting worker
-                      
-  --jobs, -j        number of jobs to run concurrently 
-
+                                                      [boolean] [default: false]
+  --jobs, -j        number of jobs to run concurrently              [default: 1]
   --idle-delay      how long to wait between polling for jobs in milliseconds
+                                                        [number] [default: 2000]
 ```
 
 ## Creating task executors

--- a/__tests__/main.runAllJobs.test.ts
+++ b/__tests__/main.runAllJobs.test.ts
@@ -1,13 +1,9 @@
 import { withPgClient, reset, sleepUntil, jobCount } from "./helpers";
-import { TaskList, Task, Worker, WorkerOptions } from "../src/interfaces";
+import { TaskList, Task, Worker } from "../src/interfaces";
 import { runAllJobs } from "../src/main";
 import deferred, { Deferred } from "../src/deferred";
 
 const sleep = (ms: number) => new Promise(resolve => setTimeout(resolve, ms));
-const workerOptions: WorkerOptions = {
-  idleDelay: 2000,
-  workerCount: 1
-};
 
 test("runs jobs", () =>
   withPgClient(async pgClient => {
@@ -48,7 +44,7 @@ Object {
       job1,
       job2
     };
-    await runAllJobs(tasks, pgClient, workerOptions);
+    await runAllJobs(tasks, pgClient);
 
     // Job should have been called once only
     expect(job1).toHaveBeenCalledTimes(1);
@@ -93,7 +89,7 @@ test("schedules errors for retry", () =>
     const tasks: TaskList = {
       job1
     };
-    await runAllJobs(tasks, pgClient, workerOptions);
+    await runAllJobs(tasks, pgClient);
     expect(job1).toHaveBeenCalledTimes(1);
 
     // Check that it failed as expected
@@ -138,11 +134,11 @@ test("retries job", () =>
     };
 
     // Run the job (it will error)
-    await runAllJobs(tasks, pgClient, workerOptions);
+    await runAllJobs(tasks, pgClient);
     expect(job1).toHaveBeenCalledTimes(1);
 
     // Should do nothing the second time, because it's queued for the future (assuming we run this fast enough afterwards!)
-    await runAllJobs(tasks, pgClient, workerOptions);
+    await runAllJobs(tasks, pgClient);
     expect(job1).toHaveBeenCalledTimes(1);
 
     // Tell the job to be runnable
@@ -152,7 +148,7 @@ test("retries job", () =>
 
     // Run the job
     const start = new Date();
-    await runAllJobs(tasks, pgClient, workerOptions);
+    await runAllJobs(tasks, pgClient);
 
     // It should have ran again
     expect(job1).toHaveBeenCalledTimes(2);
@@ -198,11 +194,11 @@ test("supports future-scheduled jobs", () =>
     };
 
     // Run all jobs (none are ready)
-    await runAllJobs(tasks, pgClient, workerOptions);
+    await runAllJobs(tasks, pgClient);
     expect(future).not.toHaveBeenCalled();
 
     // Still not ready
-    await runAllJobs(tasks, pgClient, workerOptions);
+    await runAllJobs(tasks, pgClient);
     expect(future).not.toHaveBeenCalled();
 
     // Tell the job to be runnable
@@ -211,7 +207,7 @@ test("supports future-scheduled jobs", () =>
     );
 
     // Run the job
-    await runAllJobs(tasks, pgClient, workerOptions);
+    await runAllJobs(tasks, pgClient);
 
     // It should have ran again
     expect(future).toHaveBeenCalledTimes(1);
@@ -246,7 +242,7 @@ test("runs jobs asynchronously", () =>
     const tasks: TaskList = {
       job1
     };
-    const runPromise = runAllJobs(tasks, pgClient, workerOptions);
+    const runPromise = runAllJobs(tasks, pgClient);
     const worker: Worker = runPromise["worker"];
     expect(worker).toBeTruthy();
     let executed = false;
@@ -316,11 +312,11 @@ test("runs jobs in parallel", () =>
       job1
     };
     const runPromises = [
-      runAllJobs(tasks, pgClient, workerOptions),
-      runAllJobs(tasks, pgClient, workerOptions),
-      runAllJobs(tasks, pgClient, workerOptions),
-      runAllJobs(tasks, pgClient, workerOptions),
-      runAllJobs(tasks, pgClient, workerOptions)
+      runAllJobs(tasks, pgClient),
+      runAllJobs(tasks, pgClient),
+      runAllJobs(tasks, pgClient),
+      runAllJobs(tasks, pgClient),
+      runAllJobs(tasks, pgClient)
     ];
     let executed = false;
     Promise.all(runPromises).then(() => {
@@ -394,7 +390,7 @@ test("single worker runs jobs in series, purges all before exit", () =>
     const tasks: TaskList = {
       job1
     };
-    const runPromise = runAllJobs(tasks, pgClient, workerOptions);
+    const runPromise = runAllJobs(tasks, pgClient);
     let executed = false;
     runPromise.then(() => {
       executed = true;
@@ -443,9 +439,9 @@ test("jobs added to the same queue will be ran serially (even if multiple worker
       job1
     };
     const runPromises = [
-      runAllJobs(tasks, pgClient, workerOptions),
-      runAllJobs(tasks, pgClient, workerOptions),
-      runAllJobs(tasks, pgClient, workerOptions)
+      runAllJobs(tasks, pgClient),
+      runAllJobs(tasks, pgClient),
+      runAllJobs(tasks, pgClient)
     ];
     let executed = false;
     Promise.all(runPromises).then(() => {

--- a/__tests__/main.start.test.ts
+++ b/__tests__/main.start.test.ts
@@ -1,9 +1,14 @@
 // See also main.runAllJobs.test.ts
 import { reset, withPgPool, sleepUntil, sleep, jobCount } from "./helpers";
-import { TaskList, Task } from "../src/interfaces";
+import { TaskList, Task, WorkerOptions } from "../src/interfaces";
 import { start } from "../src/main";
 import deferred, { Deferred } from "../src/deferred";
 import { Pool } from "pg";
+
+const workerOptions: WorkerOptions = {
+  idleDelay: 2000,
+  workerCount: 1
+};
 
 const addJob = (pgPool: Pool, id: string | number) =>
   pgPool.query(
@@ -32,7 +37,7 @@ test("main will execute jobs as they come up, and exits cleanly", () =>
     };
 
     // Run the worker
-    const workerPool = start(tasks, pgPool, 3);
+    const workerPool = start(tasks, pgPool, workerOptions);
     let finished = false;
     workerPool.promise.then(() => {
       finished = true;

--- a/__tests__/main.start.test.ts
+++ b/__tests__/main.start.test.ts
@@ -32,7 +32,7 @@ test("main will execute jobs as they come up, and exits cleanly", () =>
     };
 
     // Run the worker
-    const workerPool = start(tasks, pgPool);
+    const workerPool = start(tasks, pgPool, { workerCount: 3 });
     let finished = false;
     workerPool.promise.then(() => {
       finished = true;

--- a/__tests__/main.start.test.ts
+++ b/__tests__/main.start.test.ts
@@ -1,14 +1,9 @@
 // See also main.runAllJobs.test.ts
 import { reset, withPgPool, sleepUntil, sleep, jobCount } from "./helpers";
-import { TaskList, Task, WorkerOptions } from "../src/interfaces";
+import { TaskList, Task } from "../src/interfaces";
 import { start } from "../src/main";
 import deferred, { Deferred } from "../src/deferred";
 import { Pool } from "pg";
-
-const workerOptions: WorkerOptions = {
-  idleDelay: 2000,
-  workerCount: 1
-};
 
 const addJob = (pgPool: Pool, id: string | number) =>
   pgPool.query(
@@ -37,7 +32,7 @@ test("main will execute jobs as they come up, and exits cleanly", () =>
     };
 
     // Run the worker
-    const workerPool = start(tasks, pgPool, workerOptions);
+    const workerPool = start(tasks, pgPool);
     let finished = false;
     workerPool.promise.then(() => {
       finished = true;

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -54,7 +54,7 @@ const workerOptions: WorkerOptions = {
 
 const workerPoolOptions: WorkerPoolOptions = {
   workerCount: JOBS,
-  workerOptions
+  ...workerOptions
 }
 
 if (WATCH && ONCE) {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -2,7 +2,7 @@
 import { Pool, PoolClient } from "pg";
 import { migrate } from "./migrate";
 import getTasks from "./getTasks";
-import { WorkerOptions } from "./interfaces";
+import { WorkerOptions, WorkerPoolOptions } from "./interfaces";
 import { start, runAllJobs } from "./main";
 import * as yargs from "yargs";
 import { IDLE_DELAY, CONCURRENT_JOBS } from "./config";
@@ -50,8 +50,12 @@ const IDLE = isInteger(argv["idle-delay"]) ? argv["idle-delay"] : IDLE_DELAY;
 
 const workerOptions: WorkerOptions = {
   idleDelay: IDLE,
-  workerCount: JOBS
 };
+
+const workerPoolOptions: WorkerPoolOptions = {
+  workerCount: JOBS,
+  workerOptions
+}
 
 if (WATCH && ONCE) {
   throw new Error("Cannot specify both --watch and --once");
@@ -92,7 +96,7 @@ async function main() {
       );
     } else {
       // Watch for new jobs
-      const { promise } = start(watchedTasks.tasks, pgPool, workerOptions);
+      const { promise } = start(watchedTasks.tasks, pgPool, workerPoolOptions);
       // Continue forever(ish)
       await promise;
     }

--- a/src/config.ts
+++ b/src/config.ts
@@ -12,3 +12,8 @@ export const IDLE_DELAY = 2000;
  * exception?
  */
 export const MAX_CONTIGUOUS_ERRORS = 10;
+
+/**
+ * Number of jobs to run concurrently
+ */
+export const CONCURRENT_JOBS = 1;

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -81,7 +81,6 @@ export interface WorkerOptions {
   workerId?: string;
 }
 
-export interface WorkerPoolOptions {
+export interface WorkerPoolOptions extends WorkerOptions {
   workerCount?: number;
-  workerOptions?: WorkerOptions;
 }

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -1,6 +1,19 @@
 import { PoolClient } from "pg";
 import { IDebugger } from "./debug";
 
+/*
+ * Terminology:
+ *
+ * - job: an entry in the `jobs` table, representing work to be done
+ * - queue: an entry in the `job_queues` table, representing a list of jobs to be executed sequentially
+ * - task_identifier: the name of the task to be executed to complete the job
+ * - task: a function representing code to be executed for a particular job (identified by the task_identifier); i.e. a file in the `tasks/` folder
+ * - task list: an object collection of named tasks
+ * - watched task list: an abstraction for a task list that can be updated when the tasks on the disk change
+ * - worker: the thing that checks out a job from the database, executes the relevant task, and then returns the job to the database with either success or failure
+ * - worker pool: a collection of workers to enable processing multiple jobs in parallel
+ */
+
 export type WithPgClient = <T = void>(
   callback: (pgClient: PoolClient) => Promise<T>
 ) => Promise<T>;
@@ -64,6 +77,11 @@ export interface TaskOptions {
 }
 
 export interface WorkerOptions {
-  idleDelay: number,
-  workerCount: number
+  idleDelay?: number;
+  workerId?: string;
+}
+
+export interface WorkerPoolOptions {
+  workerCount?: number;
+  workerOptions?: WorkerOptions;
 }

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -62,3 +62,8 @@ export interface TaskOptions {
   runAt?: Date;
   maxAttempts?: number;
 }
+
+export interface WorkerOptions {
+  idleDelay: number,
+  workerCount: number
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -68,8 +68,8 @@ export function start(
 
   debug(`Worker pool options are %O`, options);
   const {
-    workerOptions = {},
-    workerCount = CONCURRENT_JOBS
+    workerCount = CONCURRENT_JOBS,
+    ...workerOptions
   } = options;
 
   // Clean up when certain signals occur

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,5 +1,5 @@
 import { Pool, PoolClient } from "pg";
-import { TaskList, Worker, Job, WorkerPool, WorkerOptions } from "./interfaces";
+import { TaskList, Worker, Job, WorkerPool, WorkerOptions, WorkerPoolOptions } from "./interfaces";
 import debug from "./debug";
 import deferred from "./deferred";
 import SIGNALS from "./signals";
@@ -8,6 +8,7 @@ import {
   makeWithPgClientFromPool,
   makeWithPgClientFromClient
 } from "./helpers";
+import { CONCURRENT_JOBS } from "./config"
 
 const allWorkerPools: Array<WorkerPool> = [];
 
@@ -62,10 +63,14 @@ function registerSignalHandlers() {
 export function start(
   tasks: TaskList,
   pgPool: Pool,
-  workerOptions: WorkerOptions
+  options: WorkerPoolOptions = {}
 ): WorkerPool {
 
-  debug(`Worker options are %O`, workerOptions);
+  debug(`Worker pool options are %O`, options);
+  const {
+    workerOptions = {},
+    workerCount = CONCURRENT_JOBS
+  } = options;
 
   // Clean up when certain signals occur
   registerSignalHandlers();
@@ -191,7 +196,7 @@ export function start(
 
   // Spawn our workers; they can share clients from the pool.
   const withPgClient = makeWithPgClientFromPool(pgPool);
-  for (let i = 0; i < workerOptions.workerCount; i++) {
+  for (let i = 0; i < workerCount; i++) {
     workers.push(makeNewWorker(tasks, withPgClient, workerOptions));
   }
 
@@ -200,5 +205,5 @@ export function start(
   return workerPool;
 }
 
-export const runAllJobs = (tasks: TaskList, client: PoolClient, workerOptions: WorkerOptions) =>
-  makeNewWorker(tasks, makeWithPgClientFromClient(client), workerOptions, false).promise;
+export const runAllJobs = (tasks: TaskList, client: PoolClient, options: WorkerOptions = {}) =>
+  makeNewWorker(tasks, makeWithPgClientFromClient(client), options, false).promise;

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -1,6 +1,6 @@
-import { TaskList, Worker, Job, WithPgClient } from "./interfaces";
+import { TaskList, Worker, Job, WithPgClient, WorkerOptions } from "./interfaces";
 import globalDebug from "./debug";
-import { IDLE_DELAY, MAX_CONTIGUOUS_ERRORS } from "./config";
+import { MAX_CONTIGUOUS_ERRORS } from "./config";
 import * as assert from "assert";
 import deferred from "./deferred";
 import { makeHelpers } from "./helpers";
@@ -8,6 +8,7 @@ import { makeHelpers } from "./helpers";
 export function makeNewWorker(
   tasks: TaskList,
   withPgClient: WithPgClient,
+  workerOptions: WorkerOptions,
   continuous = true,
   workerId = `worker-${Math.random()}`
 ): Worker {
@@ -87,7 +88,7 @@ export function makeNewWorker(
         } else {
           if (active) {
             // Error occurred fetching a job; try again...
-            doNextTimer = setTimeout(() => doNext(), IDLE_DELAY);
+            doNextTimer = setTimeout(() => doNext(), workerOptions.idleDelay);
           } else {
             promise.reject(err);
           }
@@ -112,7 +113,7 @@ export function makeNewWorker(
             // moment.
             doNext();
           } else {
-            doNextTimer = setTimeout(() => doNext(), IDLE_DELAY);
+            doNextTimer = setTimeout(() => doNext(), workerOptions.idleDelay);
           }
         } else {
           promise.resolve();

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -6,11 +6,10 @@ import {
   WorkerOptions
 } from "./interfaces";
 import globalDebug from "./debug";
-import { MAX_CONTIGUOUS_ERRORS } from "./config";
+import { IDLE_DELAY, MAX_CONTIGUOUS_ERRORS } from "./config";
 import * as assert from "assert";
 import deferred from "./deferred";
 import { makeHelpers } from "./helpers";
-import { IDLE_DELAY } from "./config";
 
 export function makeNewWorker(
   tasks: TaskList,
@@ -20,7 +19,8 @@ export function makeNewWorker(
 ): Worker {
   const {
     idleDelay = IDLE_DELAY,
-    workerId = `worker-${Math.random()}`
+    // The `||0.1` is to eliminate the vanishingly-small possibility of Math.random() returning 0. Math.random() can never return 1.
+    workerId = `worker-${String(Math.random() || 0.1).substr(2)}`
   } = options;
   const promise = deferred();
   let activeJob: Job | null = null;


### PR DESCRIPTION
* #4 
* In order to pass the `--idle-delay` value down to the worker, I introduced a `WorkerOptions` object. I suspect there could be more options to come.
* I tried to write tests - but no avail so far. I tried to trap the `idleDelay` option by using Jest timer mocks (https://jestjs.io/docs/en/timer-mocks.html) but I could not get it to work as expected.
* Maybe we can agree on the implementation first (or reject it) and then I can tackle the tests again.