### PR TITLE
Resolves #17 - Gives DATABASE_URL env var a chance to shine

### DIFF
--- a/src/runner.ts
+++ b/src/runner.ts
@@ -29,7 +29,7 @@ const processOptions = async (options: RunnerOptions) => {
     }
 
     assert(
-      !!options.pgPool !== !!options.connectionString,
+      !(!!options.pgPool && !!options.connectionString),
       "Exactly one of either pgPool or connectionString should be set"
     );
     let pgPool: Pool;


### PR DESCRIPTION
Might be a little more work to do here, plus test coverage for setting options, but this quickly let's us use process.env.DATABASE_URL.