### PR TITLE
load tasks written in typescript

### DIFF
--- a/src/getTasks.ts
+++ b/src/getTasks.ts
@@ -105,7 +105,7 @@ export default async function getTasks(
     if (watch) {
       watchers.push(
         chokidar
-          .watch(`${taskPath}/*.js`, {
+          .watch(`${taskPath}/*.{j,t}s`, {
             ignoreInitial: true,
           })
           .on("all", (event, eventFilePath) => {
@@ -128,7 +128,7 @@ export default async function getTasks(
     // Try and require its contents
     const files = await readdir(taskPath);
     for (const file of files) {
-      if (file.endsWith(".js")) {
+      if (file.endsWith(".js") || file.endsWith(".ts")) {
         const taskName = file.substr(0, file.length - 3);
         try {
           await loadFileIntoTasks(


### PR DESCRIPTION
makes it possible to run: `ts-node /scripts/node_modules/.bin/graphile-worker`

maybe there's another way of doing so but I'm just beginning with typescript and don't know the ecosystem very well

I tried looking for an env var to detect if we're running with ts-node but didn't find anything

if this is an interesting feature, I can a cli flag to enable this behavior