### PR TITLE
Add pgPool 'error' handler

### DIFF
--- a/src/runner.ts
+++ b/src/runner.ts
@@ -47,6 +47,19 @@ const processOptions = async (options: RunnerOptions) => {
       );
     }
 
+    pgPool.on("error", err => {
+      /*
+       * This handler is required so that client connection errors don't bring
+       * the server down (via `unhandledError`).
+       *
+       * `pg` will automatically terminate the client and remove it from the
+       * pool, so we don't actually need to take any action here, just ensure
+       * that the event listener is registered.
+       */
+      // eslint-disable-next-line no-console
+      console.error("PostgreSQL client generated error: ", err.message);
+    });
+
     const withPgClient = makeWithPgClientFromPool(pgPool);
 
     // Migrate


### PR DESCRIPTION
* #22 
* The process does not exit anymore in case of a backend restart - but there is a Promise Rejection Warning:

```
1|worker  | (node:64357) UnhandledPromiseRejectionWarning: Error: Client has encountered a connection error and is not queryable
1|worker  |     at process.nextTick (.../node_modules/pg/lib/client.js:521:25)
1|worker  |     at process._tickCallback (internal/process/next_tick.js:61:11)
1|worker  | (node:64357) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). (rejection id: 1)
1|worker  | (node:64357) [DEP0018] DeprecationWarning: Unhandled promise rejections are deprecated. In the future, promise rejections that are not handled will terminate the Node.js process with a non-zero exit code
```

* Maybe there is more work to do here...