### PR TITLE
Allow DATABASE_URL env variable, #17

### DIFF
--- a/__tests__/helpers.ts
+++ b/__tests__/helpers.ts
@@ -2,11 +2,13 @@ import * as pg from "pg";
 import { Job } from "../src/interfaces";
 import { migrate } from "../src/migrate";
 
+export const TEST_CONNECTION_STRING = "graphile_worker_test";
+
 export async function withPgPool<T = any>(
   cb: (pool: pg.Pool) => Promise<T>
 ): Promise<T> {
   const pool = new pg.Pool({
-    connectionString: "graphile_worker_test"
+    connectionString: TEST_CONNECTION_STRING,
   });
   try {
     return await cb(pool);

--- a/__tests__/runner.runOnce.test.ts
+++ b/__tests__/runner.runOnce.test.ts
@@ -1,0 +1,84 @@
+import { runOnce } from "../src/runner";
+import { RunnerOptions } from "../src/interfaces";
+import { Pool } from "pg";
+import { withPgPool, TEST_CONNECTION_STRING } from "./helpers";
+
+async function runOnceErrorAssertion(options: RunnerOptions, message: string) {
+  expect.assertions(1);
+  try {
+    await runOnce(options);
+  } catch (e) {
+    expect(e.message).toMatch(message);
+  }
+}
+
+test("at least a list of tasks or a task directory must be provided", async () => {
+  const options: RunnerOptions = {};
+  await runOnceErrorAssertion(
+    options,
+    "You must specify either `options.taskList` or `options.taskDirectory"
+  );
+});
+
+test("taskList and taskDirectory cannot be provided a the same time", async () => {
+  const options: RunnerOptions = {
+    taskDirectory: "foo",
+    taskList: { task: () => {} },
+  };
+  await runOnceErrorAssertion(
+    options,
+    "Exactly one of either `taskDirectory` or `taskList` should be set"
+  );
+});
+
+test("at least a connectionString, a pgPool or the DATABASE_URL env variable must be provided", async () => {
+  const options: RunnerOptions = {
+    taskList: { task: () => {} },
+  };
+  await runOnceErrorAssertion(
+    options,
+    "You must either specify `pgPool` or `connectionString`, or you must make the `DATABASE_URL` environmental variable available."
+  );
+});
+
+test("connectionString and a pgPool cannot provided a the same time", async () => {
+  const options: RunnerOptions = {
+    taskList: { task: () => {} },
+    connectionString: TEST_CONNECTION_STRING,
+    pgPool: new Pool(),
+  };
+  await runOnceErrorAssertion(
+    options,
+    "Both `pgPool` and `connectionString` are set, at most one of these options should be provided"
+  );
+});
+
+test("providing just a DATABASE_URL is possible", async () => {
+  process.env.DATABASE_URL = TEST_CONNECTION_STRING;
+  const options: RunnerOptions = {
+    taskList: { task: () => {} },
+  };
+  expect.assertions(0);
+  await runOnce(options);
+  delete process.env.DATABASE_URL;
+});
+
+test("providing just a connectionString is possible", async () => {
+  const options: RunnerOptions = {
+    taskList: { task: () => {} },
+    connectionString: TEST_CONNECTION_STRING,
+  };
+  expect.assertions(0);
+  await runOnce(options);
+});
+
+test("providing just a pgPool is possible", async () => {
+  withPgPool(async pgPool => {
+    const options: RunnerOptions = {
+      taskList: { task: () => {} },
+      pgPool: pgPool,
+    };
+    expect.assertions(0);
+    await runOnce(options);
+  });
+});

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -12,8 +12,8 @@ const processOptions = async (options: RunnerOptions) => {
 
   try {
     assert(
-      !!options.taskDirectory !== !!options.taskList,
-      "Exactly one of either taskDirectory or taskList should be set"
+      !options.taskDirectory || !options.taskList,
+      "Exactly one of either `taskDirectory` or `taskList` should be set"
     );
     let taskList: TaskList;
     if (options.taskList) {
@@ -29,8 +29,8 @@ const processOptions = async (options: RunnerOptions) => {
     }
 
     assert(
-      !!options.pgPool !== !!options.connectionString,
-      "Exactly one of either pgPool or connectionString should be set"
+      !options.pgPool || !options.connectionString,
+      "Both `pgPool` and `connectionString` are set, at most one of these options should be provided"
     );
     let pgPool: Pool;
     if (options.pgPool) {


### PR DESCRIPTION
* This replaces the stale PR #20 and fixes #17
* Added some tests for the options processing in form of `runner.runOnce.test`
