### PR TITLE
How to solve issue when extensions aren't in public

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,7 @@ PostgreSQL 10+\* and Node 10+\*.
 If your database doesn't already include the `pgcrypto` and `uuid-ossp`
 extensions we'll automatically install them into the public schema for you. If
 you have them installed in a different schema (unlikely) you may face issues.
+Making alias functions in the public schema, should solve this issue.
 
 \* Might work with older versions, but has not been tested.
 


### PR DESCRIPTION
This is how I fixed the issue on an old database that has extensions installed in another schema. Not sure if this is really a nice/elegant way of fixing this.

Maybe I should list the used functions, or link to an external file/readme with the code or solution to fix this? I don't really want to pollute the main readme with edge cases.

What's your thought on the best place to put this info?