### PR TITLE
Remove root level await in quickstart

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,20 +82,27 @@ You should see the worker output `Hello, Bobby Tables`. Gosh, that was fast!
 Instead of running `graphile-worker` via the CLI, you may use it directly in your Node.js code:
 
 ```js
-import { run } from "graphile-worker";
+const { run } = require("graphile-worker");
 
-const runner = await run({
-  connectionString: "postgres:///",
-  concurrency: 5,
-  pollInterval: 1000,
-  // you can set the taskList or taskDirectory but not both
-  taskList: {
-    testTask: async (payload, helpers) => {
-      console.log("working on task...");
+async function main() {
+  const runner = await run({
+    connectionString: "postgres:///",
+    concurrency: 5,
+    pollInterval: 1000,
+    // you can set the taskList or taskDirectory but not both
+    taskList: {
+      testTask: async (payload, helpers) => {
+        console.log("working on task...");
+      },
     },
-  },
-  // or:
-  //   taskDirectory: `${__dirname}/tasks`,
+    // or:
+    //   taskDirectory: `${__dirname}/tasks`,
+  });
+}
+
+main().catch(err => {
+  console.error(err);
+  process.exit(1);
 });
 ```
 


### PR DESCRIPTION
* Async/Await full example
* use `require` instead of `import` like in the other examples

Fixes #14 