### PR TITLE
fix(helpers): add `debug` helper for vague backwards compatibility

### DIFF
--- a/__tests__/helpers.ts
+++ b/__tests__/helpers.ts
@@ -2,6 +2,8 @@ import * as pg from "pg";
 import { Job } from "../src/interfaces";
 import { migrate } from "../src/migrate";
 
+process.env.GRAPHILE_WORKER_DEBUG = "1";
+
 export const TEST_CONNECTION_STRING = "graphile_worker_test";
 
 export async function withPgPool<T = any>(
@@ -66,7 +68,7 @@ export async function jobCount(
   pgPoolOrClient: pg.Pool | pg.PoolClient
 ): Promise<number> {
   const {
-    rows: [row]
+    rows: [row],
   } = await pgPoolOrClient.query(
     "select count(*)::int from graphile_worker.jobs"
   );
@@ -85,7 +87,7 @@ export function makeMockJob(taskIdentifier: string): Job {
     attempts: 0,
     last_error: null,
     created_at: createdAt,
-    updated_at: createdAt
+    updated_at: createdAt,
   };
 }
 

--- a/__tests__/runner.runOnce.test.ts
+++ b/__tests__/runner.runOnce.test.ts
@@ -72,7 +72,7 @@ test("providing just a connectionString is possible", async () => {
   await runOnce(options);
 });
 
-test("providing just a pgPool is possible", async () => {
+test("providing just a pgPool is possible", async () =>
   withPgPool(async pgPool => {
     const options: RunnerOptions = {
       taskList: { task: () => {} },
@@ -80,5 +80,4 @@ test("providing just a pgPool is possible", async () => {
     };
     expect.assertions(0);
     await runOnce(options);
-  });
-});
+  }));

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -39,15 +39,28 @@ export function makeHelpers(
     taskIdentifier: job.task_identifier,
     jobId: job.id,
   });
-  return {
+  const helpers: Helpers = {
     job,
     logger: jobLogger,
     withPgClient,
     query: (queryText, values) =>
       withPgClient(pgClient => pgClient.query(queryText, values)),
     addJob: makeAddJob(withPgClient),
+
     // TODO: add an API for giving workers more helpers
   };
+
+  // DEPRECATED METHODS
+  Object.assign(helpers, {
+    debug(format: string, ...parameters: any[]): void {
+      jobLogger.error(
+        "REMOVED: `helpers.debug` has been replaced with `helpers.logger.debug`; please do not use `helpers.debug`"
+      );
+      jobLogger.debug(format, { parameters });
+    },
+  } as any);
+
+  return helpers;
 }
 
 export function makeWithPgClientFromPool(pgPool: Pool) {


### PR DESCRIPTION
They still need to move to the new logging system, but at least their old code should still run.