### PR TITLE
Make the task payload of type any

### DIFF
--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -36,7 +36,7 @@ export interface Helpers {
   addJob: AddJobFunction;
 }
 
-export type Task = (payload: unknown, helpers: Helpers) => void | Promise<void>;
+export type Task = (payload: any, helpers: Helpers) => void | Promise<void>;
 
 export function isValidTask(fn: unknown): fn is Task {
   if (typeof fn === "function") {


### PR DESCRIPTION
It allows instead of it:
```typescript
function email(payload: unknown, helpers: Helpers) {
  const p = payload as Payload
  ...
}
```
write it:
```typescript
function email(payload: Payload, helpers: Helpers) {
  ...
}
```