### PR TITLE
Re-export `defaultLogger` from top level

### DIFF
--- a/README.md
+++ b/README.md
@@ -265,6 +265,17 @@ main().catch(err => {
 
 ### The logger option
 
+If you want to modify just the scope of the default logger, you can do so simply.  For example:
+
+```js
+const { defaultLogger, run } = require("graphile-worker");
+
+run({
+  logger: defaultLogger.scope({ workerId: 'Worker #1' }),
+  /* pgPool, taskList, etc... */
+});
+```
+
 You may customise where log messages from graphile-worker (and your tasks) go by supplying a custom `Logger` instance using your own `logFactory`.
 
 ```js

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,11 @@ export * from "./interfaces";
 
 export { runTaskList, runTaskListOnce } from "./main";
 export { run, runOnce, runMigrations } from "./runner";
-export { Logger, LogFunctionFactory, consoleLogFactory } from "./logger";
+export {
+  Logger,
+  LogFunctionFactory,
+  consoleLogFactory,
+  defaultLogger,
+} from "./logger";
 
 export { getTasks };


### PR DESCRIPTION
Also adds documentation on one potential use case: modifying the default
logger scope.