### PR TITLE
fix(types): add `workerId` to `RunnerOptions`

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,6 +217,7 @@ The following options for these methods are available.
 - `concurrency`: The equivalent of the cli `--jobs` option with the same default value.
 - `pollInterval`: The equivalent of the cli `--poll-interval` option with the same default value.
 - `logger`: To change how log messages are output you may provide a custom logger; see `logger` below
+- `workerId`: Static worker ID used for created workers; should only be used with `concurrency: 1`
 - the database is identified through one of these options:
   - `connectionString`: A PostgreSQL connection string to the database containing the job queue, or
   - `pgPool`: A `pg.Pool` instance to use

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -121,7 +121,7 @@ export interface WorkerOptions extends WorkerSharedOptions {
   workerId?: string;
 }
 
-export interface WorkerPoolOptions extends WorkerSharedOptions {
+export interface WorkerPoolOptions extends WorkerOptions {
   /**
    * Number of jobs to run concurrently
    */


### PR DESCRIPTION

This PR also adds documentation to the readme for this option.  I'd
appreciate any feedback on that part.