### PR TITLE
feat: allow existing jobs to be updated and removed

### DIFF
--- a/README.md
+++ b/README.md
@@ -420,6 +420,7 @@ function, or by calling SQL from your application code. You do this using the
 - `queue_name` - if you want certain tasks to run one at a time, add them to the same named queue (defaults to a random value)
 - `run_at` - a timestamp after which to run the job; defaults to now.
 - `max_attempts` - if this task fails, how many times should we retry it? Default: 25.
+- `job_key` - unique identifier for the job, used to update or remove it later if needed (see [Updating and removing jobs](#updating-and-removing-jobs))
 
 Typically you'll want to set the `identifier` and `payload`:
 
@@ -516,6 +517,25 @@ CREATE TRIGGER generate_pdf_update
   WHEN (NEW.title IS DISTINCT FROM OLD.title)
   EXECUTE PROCEDURE trigger_job('generate_pdf');
 ```
+
+## Updating and removing jobs
+
+Jobs scheduled with a `job_key` parameter may be updated later, provided they are still pending, by calling `add_job` again with the same `job_key` value. This can be used for rescheduling jobs scheduled to run at a future date, or to ensure only one of a given job is scheduled at a time. When a job is updated, any omitted parameters are reset to their defaults, with the exception of `queue_name`. For example:
+
+```sql
+SELECT graphile_worker.add_job('send_email', '{"count": 1}', job_key := 'abc');
+SELECT graphile_worker.add_job('send_email', '{"count": 2}', job_key := 'abc');
+```
+
+The `send_email` job above will run only once, with the payload `'{"count": 2}'`.
+
+Pending jobs may also be removed using `job_key`:
+
+```sql
+SELECT graphile_worker.remove_job('abc');
+```
+
+**Note:** If a job is updated using `add_job` once it is already running or completed, the second job will be scheduled separately, meaning both will run. Likewise, calling `remove_job` for a running or completed job is a no-op.
 
 ## Uninstallation
 

--- a/__tests__/main.runTaskList.test.ts
+++ b/__tests__/main.runTaskList.test.ts
@@ -17,7 +17,7 @@ test("main will execute jobs as they come up, and exits cleanly", () =>
 
     // Build the tasks
     const jobPromises: {
-      [id: string]: Deferred<void>;
+      [id: string]: Deferred;
     } = {};
     const job1: Task = jest.fn(({ id }: { id: string }) => {
       const jobPromise = deferred();
@@ -63,7 +63,7 @@ test("main will execute jobs as they come up, and exits cleanly", () =>
 test("doesn't bail on deprecated `debug` function", () =>
   withPgPool(async pgPool => {
     await reset(pgPool);
-    let jobPromise: Deferred<void> | null = null;
+    let jobPromise: Deferred | null = null;
     const tasks: TaskList = {
       job1(payload, helpers) {
         // @ts-ignore Not officially supported

--- a/__tests__/main.runTaskListOnce.test.ts
+++ b/__tests__/main.runTaskListOnce.test.ts
@@ -268,7 +268,7 @@ test("allows update of pending jobs", () =>
     );
     expect(updatedJobs).toHaveLength(1);
     const updatedJob = updatedJobs[0];
-    expect(updateJob.id).toEqual(job.id);
+    expect(updatedJob.id).toEqual(job.id);
     expect(updatedJob.run_at).toEqual(now);
 
     // Run the task

--- a/__tests__/main.runTaskListOnce.test.ts
+++ b/__tests__/main.runTaskListOnce.test.ts
@@ -335,7 +335,6 @@ test("schedules a new job if existing is being processed", () =>
     );
 
     // run the job
-    await sleep(20); // Give PostgreSQL connections a moment to synchronize
     const promise = runTaskListOnce(tasks, pgClient);
 
     // wait for it to be picked up for processing

--- a/__tests__/main.runTaskListOnce.test.ts
+++ b/__tests__/main.runTaskListOnce.test.ts
@@ -471,7 +471,7 @@ test("job details do not change unless specified in update", () =>
     expect(jobs).toHaveLength(1);
     expect(jobs[0]).toMatchObject(original);
 
-    // update job, but don't provided any new details
+    // update job, but don't provide any new details
     await pgClient.query(
       `select graphile_worker.add_job(
         'job1',

--- a/__tests__/main.runTaskListOnce.test.ts
+++ b/__tests__/main.runTaskListOnce.test.ts
@@ -433,7 +433,6 @@ test("schedules a new job if the existing is pending retry", () =>
   }));
 
 test("job details do not change unless specified in update", () =>
-  // queue_name, payload, task_identifier,
   withPgClient(async pgClient => {
     await reset(pgClient);
 

--- a/__tests__/main.runTaskListOnce.test.ts
+++ b/__tests__/main.runTaskListOnce.test.ts
@@ -268,6 +268,7 @@ test("allows update of pending jobs", () =>
     );
     expect(updatedJobs).toHaveLength(1);
     const updatedJob = updatedJobs[0];
+    expect(updateJob.id).toEqual(job.id);
     expect(updatedJob.run_at).toEqual(now);
 
     // Run the task

--- a/__tests__/main.runTaskListOnce.test.ts
+++ b/__tests__/main.runTaskListOnce.test.ts
@@ -238,7 +238,7 @@ test("allows update of pending jobs", () =>
 
     // Schedule a future job - note incorrect payload
     const runAt = new Date();
-    runAt.setSeconds(runAt.getSeconds() + 3);
+    runAt.setSeconds(runAt.getSeconds() + 60);
 
     await pgClient.query(
       `select graphile_worker.add_job('job1', '{"a": "wrong"}', run_at := '${runAt.toISOString()}', job_key := 'abc')`

--- a/__tests__/main.runTaskListOnce.test.ts
+++ b/__tests__/main.runTaskListOnce.test.ts
@@ -331,6 +331,7 @@ test("schedules a new job if existing is being processed", () =>
     );
 
     // run the job
+    await sleep(20); // Give PostgreSQL connections a moment to synchronise
     const promise = runTaskListOnce(tasks, pgClient);
 
     // wait for it to be picked up for processing

--- a/__tests__/main.runTaskListOnce.test.ts
+++ b/__tests__/main.runTaskListOnce.test.ts
@@ -554,10 +554,6 @@ test("pending jobs can be removed", () =>
   withPgClient(async pgClient => {
     await reset(pgClient);
 
-    const tasks: TaskList = {
-      job1: jest.fn(() => {}),
-    };
-
     // Schedule a job
     await pgClient.query(
       `select * from graphile_worker.add_job('job1', '{"a": "1"}', job_key := 'abc')`
@@ -574,10 +570,10 @@ test("pending jobs can be removed", () =>
 
     // remove the job
     await pgClient.query(`select * from graphile_worker.remove_job('abc')`);
-
-    // check no jobs run
-    await runTaskListOnce(tasks, pgClient);
-    expect(tasks.job1).not.toHaveBeenCalled();
+    // check there are no jobs
+    expect(
+      (await pgClient.query(`select * from graphile_worker.jobs`)).rows
+    ).toHaveLength(0);
   }));
 
 test("jobs in progress cannot be removed", () =>

--- a/__tests__/migrate.test.ts
+++ b/__tests__/migrate.test.ts
@@ -24,7 +24,7 @@ test("migration installs schema; second migration does no harm", async () => {
     const { rows: migrationRows } = await pgClient.query(
       `select * from graphile_worker.migrations`
     );
-    expect(migrationRows).toHaveLength(1);
+    expect(migrationRows).toHaveLength(2);
     const migration = migrationRows[0];
     expect(migration.id).toEqual(1);
 

--- a/sql/000002.sql
+++ b/sql/000002.sql
@@ -5,7 +5,12 @@ alter table graphile_worker.jobs add locked_at timestamptz;
 alter table graphile_worker.jobs add locked_by text;
 
 -- update add_job behaviour to meet new requirements
-drop function graphile_worker.add_job;
+drop function if exists graphile_worker.add_job(identifier text,
+  payload json,
+  queue_name text,
+  run_at timestamptz,
+  max_attempts int
+);
 create function graphile_worker.add_job(
   identifier text,
   payload json = null,

--- a/sql/000002.sql
+++ b/sql/000002.sql
@@ -97,6 +97,17 @@ end;
 $$ language plpgsql;
 
 
+--- implement new remove_job function
+
+create function graphile_worker.remove_job(
+  job_key text
+) returns graphile_worker.jobs as $$
+  delete from graphile_worker.jobs
+    where key = job_key
+    and locked_at is null
+  returning *;
+$$ language sql;
+
 
 -- Update other functions to handle locked_at denormalisation
 

--- a/sql/000002.sql
+++ b/sql/000002.sql
@@ -63,9 +63,9 @@ begin
       returning *
       into v_job;
 
+    -- if the returned id is null, assume job is already locked for processing
+    -- and couldn't be updated
     if v_job.id is null then
-      -- assume job is already locked for processing
-
       -- remove existing key to allow a new one to be inserted, and prevent any
       -- subsequent retries by bumping attempts to the max allowed
       update graphile_worker.jobs set

--- a/sql/000002.sql
+++ b/sql/000002.sql
@@ -1,4 +1,3 @@
--- TODO evaluate perf re partial indexing instead of full unique
 alter table graphile_worker.jobs add column key text unique;
 
 alter table graphile_worker.jobs add locked_at timestamptz;
@@ -180,4 +179,3 @@ begin
   return v_row;
 end;
 $$ language plpgsql;
-

--- a/sql/000002.sql
+++ b/sql/000002.sql
@@ -156,7 +156,7 @@ begin
       run_at = greatest(now(), run_at) + (exp(least(attempts, 10))::text || ' seconds')::interval,
       locked_by = null,
       locked_at = null
-    where id = job_id
+    where id = job_id and locked_by = worker_id
     returning * into v_row;
 
   update graphile_worker.job_queues

--- a/sql/000002.sql
+++ b/sql/000002.sql
@@ -1,0 +1,165 @@
+-- TODO evaluate perf re partial indexing instead of full unique
+alter table graphile_worker.jobs add column key text unique;
+
+alter table graphile_worker.jobs add locked_at timestamptz;
+alter table graphile_worker.jobs add locked_by text;
+
+-- update add_job behaviour to meet new requirements
+drop function graphile_worker.add_job;
+create function graphile_worker.add_job(
+  identifier text,
+  payload json = null,
+  queue_name text = null,
+  run_at timestamptz = null,
+  max_attempts int = null,
+  job_key text = null
+) returns graphile_worker.jobs as $$
+declare
+  v_job graphile_worker.jobs;
+begin
+  if job_key is null then
+    insert into graphile_worker.jobs(task_identifier, payload, queue_name, run_at, max_attempts)
+      values(
+        identifier,
+        coalesce(payload, '{}'),
+        coalesce(queue_name, public.gen_random_uuid()::text),
+        coalesce(run_at, now()),
+        coalesce(max_attempts, 25)
+      )
+      returning *
+      into v_job;
+  else
+    insert into graphile_worker.jobs (task_identifier, payload, queue_name, run_at, max_attempts, key)
+      values(
+        identifier,
+        coalesce(payload, '{}'),
+        coalesce(queue_name, public.gen_random_uuid()::text),
+        coalesce(run_at, now()),
+        coalesce(max_attempts, 25),
+        job_key
+      )
+      on conflict (key) do update set
+        -- update job details if provided, otherwise maintain existing value
+        task_identifier=coalesce(add_job.identifier, jobs.task_identifier),
+        payload=coalesce(add_job.payload, jobs.payload),
+        queue_name=coalesce(add_job.queue_name, jobs.queue_name),
+        max_attempts=coalesce(add_job.max_attempts, jobs.max_attempts),
+
+        -- update run_at if argument is provided. If not, and there has been an
+        -- error, assume run_at reflects the error retry backoff, so reset it.
+        -- If no errors, maintain existing value by default
+        run_at=coalesce(
+          add_job.run_at,
+          (case when jobs.attempts > 0
+            then now()
+            else jobs.run_at
+          end)
+        ),
+
+        -- always reset error/retry state
+        attempts=0,
+        last_error=null
+      where jobs.locked_at is null
+      returning *
+      into v_job;
+
+    if v_job.id is null then
+      -- assume job is already locked for processing
+
+      -- remove existing key to allow a new one to be inserted, and prevent any
+      -- subsequent retries by bumping attempts to the max allowed
+      update graphile_worker.jobs set
+        key = null,
+        attempts = jobs.max_attempts
+      where key = job_key;
+
+      -- insert the new job. Assume no conflicts due to the update above
+      insert into graphile_worker.jobs(task_identifier, payload, queue_name, run_at, max_attempts, key)
+        values(
+          identifier,
+          coalesce(payload, '{}'),
+          coalesce(queue_name, public.gen_random_uuid()::text),
+          coalesce(run_at, now()),
+          coalesce(max_attempts, 25),
+          job_key
+        )
+        returning *
+        into v_job;
+    end if;
+  end if;
+  return v_job;
+end;
+$$ language plpgsql;
+
+
+
+-- Update other functions to handle locked_at denormalisation
+
+create or replace function graphile_worker.get_job(worker_id text, task_identifiers text[] = null, job_expiry interval = interval '4 hours') returns graphile_worker.jobs as $$
+declare
+  v_job_id bigint;
+  v_queue_name text;
+  v_default_job_max_attempts text = '25';
+  v_row graphile_worker.jobs;
+  v_now timestamptz = now();
+begin
+  if worker_id is null or length(worker_id) < 10 then
+    raise exception 'invalid worker id';
+  end if;
+
+  select job_queues.queue_name, jobs.id into v_queue_name, v_job_id
+    from graphile_worker.jobs
+    inner join graphile_worker.job_queues using (queue_name)
+    where (job_queues.locked_at is null or job_queues.locked_at < (v_now - job_expiry))
+    and run_at <= v_now
+    and attempts < max_attempts
+    and (task_identifiers is null or task_identifier = any(task_identifiers))
+    order by priority asc, run_at asc, id asc
+    limit 1
+    for update of job_queues
+    skip locked;
+
+  if v_queue_name is null then
+    return null;
+  end if;
+
+  update graphile_worker.job_queues
+    set
+      locked_by = worker_id,
+      locked_at = v_now
+    where job_queues.queue_name = v_queue_name;
+
+  update graphile_worker.jobs
+    set
+      attempts = attempts + 1,
+      locked_by = worker_id,
+      locked_at = v_now
+    where id = v_job_id
+    returning * into v_row;
+
+  return v_row;
+end;
+$$ language plpgsql;
+
+-- I was unsuccessful, re-schedule the job please
+create or replace function graphile_worker.fail_job(worker_id text, job_id bigint, error_message text) returns graphile_worker.jobs as $$
+declare
+  v_row graphile_worker.jobs;
+begin
+  update graphile_worker.jobs
+    set
+      last_error = error_message,
+      run_at = greatest(now(), run_at) + (exp(least(attempts, 10))::text || ' seconds')::interval,
+      locked_by = null,
+      locked_at = null
+    where id = job_id
+    returning * into v_row;
+
+  update graphile_worker.job_queues
+    set locked_by = null, locked_at = null
+    where queue_name = v_row.queue_name and locked_by = worker_id;
+
+  return v_row;
+end;
+$$ language plpgsql;
+

--- a/sql/000002.sql
+++ b/sql/000002.sql
@@ -45,6 +45,8 @@ begin
       )
       on conflict (key) do update set
         -- update job details if provided, otherwise maintain existing value
+        -- note we can't use excluded here, or the value will always be updated,
+        -- due to the coalesce statements in values ( ... ) above
         task_identifier=coalesce(add_job.identifier, jobs.task_identifier),
         payload=coalesce(add_job.payload, jobs.payload),
         queue_name=coalesce(add_job.queue_name, jobs.queue_name),

--- a/sql/000002.sql
+++ b/sql/000002.sql
@@ -112,7 +112,6 @@ create or replace function graphile_worker.get_job(worker_id text, task_identifi
 declare
   v_job_id bigint;
   v_queue_name text;
-  v_default_job_max_attempts text = '25';
   v_row graphile_worker.jobs;
   v_now timestamptz = now();
 begin

--- a/src/deferred.ts
+++ b/src/deferred.ts
@@ -1,9 +1,9 @@
-export interface Deferred<T> extends Promise<T> {
+export interface Deferred<T = void> extends Promise<T> {
   resolve: (result?: T) => void;
   reject: (error: Error) => void;
 }
 
-export default function deferred<T = void>(): Deferred<T> {
+export default function defer<T = void>(): Deferred<T> {
   let resolve: (result?: T) => void;
   let reject: (error: Error) => void;
   return Object.assign(
@@ -11,7 +11,7 @@ export default function deferred<T = void>(): Deferred<T> {
       resolve = _resolve;
       reject = _reject;
     }),
-    // @ts-ignore Non-sense, these aren't used before being defined.
+    // @ts-ignore error TS2454: Variable 'resolve' is used before being assigned.
     { resolve, reject }
   );
 }


### PR DESCRIPTION
See proposal and discussion in #61

### Performance impact

Running the existing performance test script shows no impact from these changes - running in Docker (see #64) and repeated 3 times for each case, the average latency was ~2ms each time and total time to run jobs ~30s.

### `jobs.key` index

There was some discussion over whether this should be implemented as a unique partial index, since it is likely to contain a lot of null values. This would mean we couldn't use an `on conflict` clause when inserting though, so I've used a regular unique constraint

### Checklist

- [x] Update `add_job` behaviour
- [x] Implement `remove_job` function
- [x] Determine whether the jobs.key unique index should be partial
- [x] Handle issues in Postgres 9.6 
- [x] Document performance impact
- [x] Update readme
- [x] pg functions strict, volatile etc  https://github.com/graphile/worker/pull/63#discussion_r365235334
- [x] implement "deferred" pattern in tests https://github.com/graphile/worker/pull/63#discussion_r365188493

---

Closes #58 
Closes #59 
Closes #61 
