### PR TITLE
fix: runner.stop() should now work

### DIFF
--- a/src/runner.ts
+++ b/src/runner.ts
@@ -139,11 +139,11 @@ export const run = async (options: RunnerOptions): Promise<Runner> => {
   return {
     async stop() {
       if (running) {
-        throw new Error("Runner is already stopped");
-      } else {
         running = false;
         await workerPool.release();
         await release();
+      } else {
+        throw new Error("Runner is already stopped");
       }
     },
     addJob: makeAddJob(withPgClient),


### PR DESCRIPTION
The boolean check was reversed in determining if the runner was already running.

If it is already running and runner.stop() is called, it should release. Else it wasn't running when runner.stop() was called and it show throw.