### PR TITLE
perf: use prepared statements

### DIFF
--- a/src/worker.ts
+++ b/src/worker.ts
@@ -73,10 +73,14 @@ export function makeNewWorker(
       const {
         rows: [jobRow],
       } = await withPgClient(client =>
-        client.query("SELECT * FROM graphile_worker.get_job($1, $2);", [
-          workerId,
-          supportedTaskNames,
-        ])
+        client.query({
+          text:
+            // TODO: breaking change; change this to more optimal:
+            // "SELECT id, queue_name, task_identifier, payload FROM graphile_worker.get_job($1, $2);",
+            "SELECT * FROM graphile_worker.get_job($1, $2);",
+          values: [workerId, supportedTaskNames],
+          name: "get_job",
+        })
       );
 
       // `doNext` cannot be executed concurrently, so we know this is safe.
@@ -173,11 +177,11 @@ export function makeNewWorker(
         );
         // TODO: retry logic, in case of server connection interruption
         await withPgClient(client =>
-          client.query("SELECT * FROM graphile_worker.fail_job($1, $2, $3);", [
-            workerId,
-            job.id,
-            message,
-          ])
+          client.query({
+            text: "SELECT FROM graphile_worker.fail_job($1, $2, $3);",
+            values: [workerId, job.id, message],
+            name: "fail_job",
+          })
         );
       } else {
         if (!process.env.NO_LOG_SUCCESS) {
@@ -190,10 +194,11 @@ export function makeNewWorker(
         }
         // TODO: retry logic, in case of server connection interruption
         await withPgClient(client =>
-          client.query("SELECT * FROM graphile_worker.complete_job($1, $2);", [
-            workerId,
-            job.id,
-          ])
+          client.query({
+            text: "SELECT FROM graphile_worker.complete_job($1, $2);",
+            values: [workerId, job.id],
+            name: "complete_job",
+          })
         );
       }
     } catch (fatalError) {


### PR DESCRIPTION
Also avoids fetching the record for fail_job / complete_job which saves on the parsing cost in node-postgres.

We could optimise this further by only pulling down the required Job fields, but this'd be a breaking change so I've not included it.