### PR TITLE
Make worker schema configurable

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,7 @@ jobs:
           node-version: ${{ matrix.node-version }}
       - run: yarn --frozen-lockfile
       - run: yarn lint
-      - run: yarn jest -i
+      - run: yarn jest -i --ci
 
   altschema:
     runs-on: ubuntu-18.04
@@ -69,4 +69,4 @@ jobs:
           node-version: 12.x
       - run: yarn --frozen-lockfile
       - run: yarn lint
-      - run: yarn jest -i
+      - run: yarn jest -i --ci

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,3 +41,32 @@ jobs:
       - run: yarn --frozen-lockfile
       - run: yarn lint
       - run: yarn jest -i
+
+  altschema:
+    runs-on: ubuntu-18.04
+    env:
+      GRAPHILE_WORKER_SCHEMA: custom_schema
+
+    services:
+      postgres:
+        image: postgres:11
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: graphile_worker_test
+        ports:
+          - "0.0.0.0:5432:5432"
+        # needed because the postgres container does not provide a healthcheck
+        options:
+          --health-cmd pg_isready --health-interval 10s --health-timeout 5s
+          --health-retries 5
+
+    steps:
+      - uses: actions/checkout@v1
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v1
+        with:
+          node-version: 12.x
+      - run: yarn --frozen-lockfile
+      - run: yarn lint
+      - run: yarn jest -i

--- a/README.md
+++ b/README.md
@@ -981,7 +981,7 @@ docker-compose exec app yarn jest -i
 Reset the test db
 
 ```
-cat __tests__/reset-db.sql | docker-compose exec -T db psql -U postgres -v GRAPHILE_WORKER_SCHEMA=graphile-worker graphile_worker_test
+cat __tests__/reset-db.sql | docker-compose exec -T db psql -U postgres -v GRAPHILE_WORKER_SCHEMA=graphile_worker graphile_worker_test
 ```
 
 Run the perf tests

--- a/README.md
+++ b/README.md
@@ -981,7 +981,7 @@ docker-compose exec app yarn jest -i
 Reset the test db
 
 ```
-cat __tests__/reset-db.sql | docker-compose exec -T db psql -U postgres -v WORKER_SCHEMA=graphile-worker graphile_worker_test
+cat __tests__/reset-db.sql | docker-compose exec -T db psql -U postgres -v GRAPHILE_WORKER_SCHEMA=graphile-worker graphile_worker_test
 ```
 
 Run the perf tests

--- a/README.md
+++ b/README.md
@@ -981,7 +981,7 @@ docker-compose exec app yarn jest -i
 Reset the test db
 
 ```
-cat __tests__/reset-db.sql | docker-compose exec -T db psql -U postgres graphile_worker_test
+cat __tests__/reset-db.sql | docker-compose exec -T db psql -U postgres -v WORKER_SCHEMA=graphile-worker graphile_worker_test
 ```
 
 Run the perf tests

--- a/README.md
+++ b/README.md
@@ -813,6 +813,7 @@ printable ASCII characters.
 - `queue_name` can be at most 128 characters long
 - `task_identifier` can be at most 128 characters long
 - `job_key` can be at most 512 characters long
+- `schema` should be reasonable; max 32 characters is preferred. Defaults to `graphile_worker` (15 chars)
 
 ## Uninstallation
 

--- a/README.md
+++ b/README.md
@@ -218,6 +218,8 @@ Options:
   --version            Show version number                             [boolean]
   --connection, -c     Database connection string, defaults to the
                        'DATABASE_URL' envvar                            [string]
+  --schema, -s         The database schema in which Graphile Worker is (to be)
+                       located             [string] [default: "graphile_worker"]
   --schema-only        Just install (or update) the database schema, then exit
                                                       [boolean] [default: false]
   --once               Run until there are no runnable jobs left, then exit

--- a/README.md
+++ b/README.md
@@ -266,9 +266,9 @@ migrations and then resolves.
 
 The following options for these methods are available.
 
-- `concurrency`: The equivalent of the cli `--jobs` option with the same default value.
+- `concurrency`: The equivalent of the CLI `--jobs` option with the same default value.
 - `nohandleSignals`: If set true, we won't install signal handlers and it'll be up to you to handle graceful shutdown of the worker if the process receives a signal.
-- `pollInterval`: The equivalent of the cli `--poll-interval` option with the same default value.
+- `pollInterval`: The equivalent of the CLI `--poll-interval` option with the same default value.
 - `logger`: To change how log messages are output you may provide a custom logger; see [`Logger`](#logger) below
 - the database is identified through one of these options:
   - `connectionString`: A PostgreSQL connection string to the database containing the job queue, or
@@ -276,6 +276,7 @@ The following options for these methods are available.
 - the tasks to execute are identified through one of these options:
   - `taskDirectory`: A path string to a directory containing the task handlers.
   - `taskList`: An object with the task names as keys and a corresponding task handler functions as values
+- `schema` can be used to change the default `graphile_worker` schema to something else (equivalent to `--schema` on the CLI)
 
 Exactly one of either `taskDirectory` or `taskList` must be provided (except for `runMigrations` which doesn't require a task list).
 
@@ -350,7 +351,7 @@ singleton throughout your code.
 - exactly one of these keys must be present to determine how to connect to the database:
   - `connectionString`: A PostgreSQL connection string to the database containing the job queue, or
   - `pgPool`: A `pg.Pool` instance to use
-- there are currently no other options
+- `schema` can be used to change the default `graphile_worker` schema to something else (equivalent to `--schema` on the CLI)
 
 ### WorkerUtils
 

--- a/__tests__/getTasks.test.ts
+++ b/__tests__/getTasks.test.ts
@@ -1,7 +1,9 @@
 import getTasks from "../src/getTasks";
 import { makeMockJob, withPgClient } from "./helpers";
 import { makeJobHelpers, makeWithPgClientFromClient } from "../src/helpers";
-import { defaultLogger } from "../src/logger";
+import { WorkerSharedOptions } from "../src";
+
+const options: WorkerSharedOptions = {};
 
 test("gets tasks from folder", () =>
   withPgClient(async client => {
@@ -18,7 +20,7 @@ Array [
       {
         withPgClient: makeWithPgClientFromClient(client),
       },
-      defaultLogger
+      options
     );
     expect(await tasks.wouldyoulike(helpers.job.payload, helpers)).toEqual(
       "some sausages"
@@ -47,7 +49,7 @@ Array [
       {
         withPgClient: makeWithPgClientFromClient(client),
       },
-      defaultLogger
+      options
     );
     expect(await tasks.task1(helpers.job.payload, helpers)).toEqual("hi");
     expect(await tasks.task2(helpers.job.payload, helpers)).toEqual("hello");
@@ -73,7 +75,7 @@ Array [
       {
         withPgClient: makeWithPgClientFromClient(client),
       },
-      defaultLogger
+      options
     );
     expect(await tasks.t1(helpers.job.payload, helpers)).toEqual(
       "come with me"

--- a/__tests__/getTasks.test.ts
+++ b/__tests__/getTasks.test.ts
@@ -7,7 +7,10 @@ const options: WorkerSharedOptions = {};
 
 test("gets tasks from folder", () =>
   withPgClient(async client => {
-    const { tasks, release } = await getTasks(`${__dirname}/fixtures/tasks`);
+    const { tasks, release } = await getTasks(
+      options,
+      `${__dirname}/fixtures/tasks`
+    );
     expect(tasks).toBeTruthy();
     expect(Object.keys(tasks).sort()).toMatchInlineSnapshot(`
 Array [
@@ -34,6 +37,7 @@ Array [
 test("get tasks from file (vanilla)", () =>
   withPgClient(async client => {
     const { tasks, release } = await getTasks(
+      options,
       `${__dirname}/fixtures/tasksFile.js`
     );
     expect(tasks).toBeTruthy();
@@ -60,6 +64,7 @@ Array [
 test("get tasks from file (default)", () =>
   withPgClient(async client => {
     const { tasks, release } = await getTasks(
+      options,
       `${__dirname}/fixtures/tasksFile_default.js`
     );
     expect(tasks).toBeTruthy();

--- a/__tests__/getTasks.test.ts
+++ b/__tests__/getTasks.test.ts
@@ -18,13 +18,9 @@ Array [
   "wouldyoulike_default",
 ]
 `);
-    const helpers = makeJobHelpers(
-      makeMockJob("would you like"),
-      {
-        withPgClient: makeWithPgClientFromClient(client),
-      },
-      options
-    );
+    const helpers = makeJobHelpers(options, makeMockJob("would you like"), {
+      withPgClient: makeWithPgClientFromClient(client),
+    });
     expect(await tasks.wouldyoulike(helpers.job.payload, helpers)).toEqual(
       "some sausages"
     );
@@ -48,13 +44,9 @@ Array [
 ]
 `);
 
-    const helpers = makeJobHelpers(
-      makeMockJob("task1"),
-      {
-        withPgClient: makeWithPgClientFromClient(client),
-      },
-      options
-    );
+    const helpers = makeJobHelpers(options, makeMockJob("task1"), {
+      withPgClient: makeWithPgClientFromClient(client),
+    });
     expect(await tasks.task1(helpers.job.payload, helpers)).toEqual("hi");
     expect(await tasks.task2(helpers.job.payload, helpers)).toEqual("hello");
 
@@ -75,13 +67,9 @@ Array [
 ]
 `);
 
-    const helpers = makeJobHelpers(
-      makeMockJob("t1"),
-      {
-        withPgClient: makeWithPgClientFromClient(client),
-      },
-      options
-    );
+    const helpers = makeJobHelpers(options, makeMockJob("t1"), {
+      withPgClient: makeWithPgClientFromClient(client),
+    });
     expect(await tasks.t1(helpers.job.payload, helpers)).toEqual(
       "come with me"
     );

--- a/__tests__/helpers.ts
+++ b/__tests__/helpers.ts
@@ -65,11 +65,11 @@ export async function reset(
     `drop schema if exists ${ESCAPED_GRAPHILE_WORKER_SCHEMA} cascade;`
   );
   if (isPoolClient(pgPoolOrClient)) {
-    await migrate(pgPoolOrClient, options);
+    await migrate(options, pgPoolOrClient);
   } else {
     const client = await pgPoolOrClient.connect();
     try {
-      await migrate(client, options);
+      await migrate(options, client);
     } finally {
       await client.release();
     }

--- a/__tests__/helpers.ts
+++ b/__tests__/helpers.ts
@@ -17,7 +17,7 @@ export const ESCAPED_GRAPHILE_WORKER_SCHEMA = pg.Client.prototype.escapeIdentifi
   GRAPHILE_WORKER_SCHEMA
 );
 
-export async function withPgPool<T = any>(
+export async function withPgPool<T>(
   cb: (pool: pg.Pool) => Promise<T>
 ): Promise<T> {
   const pool = new pg.Pool({
@@ -30,7 +30,7 @@ export async function withPgPool<T = any>(
   }
 }
 
-export async function withPgClient<T = any>(
+export async function withPgClient<T>(
   cb: (client: pg.PoolClient) => Promise<T>
 ): Promise<T> {
   return withPgPool(async pool => {
@@ -43,7 +43,7 @@ export async function withPgClient<T = any>(
   });
 }
 
-export async function withTransaction<T = any>(
+export async function withTransaction<T>(
   cb: (client: pg.PoolClient) => Promise<T>,
   closeCommand = "rollback"
 ): Promise<T> {
@@ -57,8 +57,8 @@ export async function withTransaction<T = any>(
   });
 }
 
-function isPoolClient(o: any): o is pg.PoolClient {
-  return o && typeof o.release === "function";
+function isPoolClient(o: unknown): o is pg.PoolClient {
+  return typeof o === "object" && !!o && typeof o["release"] === "function";
 }
 
 export async function reset(

--- a/__tests__/helpers.ts
+++ b/__tests__/helpers.ts
@@ -7,9 +7,10 @@ process.env.GRAPHILE_WORKER_DEBUG = "1";
 export const TEST_CONNECTION_STRING =
   process.env.TEST_CONNECTION_STRING || "graphile_worker_test";
 
-export const WORKER_SCHEMA = process.env.WORKER_SCHEMA || "graphile_worker";
-export const ESCAPED_WORKER_SCHEMA = pg.Client.prototype.escapeIdentifier(
-  WORKER_SCHEMA
+export const GRAPHILE_WORKER_SCHEMA =
+  process.env.GRAPHILE_WORKER_SCHEMA || "graphile_worker";
+export const ESCAPED_GRAPHILE_WORKER_SCHEMA = pg.Client.prototype.escapeIdentifier(
+  GRAPHILE_WORKER_SCHEMA
 );
 
 export async function withPgPool<T = any>(
@@ -61,7 +62,7 @@ export async function reset(
   options: WorkerPoolOptions
 ) {
   await pgPoolOrClient.query(
-    `drop schema if exists ${ESCAPED_WORKER_SCHEMA} cascade;`
+    `drop schema if exists ${ESCAPED_GRAPHILE_WORKER_SCHEMA} cascade;`
   );
   if (isPoolClient(pgPoolOrClient)) {
     await migrate(pgPoolOrClient, options);
@@ -81,7 +82,7 @@ export async function jobCount(
   const {
     rows: [row],
   } = await pgPoolOrClient.query(
-    `select count(*)::int from ${ESCAPED_WORKER_SCHEMA}.jobs`
+    `select count(*)::int from ${ESCAPED_GRAPHILE_WORKER_SCHEMA}.jobs`
   );
   return row ? row.count || 0 : 0;
 }
@@ -135,13 +136,13 @@ export async function makeSelectionOfJobs(
   ({
     rows: [lockedJob],
   } = await pgClient.query<Job>(
-    `update ${ESCAPED_WORKER_SCHEMA}.jobs set locked_by = 'test', locked_at = now() where id = $1 returning *`,
+    `update ${ESCAPED_GRAPHILE_WORKER_SCHEMA}.jobs set locked_by = 'test', locked_at = now() where id = $1 returning *`,
     [lockedJob.id]
   ));
   ({
     rows: [failedJob],
   } = await pgClient.query<Job>(
-    `update ${ESCAPED_WORKER_SCHEMA}.jobs set attempts = max_attempts, last_error = 'Failed forever' where id = $1 returning *`,
+    `update ${ESCAPED_GRAPHILE_WORKER_SCHEMA}.jobs set attempts = max_attempts, last_error = 'Failed forever' where id = $1 returning *`,
     [failedJob.id]
   ));
 

--- a/__tests__/helpers.ts
+++ b/__tests__/helpers.ts
@@ -2,6 +2,10 @@ import * as pg from "pg";
 import { Job, WorkerUtils, WorkerPoolOptions } from "../src/interfaces";
 import { migrate } from "../src/migrate";
 
+// Sometimes CI's clock can get interrupted (it is shared infra!) so this
+// extends the default timeout just in case.
+jest.setTimeout(15000);
+
 process.env.GRAPHILE_WORKER_DEBUG = "1";
 
 export const TEST_CONNECTION_STRING =

--- a/__tests__/helpers.ts
+++ b/__tests__/helpers.ts
@@ -57,8 +57,8 @@ export async function withTransaction<T>(
   });
 }
 
-function isPoolClient(o: unknown): o is pg.PoolClient {
-  return typeof o === "object" && !!o && typeof o["release"] === "function";
+function isPoolClient(o: pg.Pool | pg.PoolClient): o is pg.PoolClient {
+  return typeof o["release"] === "function";
 }
 
 export async function reset(

--- a/__tests__/main.runTaskList.test.ts
+++ b/__tests__/main.runTaskList.test.ts
@@ -1,19 +1,28 @@
 // See also main.runTaskListOnce.test.ts
-import { reset, withPgPool, sleepUntil, sleep, jobCount } from "./helpers";
-import { TaskList, Task } from "../src/interfaces";
+import {
+  reset,
+  withPgPool,
+  sleepUntil,
+  sleep,
+  jobCount,
+  ESCAPED_WORKER_SCHEMA,
+} from "./helpers";
+import { TaskList, Task, WorkerSharedOptions } from "../src/interfaces";
 import { runTaskList } from "../src/main";
 import deferred, { Deferred } from "../src/deferred";
 import { Pool } from "pg";
 
 const addJob = (pgPool: Pool, id?: string | number) =>
   pgPool.query(
-    `select graphile_worker.add_job('job1', json_build_object('id', $1::text), 'serial')`,
+    `select ${ESCAPED_WORKER_SCHEMA}.add_job('job1', json_build_object('id', $1::text), 'serial')`,
     [String(id != null ? id : Math.random())]
   );
 
+const options: WorkerSharedOptions = {};
+
 test("main will execute jobs as they come up, and exits cleanly", () =>
   withPgPool(async pgPool => {
-    await reset(pgPool);
+    await reset(pgPool, options);
 
     // Build the tasks
     const jobPromises: {
@@ -62,7 +71,7 @@ test("main will execute jobs as they come up, and exits cleanly", () =>
 
 test("doesn't bail on deprecated `debug` function", () =>
   withPgPool(async pgPool => {
-    await reset(pgPool);
+    await reset(pgPool, options);
     let jobPromise: Deferred | null = null;
     const tasks: TaskList = {
       job1(payload, helpers) {

--- a/__tests__/main.runTaskList.test.ts
+++ b/__tests__/main.runTaskList.test.ts
@@ -41,7 +41,7 @@ test("main will execute jobs as they come up, and exits cleanly", () =>
     };
 
     // Run the worker
-    const workerPool = runTaskList(tasks, pgPool, { concurrency: 3 });
+    const workerPool = runTaskList({ concurrency: 3 }, tasks, pgPool);
     let finished = false;
     workerPool.promise.then(() => {
       finished = true;
@@ -80,7 +80,7 @@ test("doesn't bail on deprecated `debug` function", () =>
         jobPromise = deferred();
       },
     };
-    const workerPool = runTaskList(tasks, pgPool, { concurrency: 3 });
+    const workerPool = runTaskList({ concurrency: 3 }, tasks, pgPool);
     await addJob(pgPool);
     await sleepUntil(() => !!jobPromise);
     jobPromise!.resolve();

--- a/__tests__/main.runTaskList.test.ts
+++ b/__tests__/main.runTaskList.test.ts
@@ -5,7 +5,7 @@ import {
   sleepUntil,
   sleep,
   jobCount,
-  ESCAPED_WORKER_SCHEMA,
+  ESCAPED_GRAPHILE_WORKER_SCHEMA,
 } from "./helpers";
 import { TaskList, Task, WorkerSharedOptions } from "../src/interfaces";
 import { runTaskList } from "../src/main";
@@ -14,7 +14,7 @@ import { Pool } from "pg";
 
 const addJob = (pgPool: Pool, id?: string | number) =>
   pgPool.query(
-    `select ${ESCAPED_WORKER_SCHEMA}.add_job('job1', json_build_object('id', $1::text), 'serial')`,
+    `select ${ESCAPED_GRAPHILE_WORKER_SCHEMA}.add_job('job1', json_build_object('id', $1::text), 'serial')`,
     [String(id != null ? id : Math.random())]
   );
 

--- a/__tests__/main.runTaskListOnce.test.ts
+++ b/__tests__/main.runTaskListOnce.test.ts
@@ -3,7 +3,7 @@ import {
   reset,
   sleepUntil,
   jobCount,
-  ESCAPED_WORKER_SCHEMA,
+  ESCAPED_GRAPHILE_WORKER_SCHEMA,
 } from "./helpers";
 import { TaskList, Task, Worker, WorkerSharedOptions } from "../src/interfaces";
 import { runTaskListOnce } from "../src/main";
@@ -20,19 +20,19 @@ test("runs jobs", () =>
     // Schedule a job
     const start = new Date();
     await pgClient.query(
-      `select * from ${ESCAPED_WORKER_SCHEMA}.add_job('job1', '{"a": 1}', queue_name := 'myqueue')`
+      `select * from ${ESCAPED_GRAPHILE_WORKER_SCHEMA}.add_job('job1', '{"a": 1}', queue_name := 'myqueue')`
     );
 
     // Assert that it has an entry in jobs / job_queues
     const { rows: jobs } = await pgClient.query(
-      `select * from ${ESCAPED_WORKER_SCHEMA}.jobs order by id asc`
+      `select * from ${ESCAPED_GRAPHILE_WORKER_SCHEMA}.jobs order by id asc`
     );
     expect(jobs).toHaveLength(1);
     const job = jobs[0];
     expect(+job.run_at).toBeGreaterThanOrEqual(+start);
     expect(+job.run_at).toBeLessThanOrEqual(+new Date());
     const { rows: jobQueues } = await pgClient.query(
-      `select * from ${ESCAPED_WORKER_SCHEMA}.job_queues`
+      `select * from ${ESCAPED_GRAPHILE_WORKER_SCHEMA}.job_queues`
     );
     expect(jobQueues).toHaveLength(1);
     const q = jobQueues[0];
@@ -69,12 +69,12 @@ test("schedules errors for retry", () =>
     // Schedule a job
     const start = new Date();
     await pgClient.query(
-      `select * from ${ESCAPED_WORKER_SCHEMA}.add_job('job1', '{"a": 1}', queue_name := 'myqueue')`
+      `select * from ${ESCAPED_GRAPHILE_WORKER_SCHEMA}.add_job('job1', '{"a": 1}', queue_name := 'myqueue')`
     );
 
     {
       const { rows: jobs } = await pgClient.query(
-        `select * from ${ESCAPED_WORKER_SCHEMA}.jobs order by id asc`
+        `select * from ${ESCAPED_GRAPHILE_WORKER_SCHEMA}.jobs order by id asc`
       );
       expect(jobs).toHaveLength(1);
       const job = jobs[0];
@@ -84,7 +84,7 @@ test("schedules errors for retry", () =>
       expect(+job.run_at).toBeLessThanOrEqual(+new Date());
 
       const { rows: jobQueues } = await pgClient.query(
-        `select * from ${ESCAPED_WORKER_SCHEMA}.job_queues`
+        `select * from ${ESCAPED_GRAPHILE_WORKER_SCHEMA}.job_queues`
       );
       expect(jobQueues).toHaveLength(1);
       const q = jobQueues[0];
@@ -107,7 +107,7 @@ test("schedules errors for retry", () =>
     // Check that it failed as expected
     {
       const { rows: jobs } = await pgClient.query(
-        `select * from ${ESCAPED_WORKER_SCHEMA}.jobs order by id asc`
+        `select * from ${ESCAPED_GRAPHILE_WORKER_SCHEMA}.jobs order by id asc`
       );
       expect(jobs).toHaveLength(1);
       const job = jobs[0];
@@ -120,7 +120,7 @@ test("schedules errors for retry", () =>
       expect(+job.run_at).toBeLessThanOrEqual(+new Date() + 2719);
 
       const { rows: jobQueues } = await pgClient.query(
-        `select * from ${ESCAPED_WORKER_SCHEMA}.job_queues`
+        `select * from ${ESCAPED_GRAPHILE_WORKER_SCHEMA}.job_queues`
       );
       expect(jobQueues).toHaveLength(1);
       const q = jobQueues[0];
@@ -137,7 +137,7 @@ test("retries job", () =>
 
     // Add the job
     await pgClient.query(
-      `select * from ${ESCAPED_WORKER_SCHEMA}.add_job('job1', '{"a": 1}', queue_name := 'myqueue')`
+      `select * from ${ESCAPED_GRAPHILE_WORKER_SCHEMA}.add_job('job1', '{"a": 1}', queue_name := 'myqueue')`
     );
     let counter = 0;
     const job1: Task = jest.fn(() => {
@@ -157,7 +157,7 @@ test("retries job", () =>
 
     // Tell the job to be runnable
     await pgClient.query(
-      `update ${ESCAPED_WORKER_SCHEMA}.jobs set run_at = now() where task_identifier = 'job1'`
+      `update ${ESCAPED_GRAPHILE_WORKER_SCHEMA}.jobs set run_at = now() where task_identifier = 'job1'`
     );
 
     // Run the job
@@ -170,7 +170,7 @@ test("retries job", () =>
     // And it should have been rejected again
     {
       const { rows: jobs } = await pgClient.query(
-        `select * from ${ESCAPED_WORKER_SCHEMA}.jobs order by id asc`
+        `select * from ${ESCAPED_GRAPHILE_WORKER_SCHEMA}.jobs order by id asc`
       );
       expect(jobs).toHaveLength(1);
       const job = jobs[0];
@@ -183,7 +183,7 @@ test("retries job", () =>
       expect(+job.run_at).toBeLessThanOrEqual(+new Date() + 7389);
 
       const { rows: jobQueues } = await pgClient.query(
-        `select * from ${ESCAPED_WORKER_SCHEMA}.job_queues`
+        `select * from ${ESCAPED_GRAPHILE_WORKER_SCHEMA}.job_queues`
       );
       expect(jobQueues).toHaveLength(1);
       const q = jobQueues[0];
@@ -200,7 +200,7 @@ test("supports future-scheduled jobs", () =>
 
     // Add the job
     await pgClient.query(
-      `select * from ${ESCAPED_WORKER_SCHEMA}.add_job('future', run_at := now() + interval '3 seconds')`
+      `select * from ${ESCAPED_GRAPHILE_WORKER_SCHEMA}.add_job('future', run_at := now() + interval '3 seconds')`
     );
     const future: Task = jest.fn();
     const tasks: TaskList = {
@@ -217,7 +217,7 @@ test("supports future-scheduled jobs", () =>
 
     // Tell the job to be runnable
     await pgClient.query(
-      `update ${ESCAPED_WORKER_SCHEMA}.jobs set run_at = now() where task_identifier = 'future'`
+      `update ${ESCAPED_GRAPHILE_WORKER_SCHEMA}.jobs set run_at = now() where task_identifier = 'future'`
     );
 
     // Run the job
@@ -229,11 +229,11 @@ test("supports future-scheduled jobs", () =>
     // It should be successful
     {
       const { rows: jobs } = await pgClient.query(
-        `select * from ${ESCAPED_WORKER_SCHEMA}.jobs order by id asc`
+        `select * from ${ESCAPED_GRAPHILE_WORKER_SCHEMA}.jobs order by id asc`
       );
       expect(jobs).toHaveLength(0);
       const { rows: jobQueues } = await pgClient.query(
-        `select * from ${ESCAPED_WORKER_SCHEMA}.job_queues`
+        `select * from ${ESCAPED_GRAPHILE_WORKER_SCHEMA}.job_queues`
       );
       expect(jobQueues).toHaveLength(0);
     }
@@ -255,12 +255,12 @@ test("allows update of pending jobs", () =>
     runAt.setSeconds(runAt.getSeconds() + 60);
 
     await pgClient.query(
-      `select * from ${ESCAPED_WORKER_SCHEMA}.add_job('job1', '{"a": "wrong"}', run_at := '${runAt.toISOString()}', job_key := 'abc')`
+      `select * from ${ESCAPED_GRAPHILE_WORKER_SCHEMA}.add_job('job1', '{"a": "wrong"}', run_at := '${runAt.toISOString()}', job_key := 'abc')`
     );
 
     // Assert that it has an entry in jobs / job_queues
     const { rows: jobs } = await pgClient.query(
-      `select * from ${ESCAPED_WORKER_SCHEMA}.jobs order by id asc`
+      `select * from ${ESCAPED_GRAPHILE_WORKER_SCHEMA}.jobs order by id asc`
     );
     expect(jobs).toHaveLength(1);
     const job = jobs[0];
@@ -273,12 +273,12 @@ test("allows update of pending jobs", () =>
     // update the job to run immediately with correct payload
     const now = new Date();
     await pgClient.query(
-      `select * from ${ESCAPED_WORKER_SCHEMA}.add_job('job1', '{"a": "right"}', run_at := '${now.toISOString()}', job_key := 'abc')`
+      `select * from ${ESCAPED_GRAPHILE_WORKER_SCHEMA}.add_job('job1', '{"a": "right"}', run_at := '${now.toISOString()}', job_key := 'abc')`
     );
 
     // Assert that it has updated the existing entry and not created a new one
     const { rows: updatedJobs } = await pgClient.query(
-      `select * from ${ESCAPED_WORKER_SCHEMA}.jobs order by id asc`
+      `select * from ${ESCAPED_GRAPHILE_WORKER_SCHEMA}.jobs order by id asc`
     );
     expect(updatedJobs).toHaveLength(1);
     const updatedJob = updatedJobs[0];
@@ -300,7 +300,7 @@ test("schedules a new job if existing is completed", () =>
 
     // Schedule a job to run immediately
     await pgClient.query(
-      `select * from ${ESCAPED_WORKER_SCHEMA}.add_job('job1', '{"a": "first"}', job_key := 'abc')`
+      `select * from ${ESCAPED_GRAPHILE_WORKER_SCHEMA}.add_job('job1', '{"a": "first"}', job_key := 'abc')`
     );
 
     // run the job
@@ -309,7 +309,7 @@ test("schedules a new job if existing is completed", () =>
 
     // attempt to update the job - it should schedule a new one instead
     await pgClient.query(
-      `select * from ${ESCAPED_WORKER_SCHEMA}.add_job('job1', '{"a": "second"}',  job_key := 'abc')`
+      `select * from ${ESCAPED_GRAPHILE_WORKER_SCHEMA}.add_job('job1', '{"a": "second"}',  job_key := 'abc')`
     );
 
     // run again
@@ -345,7 +345,7 @@ test("schedules a new job if existing is being processed", () =>
 
     // Schedule a job to run immediately
     await pgClient.query(
-      `select * from ${ESCAPED_WORKER_SCHEMA}.add_job('job1', '{"a": "first"}', job_key := 'abc')`
+      `select * from ${ESCAPED_GRAPHILE_WORKER_SCHEMA}.add_job('job1', '{"a": "first"}', job_key := 'abc')`
     );
 
     // run the job
@@ -357,14 +357,14 @@ test("schedules a new job if existing is being processed", () =>
 
     // attempt to update the job - it should schedule a new one instead
     await pgClient.query(
-      `select * from ${ESCAPED_WORKER_SCHEMA}.add_job('job1', '{"a": "second"}',  job_key := 'abc')`
+      `select * from ${ESCAPED_GRAPHILE_WORKER_SCHEMA}.add_job('job1', '{"a": "second"}',  job_key := 'abc')`
     );
 
     // check there are now two jobs scheduled
     expect(
       (
         await pgClient.query(
-          `select * from ${ESCAPED_WORKER_SCHEMA}.jobs order by id asc`
+          `select * from ${ESCAPED_GRAPHILE_WORKER_SCHEMA}.jobs order by id asc`
         )
       ).rows
     ).toHaveLength(2);
@@ -407,7 +407,7 @@ test("schedules a new job if the existing is pending retry", () =>
     const {
       rows: [initialJob],
     } = await pgClient.query(
-      `select * from ${ESCAPED_WORKER_SCHEMA}.add_job('job1', '{"succeed": false}', job_key := 'abc')`
+      `select * from ${ESCAPED_GRAPHILE_WORKER_SCHEMA}.add_job('job1', '{"succeed": false}', job_key := 'abc')`
     );
 
     // run the job
@@ -416,7 +416,7 @@ test("schedules a new job if the existing is pending retry", () =>
 
     // Check that it failed as expected and retry has been scheduled
     const { rows: jobs } = await pgClient.query(
-      `select * from ${ESCAPED_WORKER_SCHEMA}.jobs order by id asc`
+      `select * from ${ESCAPED_GRAPHILE_WORKER_SCHEMA}.jobs order by id asc`
     );
     expect(jobs).toHaveLength(1);
     expect(jobs[0].id).toEqual(initialJob.id);
@@ -430,12 +430,12 @@ test("schedules a new job if the existing is pending retry", () =>
 
     // update the job to succeed
     await pgClient.query(
-      `select * from ${ESCAPED_WORKER_SCHEMA}.add_job('job1', '{"succeed": true}',  job_key := 'abc')`
+      `select * from ${ESCAPED_GRAPHILE_WORKER_SCHEMA}.add_job('job1', '{"succeed": true}',  job_key := 'abc')`
     );
 
     // Assert that it has updated the existing entry and not created a new one
     const { rows: updatedJobs } = await pgClient.query(
-      `select * from ${ESCAPED_WORKER_SCHEMA}.jobs order by id asc`
+      `select * from ${ESCAPED_GRAPHILE_WORKER_SCHEMA}.jobs order by id asc`
     );
     expect(updatedJobs).toHaveLength(1);
     expect(updatedJobs[0].id).toEqual(initialJob.id);
@@ -469,7 +469,7 @@ test("job details are reset if not specified in update", () =>
     const {
       rows: [original],
     } = await pgClient.query(
-      `select * from ${ESCAPED_WORKER_SCHEMA}.add_job(
+      `select * from ${ESCAPED_GRAPHILE_WORKER_SCHEMA}.add_job(
         'job1',
         '{"a": 1}',
         queue_name := 'queue1',
@@ -494,14 +494,14 @@ test("job details are reset if not specified in update", () =>
 
     // Assert that it has an entry in jobs
     const { rows: jobs } = await pgClient.query(
-      `select * from ${ESCAPED_WORKER_SCHEMA}.jobs order by id asc`
+      `select * from ${ESCAPED_GRAPHILE_WORKER_SCHEMA}.jobs order by id asc`
     );
     expect(jobs).toHaveLength(1);
     expect(jobs[0]).toMatchObject(original);
 
     // update job, but don't provide any new details
     await pgClient.query(
-      `select * from ${ESCAPED_WORKER_SCHEMA}.add_job(
+      `select * from ${ESCAPED_GRAPHILE_WORKER_SCHEMA}.add_job(
         'job1',
         job_key := 'abc'
       )`
@@ -510,7 +510,7 @@ test("job details are reset if not specified in update", () =>
     // check omitted details have reverted to the default values, bar queue name
     // which should not change unless explicitly updated
     const { rows: jobs2 } = await pgClient.query(
-      `select * from ${ESCAPED_WORKER_SCHEMA}.jobs order by id asc`
+      `select * from ${ESCAPED_GRAPHILE_WORKER_SCHEMA}.jobs order by id asc`
     );
     expect(jobs2).toHaveLength(1);
     expect(jobs2[0]).toMatchObject({
@@ -528,7 +528,7 @@ test("job details are reset if not specified in update", () =>
     const runAt2 = new Date();
     runAt2.setSeconds(runAt.getSeconds() + 5);
     await pgClient.query(
-      `select * from ${ESCAPED_WORKER_SCHEMA}.add_job(
+      `select * from ${ESCAPED_GRAPHILE_WORKER_SCHEMA}.add_job(
         'job2',
         '{"a": 2}',
         queue_name := 'queue2',
@@ -540,7 +540,7 @@ test("job details are reset if not specified in update", () =>
 
     // check details have changed
     const { rows: jobs3 } = await pgClient.query(
-      `select * from ${ESCAPED_WORKER_SCHEMA}.jobs order by id asc`
+      `select * from ${ESCAPED_GRAPHILE_WORKER_SCHEMA}.jobs order by id asc`
     );
     expect(jobs3).toHaveLength(1);
     expect(jobs3[0]).toMatchObject({
@@ -564,25 +564,29 @@ test("pending jobs can be removed", () =>
 
     // Schedule a job
     await pgClient.query(
-      `select * from ${ESCAPED_WORKER_SCHEMA}.add_job('job1', '{"a": "1"}', job_key := 'abc')`
+      `select * from ${ESCAPED_GRAPHILE_WORKER_SCHEMA}.add_job('job1', '{"a": "1"}', job_key := 'abc')`
     );
 
     // Assert that it has an entry in jobs / job_queues
     expect(
       (
         await pgClient.query(
-          `select * from ${ESCAPED_WORKER_SCHEMA}.jobs order by id asc`
+          `select * from ${ESCAPED_GRAPHILE_WORKER_SCHEMA}.jobs order by id asc`
         )
       ).rows
     ).toHaveLength(1);
 
     // remove the job
     await pgClient.query(
-      `select * from ${ESCAPED_WORKER_SCHEMA}.remove_job('abc')`
+      `select * from ${ESCAPED_GRAPHILE_WORKER_SCHEMA}.remove_job('abc')`
     );
     // check there are no jobs
     expect(
-      (await pgClient.query(`select * from ${ESCAPED_WORKER_SCHEMA}.jobs`)).rows
+      (
+        await pgClient.query(
+          `select * from ${ESCAPED_GRAPHILE_WORKER_SCHEMA}.jobs`
+        )
+      ).rows
     ).toHaveLength(0);
   }));
 
@@ -601,14 +605,14 @@ test("jobs in progress cannot be removed", () =>
 
     // Schedule a job
     await pgClient.query(
-      `select * from ${ESCAPED_WORKER_SCHEMA}.add_job('job1', '{"a": 123}', job_key := 'abc')`
+      `select * from ${ESCAPED_GRAPHILE_WORKER_SCHEMA}.add_job('job1', '{"a": 123}', job_key := 'abc')`
     );
 
     // check it was inserted
     expect(
       (
         await pgClient.query(
-          `select * from ${ESCAPED_WORKER_SCHEMA}.jobs order by id asc`
+          `select * from ${ESCAPED_GRAPHILE_WORKER_SCHEMA}.jobs order by id asc`
         )
       ).rows
     ).toHaveLength(1);
@@ -620,14 +624,14 @@ test("jobs in progress cannot be removed", () =>
 
     // attempt to remove the job
     await pgClient.query(
-      `select * from ${ESCAPED_WORKER_SCHEMA}.remove_job('abc')`
+      `select * from ${ESCAPED_GRAPHILE_WORKER_SCHEMA}.remove_job('abc')`
     );
 
     // check it was not removed
     expect(
       (
         await pgClient.query(
-          `select * from ${ESCAPED_WORKER_SCHEMA}.jobs order by id asc`
+          `select * from ${ESCAPED_GRAPHILE_WORKER_SCHEMA}.jobs order by id asc`
         )
       ).rows
     ).toHaveLength(1);
@@ -647,7 +651,7 @@ test("runs jobs asynchronously", () =>
     // Schedule a job
     const start = new Date();
     await pgClient.query(
-      `select * from ${ESCAPED_WORKER_SCHEMA}.add_job('job1', '{"a": 1}', queue_name := 'myqueue')`
+      `select * from ${ESCAPED_GRAPHILE_WORKER_SCHEMA}.add_job('job1', '{"a": 1}', queue_name := 'myqueue')`
     );
 
     // Run the task
@@ -677,7 +681,7 @@ test("runs jobs asynchronously", () =>
 
     {
       const { rows: jobs } = await pgClient.query(
-        `select * from ${ESCAPED_WORKER_SCHEMA}.jobs order by id asc`
+        `select * from ${ESCAPED_GRAPHILE_WORKER_SCHEMA}.jobs order by id asc`
       );
       expect(jobs).toHaveLength(1);
       const job = jobs[0];
@@ -688,7 +692,7 @@ test("runs jobs asynchronously", () =>
       expect(job.attempts).toEqual(1); // It gets increased when the job is checked out
 
       const { rows: jobQueues } = await pgClient.query(
-        `select * from ${ESCAPED_WORKER_SCHEMA}.job_queues`
+        `select * from ${ESCAPED_GRAPHILE_WORKER_SCHEMA}.job_queues`
       );
       expect(jobQueues).toHaveLength(1);
       const q = jobQueues[0];
@@ -715,7 +719,7 @@ test("runs jobs in parallel", () =>
     // Schedule 5 jobs
     const start = new Date();
     await pgClient.query(
-      `select ${ESCAPED_WORKER_SCHEMA}.add_job('job1', '{"a": 1}', queue_name := 'queue_' || s::text) from generate_series(1, 5) s`
+      `select ${ESCAPED_GRAPHILE_WORKER_SCHEMA}.add_job('job1', '{"a": 1}', queue_name := 'queue_' || s::text) from generate_series(1, 5) s`
     );
 
     // Run the task
@@ -750,7 +754,7 @@ test("runs jobs in parallel", () =>
 
     {
       const { rows: jobs } = await pgClient.query(
-        `select * from ${ESCAPED_WORKER_SCHEMA}.jobs order by id asc`
+        `select * from ${ESCAPED_GRAPHILE_WORKER_SCHEMA}.jobs order by id asc`
       );
       expect(jobs).toHaveLength(5);
       jobs.forEach(job => {
@@ -762,7 +766,7 @@ test("runs jobs in parallel", () =>
       });
 
       const { rows: jobQueues } = await pgClient.query(
-        `select * from ${ESCAPED_WORKER_SCHEMA}.job_queues`
+        `select * from ${ESCAPED_GRAPHILE_WORKER_SCHEMA}.job_queues`
       );
       expect(jobQueues).toHaveLength(5);
       const locks: Array<string> = [];
@@ -794,7 +798,7 @@ test("single worker runs jobs in series, purges all before exit", () =>
 
     // Schedule 5 jobs
     await pgClient.query(
-      `select ${ESCAPED_WORKER_SCHEMA}.add_job('job1', '{"a": 1}') from generate_series(1, 5)`
+      `select ${ESCAPED_GRAPHILE_WORKER_SCHEMA}.add_job('job1', '{"a": 1}') from generate_series(1, 5)`
     );
 
     // Run the task
@@ -842,7 +846,7 @@ test("jobs added to the same queue will be ran serially (even if multiple worker
 
     // Schedule 5 jobs
     await pgClient.query(
-      `select ${ESCAPED_WORKER_SCHEMA}.add_job('job1', '{"a": 1}', 'serial') from generate_series(1, 5)`
+      `select ${ESCAPED_GRAPHILE_WORKER_SCHEMA}.add_job('job1', '{"a": 1}', 'serial') from generate_series(1, 5)`
     );
 
     // Run the task

--- a/__tests__/migrate.test.ts
+++ b/__tests__/migrate.test.ts
@@ -1,9 +1,14 @@
 import { migrate } from "../src/migrate";
-import { withPgClient } from "./helpers";
+import { withPgClient, ESCAPED_WORKER_SCHEMA, WORKER_SCHEMA } from "./helpers";
+import { WorkerSharedOptions } from "../src";
+
+const options: WorkerSharedOptions = {};
 
 test("migration installs schema; second migration does no harm", async () => {
   await withPgClient(async pgClient => {
-    await pgClient.query("drop schema if exists graphile_worker cascade;");
+    await pgClient.query(
+      `drop schema if exists ${ESCAPED_WORKER_SCHEMA} cascade;`
+    );
   });
   // We need to use a fresh connection after dropping the schema because the SQL
   // functions' plans get cached using the stale OIDs.
@@ -13,38 +18,40 @@ test("migration installs schema; second migration does no harm", async () => {
       rows: [graphileWorkerNamespaceBeforeMigration],
     } = await pgClient.query(
       `select * from pg_catalog.pg_namespace where nspname = $1`,
-      ["graphile_worker"]
+      [WORKER_SCHEMA]
     );
     expect(graphileWorkerNamespaceBeforeMigration).toBeFalsy();
 
     // Perform migration
-    await migrate(pgClient);
+    await migrate(pgClient, options);
 
     // Assert migrations table exists and has relevant entries
     const { rows: migrationRows } = await pgClient.query(
-      `select * from graphile_worker.migrations`
+      `select * from ${ESCAPED_WORKER_SCHEMA}.migrations`
     );
     expect(migrationRows).toHaveLength(4);
     const migration = migrationRows[0];
     expect(migration.id).toEqual(1);
 
     // Assert job schema files have been created (we're asserting no error is thrown)
-    await pgClient.query(`select graphile_worker.add_job('assert_jobs_work')`);
+    await pgClient.query(
+      `select ${ESCAPED_WORKER_SCHEMA}.add_job('assert_jobs_work')`
+    );
     {
       const { rows: jobsRows } = await pgClient.query(
-        "select * from graphile_worker.jobs"
+        `select * from ${ESCAPED_WORKER_SCHEMA}.jobs`
       );
       expect(jobsRows).toHaveLength(1);
       expect(jobsRows[0].task_identifier).toEqual("assert_jobs_work");
     }
 
     // Assert that re-migrating causes no issues
-    await migrate(pgClient);
-    await migrate(pgClient);
-    await migrate(pgClient);
+    await migrate(pgClient, options);
+    await migrate(pgClient, options);
+    await migrate(pgClient, options);
     {
       const { rows: jobsRows } = await pgClient.query(
-        "select * from graphile_worker.jobs"
+        `select * from ${ESCAPED_WORKER_SCHEMA}.jobs`
       );
       expect(jobsRows).toHaveLength(1);
       expect(jobsRows[0].task_identifier).toEqual("assert_jobs_work");

--- a/__tests__/migrate.test.ts
+++ b/__tests__/migrate.test.ts
@@ -1,5 +1,9 @@
 import { migrate } from "../src/migrate";
-import { withPgClient, ESCAPED_WORKER_SCHEMA, WORKER_SCHEMA } from "./helpers";
+import {
+  withPgClient,
+  ESCAPED_GRAPHILE_WORKER_SCHEMA,
+  GRAPHILE_WORKER_SCHEMA,
+} from "./helpers";
 import { WorkerSharedOptions } from "../src";
 
 const options: WorkerSharedOptions = {};
@@ -7,7 +11,7 @@ const options: WorkerSharedOptions = {};
 test("migration installs schema; second migration does no harm", async () => {
   await withPgClient(async pgClient => {
     await pgClient.query(
-      `drop schema if exists ${ESCAPED_WORKER_SCHEMA} cascade;`
+      `drop schema if exists ${ESCAPED_GRAPHILE_WORKER_SCHEMA} cascade;`
     );
   });
   // We need to use a fresh connection after dropping the schema because the SQL
@@ -18,7 +22,7 @@ test("migration installs schema; second migration does no harm", async () => {
       rows: [graphileWorkerNamespaceBeforeMigration],
     } = await pgClient.query(
       `select * from pg_catalog.pg_namespace where nspname = $1`,
-      [WORKER_SCHEMA]
+      [GRAPHILE_WORKER_SCHEMA]
     );
     expect(graphileWorkerNamespaceBeforeMigration).toBeFalsy();
 
@@ -27,7 +31,7 @@ test("migration installs schema; second migration does no harm", async () => {
 
     // Assert migrations table exists and has relevant entries
     const { rows: migrationRows } = await pgClient.query(
-      `select * from ${ESCAPED_WORKER_SCHEMA}.migrations`
+      `select * from ${ESCAPED_GRAPHILE_WORKER_SCHEMA}.migrations`
     );
     expect(migrationRows).toHaveLength(4);
     const migration = migrationRows[0];
@@ -35,11 +39,11 @@ test("migration installs schema; second migration does no harm", async () => {
 
     // Assert job schema files have been created (we're asserting no error is thrown)
     await pgClient.query(
-      `select ${ESCAPED_WORKER_SCHEMA}.add_job('assert_jobs_work')`
+      `select ${ESCAPED_GRAPHILE_WORKER_SCHEMA}.add_job('assert_jobs_work')`
     );
     {
       const { rows: jobsRows } = await pgClient.query(
-        `select * from ${ESCAPED_WORKER_SCHEMA}.jobs`
+        `select * from ${ESCAPED_GRAPHILE_WORKER_SCHEMA}.jobs`
       );
       expect(jobsRows).toHaveLength(1);
       expect(jobsRows[0].task_identifier).toEqual("assert_jobs_work");
@@ -51,7 +55,7 @@ test("migration installs schema; second migration does no harm", async () => {
     await migrate(pgClient, options);
     {
       const { rows: jobsRows } = await pgClient.query(
-        `select * from ${ESCAPED_WORKER_SCHEMA}.jobs`
+        `select * from ${ESCAPED_GRAPHILE_WORKER_SCHEMA}.jobs`
       );
       expect(jobsRows).toHaveLength(1);
       expect(jobsRows[0].task_identifier).toEqual("assert_jobs_work");

--- a/__tests__/migrate.test.ts
+++ b/__tests__/migrate.test.ts
@@ -27,7 +27,7 @@ test("migration installs schema; second migration does no harm", async () => {
     expect(graphileWorkerNamespaceBeforeMigration).toBeFalsy();
 
     // Perform migration
-    await migrate(pgClient, options);
+    await migrate(options, pgClient);
 
     // Assert migrations table exists and has relevant entries
     const { rows: migrationRows } = await pgClient.query(
@@ -50,9 +50,9 @@ test("migration installs schema; second migration does no harm", async () => {
     }
 
     // Assert that re-migrating causes no issues
-    await migrate(pgClient, options);
-    await migrate(pgClient, options);
-    await migrate(pgClient, options);
+    await migrate(options, pgClient);
+    await migrate(options, pgClient);
+    await migrate(options, pgClient);
     {
       const { rows: jobsRows } = await pgClient.query(
         `select * from ${ESCAPED_GRAPHILE_WORKER_SCHEMA}.jobs`

--- a/__tests__/reset-db.sql
+++ b/__tests__/reset-db.sql
@@ -1,2 +1,2 @@
-drop schema if exists graphile_worker cascade;
+drop schema if exists :WORKER_SCHEMA cascade;
 drop extension if exists pgcrypto;

--- a/__tests__/reset-db.sql
+++ b/__tests__/reset-db.sql
@@ -1,2 +1,2 @@
-drop schema if exists :WORKER_SCHEMA cascade;
+drop schema if exists :GRAPHILE_WORKER_SCHEMA cascade;
 drop extension if exists pgcrypto;

--- a/__tests__/reset-db.sql
+++ b/__tests__/reset-db.sql
@@ -1,2 +1,2 @@
 drop schema if exists :GRAPHILE_WORKER_SCHEMA cascade;
-drop extension if exists pgcrypto;
+drop extension if exists pgcrypto cascade;

--- a/__tests__/runner.runOnce.test.ts
+++ b/__tests__/runner.runOnce.test.ts
@@ -13,7 +13,9 @@ async function runOnceErrorAssertion(options: RunnerOptions, message: string) {
 }
 
 test("at least a list of tasks or a task directory must be provided", async () => {
-  const options: RunnerOptions = {};
+  const options: RunnerOptions = {
+    connectionString: TEST_CONNECTION_STRING,
+  };
   await runOnceErrorAssertion(
     options,
     "You must specify either `options.taskList` or `options.taskDirectory"
@@ -22,6 +24,7 @@ test("at least a list of tasks or a task directory must be provided", async () =
 
 test("taskList and taskDirectory cannot be provided a the same time", async () => {
   const options: RunnerOptions = {
+    connectionString: TEST_CONNECTION_STRING,
     taskDirectory: "foo",
     taskList: { task: () => {} },
   };

--- a/__tests__/workerUtils.addJob.test.ts
+++ b/__tests__/workerUtils.addJob.test.ts
@@ -33,7 +33,7 @@ test("runs a job added through the worker utils", () =>
 
     const task: Task = jest.fn();
     const taskList = { task };
-    await runTaskListOnce(taskList, pgClient);
+    await runTaskListOnce(options, taskList, pgClient);
   }));
 
 test("supports the jobKey API", () =>
@@ -57,7 +57,7 @@ test("supports the jobKey API", () =>
 
     const task: Task = jest.fn();
     const taskList = { task };
-    await runTaskListOnce(taskList, pgClient);
+    await runTaskListOnce(options, taskList, pgClient);
   }));
 
 test("runs a job added through the addJob shortcut function", () =>
@@ -77,5 +77,5 @@ test("runs a job added through the addJob shortcut function", () =>
 
     const task: Task = jest.fn();
     const taskList = { task };
-    await runTaskListOnce(taskList, pgClient);
+    await runTaskListOnce(options, taskList, pgClient);
   }));

--- a/__tests__/workerUtils.addJob.test.ts
+++ b/__tests__/workerUtils.addJob.test.ts
@@ -2,7 +2,7 @@ import {
   withPgClient,
   reset,
   TEST_CONNECTION_STRING,
-  ESCAPED_WORKER_SCHEMA,
+  ESCAPED_GRAPHILE_WORKER_SCHEMA,
 } from "./helpers";
 import {
   makeWorkerUtils,
@@ -27,7 +27,7 @@ test("runs a job added through the worker utils", () =>
 
     // Assert that it has an entry in jobs / job_queues
     const { rows: jobs } = await pgClient.query(
-      `select * from ${ESCAPED_WORKER_SCHEMA}.jobs`
+      `select * from ${ESCAPED_GRAPHILE_WORKER_SCHEMA}.jobs`
     );
     expect(jobs).toHaveLength(1);
 
@@ -51,7 +51,7 @@ test("supports the jobKey API", () =>
 
     // Assert that it has an entry in jobs / job_queues
     const { rows: jobs } = await pgClient.query(
-      `select * from ${ESCAPED_WORKER_SCHEMA}.jobs`
+      `select * from ${ESCAPED_GRAPHILE_WORKER_SCHEMA}.jobs`
     );
     expect(jobs).toHaveLength(1);
 
@@ -71,7 +71,7 @@ test("runs a job added through the addJob shortcut function", () =>
 
     // Assert that it has an entry in jobs / job_queues
     const { rows: jobs } = await pgClient.query(
-      `select * from ${ESCAPED_WORKER_SCHEMA}.jobs`
+      `select * from ${ESCAPED_GRAPHILE_WORKER_SCHEMA}.jobs`
     );
     expect(jobs).toHaveLength(1);
 

--- a/__tests__/workerUtils.addJob.test.ts
+++ b/__tests__/workerUtils.addJob.test.ts
@@ -1,14 +1,22 @@
-import { withPgClient, reset, TEST_CONNECTION_STRING } from "./helpers";
+import {
+  withPgClient,
+  reset,
+  TEST_CONNECTION_STRING,
+  ESCAPED_WORKER_SCHEMA,
+} from "./helpers";
 import {
   makeWorkerUtils,
   quickAddJob,
   runTaskListOnce,
   Task,
+  WorkerSharedOptions,
 } from "../src/index";
+
+const options: WorkerSharedOptions = {};
 
 test("runs a job added through the worker utils", () =>
   withPgClient(async pgClient => {
-    await reset(pgClient);
+    await reset(pgClient, options);
 
     // Schedule a job
     const utils = await makeWorkerUtils({
@@ -19,7 +27,7 @@ test("runs a job added through the worker utils", () =>
 
     // Assert that it has an entry in jobs / job_queues
     const { rows: jobs } = await pgClient.query(
-      `select * from graphile_worker.jobs`
+      `select * from ${ESCAPED_WORKER_SCHEMA}.jobs`
     );
     expect(jobs).toHaveLength(1);
 
@@ -30,7 +38,7 @@ test("runs a job added through the worker utils", () =>
 
 test("supports the jobKey API", () =>
   withPgClient(async pgClient => {
-    await reset(pgClient);
+    await reset(pgClient, options);
 
     // Schedule a job
     const utils = await makeWorkerUtils({
@@ -43,7 +51,7 @@ test("supports the jobKey API", () =>
 
     // Assert that it has an entry in jobs / job_queues
     const { rows: jobs } = await pgClient.query(
-      `select * from graphile_worker.jobs`
+      `select * from ${ESCAPED_WORKER_SCHEMA}.jobs`
     );
     expect(jobs).toHaveLength(1);
 
@@ -54,7 +62,7 @@ test("supports the jobKey API", () =>
 
 test("runs a job added through the addJob shortcut function", () =>
   withPgClient(async pgClient => {
-    await reset(pgClient);
+    await reset(pgClient, options);
 
     // Schedule a job
     await quickAddJob({ connectionString: TEST_CONNECTION_STRING }, "job1", {
@@ -63,7 +71,7 @@ test("runs a job added through the addJob shortcut function", () =>
 
     // Assert that it has an entry in jobs / job_queues
     const { rows: jobs } = await pgClient.query(
-      `select * from graphile_worker.jobs`
+      `select * from ${ESCAPED_WORKER_SCHEMA}.jobs`
     );
     expect(jobs).toHaveLength(1);
 

--- a/__tests__/workerUtils.completeJobs.test.ts
+++ b/__tests__/workerUtils.completeJobs.test.ts
@@ -3,17 +3,20 @@ import {
   reset,
   TEST_CONNECTION_STRING,
   makeSelectionOfJobs,
+  ESCAPED_WORKER_SCHEMA,
 } from "./helpers";
-import { makeWorkerUtils } from "../src/index";
+import { makeWorkerUtils, WorkerSharedOptions } from "../src/index";
 
 /** For sorting arrays of numbers or numeric strings */
 function numerically(a: string | number, b: string | number) {
   return parseFloat(String(a)) - parseFloat(String(b));
 }
 
+const options: WorkerSharedOptions = {};
+
 test("completes the jobs, leaves others unaffected", () =>
   withPgClient(async pgClient => {
-    await reset(pgClient);
+    await reset(pgClient, options);
 
     const utils = await makeWorkerUtils({
       connectionString: TEST_CONNECTION_STRING,
@@ -37,7 +40,7 @@ test("completes the jobs, leaves others unaffected", () =>
     );
 
     const { rows: remaining } = await pgClient.query(
-      `select * from graphile_worker.jobs order by id asc`
+      `select * from ${ESCAPED_WORKER_SCHEMA}.jobs order by id asc`
     );
     expect(remaining).toHaveLength(2);
     expect(remaining[0]).toMatchObject(lockedJob);

--- a/__tests__/workerUtils.completeJobs.test.ts
+++ b/__tests__/workerUtils.completeJobs.test.ts
@@ -3,7 +3,7 @@ import {
   reset,
   TEST_CONNECTION_STRING,
   makeSelectionOfJobs,
-  ESCAPED_WORKER_SCHEMA,
+  ESCAPED_GRAPHILE_WORKER_SCHEMA,
 } from "./helpers";
 import { makeWorkerUtils, WorkerSharedOptions } from "../src/index";
 
@@ -40,7 +40,7 @@ test("completes the jobs, leaves others unaffected", () =>
     );
 
     const { rows: remaining } = await pgClient.query(
-      `select * from ${ESCAPED_WORKER_SCHEMA}.jobs order by id asc`
+      `select * from ${ESCAPED_GRAPHILE_WORKER_SCHEMA}.jobs order by id asc`
     );
     expect(remaining).toHaveLength(2);
     expect(remaining[0]).toMatchObject(lockedJob);

--- a/__tests__/workerUtils.permanentlyFailJobs.test.ts
+++ b/__tests__/workerUtils.permanentlyFailJobs.test.ts
@@ -3,17 +3,20 @@ import {
   reset,
   TEST_CONNECTION_STRING,
   makeSelectionOfJobs,
+  ESCAPED_WORKER_SCHEMA,
 } from "./helpers";
-import { makeWorkerUtils } from "../src/index";
+import { makeWorkerUtils, WorkerSharedOptions } from "../src/index";
 
 /** For sorting arrays of numbers or numeric strings */
 function numerically(a: string | number, b: string | number) {
   return parseFloat(String(a)) - parseFloat(String(b));
 }
 
+const options: WorkerSharedOptions = {};
+
 test("completes the jobs, leaves others unaffected", () =>
   withPgClient(async pgClient => {
-    await reset(pgClient);
+    await reset(pgClient, options);
 
     const utils = await makeWorkerUtils({
       connectionString: TEST_CONNECTION_STRING,
@@ -44,7 +47,7 @@ test("completes the jobs, leaves others unaffected", () =>
     const {
       rows: remaining,
     } = await pgClient.query(
-      `select * from graphile_worker.jobs where not (id = any($1)) order by id asc`,
+      `select * from ${ESCAPED_WORKER_SCHEMA}.jobs where not (id = any($1)) order by id asc`,
       [failedJobIds]
     );
     expect(remaining).toHaveLength(2);

--- a/__tests__/workerUtils.permanentlyFailJobs.test.ts
+++ b/__tests__/workerUtils.permanentlyFailJobs.test.ts
@@ -3,7 +3,7 @@ import {
   reset,
   TEST_CONNECTION_STRING,
   makeSelectionOfJobs,
-  ESCAPED_WORKER_SCHEMA,
+  ESCAPED_GRAPHILE_WORKER_SCHEMA,
 } from "./helpers";
 import { makeWorkerUtils, WorkerSharedOptions } from "../src/index";
 
@@ -47,7 +47,7 @@ test("completes the jobs, leaves others unaffected", () =>
     const {
       rows: remaining,
     } = await pgClient.query(
-      `select * from ${ESCAPED_WORKER_SCHEMA}.jobs where not (id = any($1)) order by id asc`,
+      `select * from ${ESCAPED_GRAPHILE_WORKER_SCHEMA}.jobs where not (id = any($1)) order by id asc`,
       [failedJobIds]
     );
     expect(remaining).toHaveLength(2);

--- a/__tests__/workerUtils.rescheduleJobs.test.ts
+++ b/__tests__/workerUtils.rescheduleJobs.test.ts
@@ -3,17 +3,20 @@ import {
   reset,
   TEST_CONNECTION_STRING,
   makeSelectionOfJobs,
+  ESCAPED_WORKER_SCHEMA,
 } from "./helpers";
-import { makeWorkerUtils, Job } from "../src/index";
+import { makeWorkerUtils, Job, WorkerSharedOptions } from "../src/index";
 
 /** For sorting arrays of numbers or numeric strings */
 function numerically(a: string | number, b: string | number) {
   return parseFloat(String(a)) - parseFloat(String(b));
 }
 
+const options: WorkerSharedOptions = {};
+
 test("completes the jobs, leaves others unaffected", () =>
   withPgClient(async pgClient => {
-    await reset(pgClient);
+    await reset(pgClient, options);
 
     const utils = await makeWorkerUtils({
       connectionString: TEST_CONNECTION_STRING,
@@ -48,7 +51,7 @@ test("completes the jobs, leaves others unaffected", () =>
     }
 
     const { rows: remaining } = await pgClient.query<Job>(
-      `select * from graphile_worker.jobs where not (id = any($1)) order by id asc`,
+      `select * from ${ESCAPED_WORKER_SCHEMA}.jobs where not (id = any($1)) order by id asc`,
       [rescheduledJobIds]
     );
     expect(remaining).toHaveLength(2);

--- a/__tests__/workerUtils.rescheduleJobs.test.ts
+++ b/__tests__/workerUtils.rescheduleJobs.test.ts
@@ -3,7 +3,7 @@ import {
   reset,
   TEST_CONNECTION_STRING,
   makeSelectionOfJobs,
-  ESCAPED_WORKER_SCHEMA,
+  ESCAPED_GRAPHILE_WORKER_SCHEMA,
 } from "./helpers";
 import { makeWorkerUtils, Job, WorkerSharedOptions } from "../src/index";
 
@@ -51,7 +51,7 @@ test("completes the jobs, leaves others unaffected", () =>
     }
 
     const { rows: remaining } = await pgClient.query<Job>(
-      `select * from ${ESCAPED_WORKER_SCHEMA}.jobs where not (id = any($1)) order by id asc`,
+      `select * from ${ESCAPED_GRAPHILE_WORKER_SCHEMA}.jobs where not (id = any($1)) order by id asc`,
       [rescheduledJobIds]
     );
     expect(remaining).toHaveLength(2);

--- a/package.json
+++ b/package.json
@@ -40,7 +40,6 @@
     "@types/pg": "^7.14.1",
     "chokidar": "^3.3.1",
     "pg": ">=6.5 <8",
-    "pg-connection-string": "^2.0.0",
     "tslib": "^1.9.3",
     "yargs": "^15.1.0"
   },
@@ -54,6 +53,7 @@
     "eslint-plugin-prettier": "^3.1.2",
     "eslint_d": "^8.0.0",
     "jest": "^25.1.0",
+    "pg-connection-string": "^2.0.0",
     "prettier": "^1.19.1",
     "ts-jest": "^25.2.0",
     "typescript": "^3.7.5"

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "@types/debug": "^4.1.2",
     "@types/pg": "^7.14.1",
     "chokidar": "^3.3.1",
+    "cosmiconfig": "^6.0.0",
     "pg": ">=6.5 <8",
     "tslib": "^1.9.3",
     "yargs": "^15.1.0"

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "prepack": "rm -Rf dist && tsc && chmod +x dist/cli.js",
     "watch": "mkdir -p dist && touch dist/cli.js && chmod +x dist/cli.js && tsc --watch",
     "lint": "eslint 'src/**/*'",
-    "test": "createdb graphile_worker_test || true && psql -X -v WORKER_SCHEMA=\"${WORKER_SCHEMA:-graphile_worker}\" -v ON_ERROR_STOP=1 -f __tests__/reset-db.sql graphile_worker_test && jest -i",
+    "test": "createdb graphile_worker_test || true && psql -X -v GRAPHILE_WORKER_SCHEMA=\"${GRAPHILE_WORKER_SCHEMA:-graphile_worker}\" -v ON_ERROR_STOP=1 -f __tests__/reset-db.sql graphile_worker_test && jest -i",
     "perfTest": "cd perfTest && node ./run.js"
   },
   "bin": {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "prepack": "rm -Rf dist && tsc && chmod +x dist/cli.js",
     "watch": "mkdir -p dist && touch dist/cli.js && chmod +x dist/cli.js && tsc --watch",
     "lint": "eslint 'src/**/*'",
-    "test": "createdb graphile_worker_test || true && psql -Xv ON_ERROR_STOP=1 -f __tests__/reset-db.sql graphile_worker_test && jest -i",
+    "test": "createdb graphile_worker_test || true && psql -X -v WORKER_SCHEMA=\"${WORKER_SCHEMA:-graphile_worker}\" -v ON_ERROR_STOP=1 -f __tests__/reset-db.sql graphile_worker_test && jest -i",
     "perfTest": "cd perfTest && node ./run.js"
   },
   "bin": {

--- a/perfTest/latencyTest.js
+++ b/perfTest/latencyTest.js
@@ -5,6 +5,10 @@ const { default: deferred } = require("../dist/deferred");
 
 const sleep = ms => new Promise(resolve => setTimeout(resolve, ms));
 
+const options = {
+  concurrecy: 1,
+};
+
 async function main() {
   const pgPool = new Pool({ connectionString: process.env.PERF_DATABASE_URL });
   const startTimes = {};
@@ -18,7 +22,7 @@ async function main() {
       }
     },
   };
-  const workerPool = runTaskList(tasks, pgPool, 1);
+  const workerPool = runTaskList(options, tasks, pgPool);
 
   // Warm up
   await pgPool.query(

--- a/sql/000001.sql
+++ b/sql/000001.sql
@@ -1,13 +1,13 @@
 -- Create the tables
-create table graphile_worker.job_queues (
+create table :WORKER_SCHEMA.job_queues (
   queue_name text not null primary key,
   job_count int not null,
   locked_at timestamptz,
   locked_by text
 );
-alter table graphile_worker.job_queues enable row level security;
+alter table :WORKER_SCHEMA.job_queues enable row level security;
 
-create table graphile_worker.jobs (
+create table :WORKER_SCHEMA.jobs (
   id bigserial primary key,
   queue_name text default (public.gen_random_uuid())::text not null,
   task_identifier text not null,
@@ -20,39 +20,39 @@ create table graphile_worker.jobs (
   created_at timestamp with time zone not null default now(),
   updated_at timestamp with time zone not null default now()
 );
-alter table graphile_worker.jobs enable row level security;
+alter table :WORKER_SCHEMA.jobs enable row level security;
 
-create index on graphile_worker.jobs (priority, run_at, id);
+create index on :WORKER_SCHEMA.jobs (priority, run_at, id);
 
 -- Keep updated_at up to date
-create function graphile_worker.tg__update_timestamp() returns trigger as $$
+create function :WORKER_SCHEMA.tg__update_timestamp() returns trigger as $$
 begin
   new.updated_at = greatest(now(), old.updated_at + interval '1 millisecond');
   return new;
 end;
 $$ language plpgsql;
-create trigger _100_timestamps before update on graphile_worker.jobs for each row execute procedure graphile_worker.tg__update_timestamp();
+create trigger _100_timestamps before update on :WORKER_SCHEMA.jobs for each row execute procedure :WORKER_SCHEMA.tg__update_timestamp();
 
 -- Manage the job_queues table - creating and deleting entries as appropriate
-create function graphile_worker.jobs__decrease_job_queue_count() returns trigger as $$
+create function :WORKER_SCHEMA.jobs__decrease_job_queue_count() returns trigger as $$
 declare
   v_new_job_count int;
 begin
-  update graphile_worker.job_queues
+  update :WORKER_SCHEMA.job_queues
     set job_count = job_queues.job_count - 1
     where queue_name = old.queue_name
     returning job_count into v_new_job_count;
 
   if v_new_job_count <= 0 then
-    delete from graphile_worker.job_queues where queue_name = old.queue_name and job_count <= 0;
+    delete from :WORKER_SCHEMA.job_queues where queue_name = old.queue_name and job_count <= 0;
   end if;
 
   return old;
 end;
 $$ language plpgsql;
-create function graphile_worker.jobs__increase_job_queue_count() returns trigger as $$
+create function :WORKER_SCHEMA.jobs__increase_job_queue_count() returns trigger as $$
 begin
-  insert into graphile_worker.job_queues(queue_name, job_count)
+  insert into :WORKER_SCHEMA.job_queues(queue_name, job_count)
     values(new.queue_name, 1)
     on conflict (queue_name)
     do update
@@ -61,40 +61,40 @@ begin
   return new;
 end;
 $$ language plpgsql;
-create trigger _500_increase_job_queue_count after insert on graphile_worker.jobs for each row execute procedure graphile_worker.jobs__increase_job_queue_count();
-create trigger _500_decrease_job_queue_count after delete on graphile_worker.jobs for each row execute procedure graphile_worker.jobs__decrease_job_queue_count();
-create trigger _500_increase_job_queue_count_update after update of queue_name on graphile_worker.jobs for each row execute procedure graphile_worker.jobs__increase_job_queue_count();
-create trigger _500_decrease_job_queue_count_update after update of queue_name on graphile_worker.jobs for each row execute procedure graphile_worker.jobs__decrease_job_queue_count();
+create trigger _500_increase_job_queue_count after insert on :WORKER_SCHEMA.jobs for each row execute procedure :WORKER_SCHEMA.jobs__increase_job_queue_count();
+create trigger _500_decrease_job_queue_count after delete on :WORKER_SCHEMA.jobs for each row execute procedure :WORKER_SCHEMA.jobs__decrease_job_queue_count();
+create trigger _500_increase_job_queue_count_update after update of queue_name on :WORKER_SCHEMA.jobs for each row execute procedure :WORKER_SCHEMA.jobs__increase_job_queue_count();
+create trigger _500_decrease_job_queue_count_update after update of queue_name on :WORKER_SCHEMA.jobs for each row execute procedure :WORKER_SCHEMA.jobs__decrease_job_queue_count();
 
 -- Notify worker of new jobs
-create function graphile_worker.tg_jobs__notify_new_jobs() returns trigger as $$
+create function :WORKER_SCHEMA.tg_jobs__notify_new_jobs() returns trigger as $$
 begin
   perform pg_notify('jobs:insert', '');
   return new;
 end;
 $$ language plpgsql;
-create trigger _900_notify_worker after insert on graphile_worker.jobs for each statement execute procedure graphile_worker.tg_jobs__notify_new_jobs();
+create trigger _900_notify_worker after insert on :WORKER_SCHEMA.jobs for each statement execute procedure :WORKER_SCHEMA.tg_jobs__notify_new_jobs();
 
 -- Function to queue a job
-create function graphile_worker.add_job(identifier text, payload json = '{}', queue_name text = public.gen_random_uuid()::text, run_at timestamptz = now(), max_attempts int = 25) returns graphile_worker.jobs as $$
-  insert into graphile_worker.jobs(task_identifier, payload, queue_name, run_at, max_attempts) values(identifier, payload, queue_name, run_at, max_attempts) returning *;
+create function :WORKER_SCHEMA.add_job(identifier text, payload json = '{}', queue_name text = public.gen_random_uuid()::text, run_at timestamptz = now(), max_attempts int = 25) returns :WORKER_SCHEMA.jobs as $$
+  insert into :WORKER_SCHEMA.jobs(task_identifier, payload, queue_name, run_at, max_attempts) values(identifier, payload, queue_name, run_at, max_attempts) returning *;
 $$ language sql;
 
 -- The main function - find me a job to do!
-create function graphile_worker.get_job(worker_id text, task_identifiers text[] = null, job_expiry interval = interval '4 hours') returns graphile_worker.jobs as $$
+create function :WORKER_SCHEMA.get_job(worker_id text, task_identifiers text[] = null, job_expiry interval = interval '4 hours') returns :WORKER_SCHEMA.jobs as $$
 declare
   v_job_id bigint;
   v_queue_name text;
   v_default_job_max_attempts text = '25';
-  v_row graphile_worker.jobs;
+  v_row :WORKER_SCHEMA.jobs;
 begin
   if worker_id is null or length(worker_id) < 10 then
     raise exception 'invalid worker id';
   end if;
 
   select job_queues.queue_name, jobs.id into v_queue_name, v_job_id
-    from graphile_worker.jobs
-    inner join graphile_worker.job_queues using (queue_name)
+    from :WORKER_SCHEMA.jobs
+    inner join :WORKER_SCHEMA.job_queues using (queue_name)
     where (locked_at is null or locked_at < (now() - job_expiry))
     and run_at <= now()
     and attempts < max_attempts
@@ -108,13 +108,13 @@ begin
     return null;
   end if;
 
-  update graphile_worker.job_queues
+  update :WORKER_SCHEMA.job_queues
     set
       locked_by = worker_id,
       locked_at = now()
     where job_queues.queue_name = v_queue_name;
 
-  update graphile_worker.jobs
+  update :WORKER_SCHEMA.jobs
     set attempts = attempts + 1
     where id = v_job_id
     returning * into v_row;
@@ -124,15 +124,15 @@ end;
 $$ language plpgsql;
 
 -- I was successful, mark the job as completed
-create function graphile_worker.complete_job(worker_id text, job_id bigint) returns graphile_worker.jobs as $$
+create function :WORKER_SCHEMA.complete_job(worker_id text, job_id bigint) returns :WORKER_SCHEMA.jobs as $$
 declare
-  v_row graphile_worker.jobs;
+  v_row :WORKER_SCHEMA.jobs;
 begin
-  delete from graphile_worker.jobs
+  delete from :WORKER_SCHEMA.jobs
     where id = job_id
     returning * into v_row;
 
-  update graphile_worker.job_queues
+  update :WORKER_SCHEMA.job_queues
     set locked_by = null, locked_at = null
     where queue_name = v_row.queue_name and locked_by = worker_id;
 
@@ -141,18 +141,18 @@ end;
 $$ language plpgsql;
 
 -- I was unsuccessful, re-schedule the job please
-create function graphile_worker.fail_job(worker_id text, job_id bigint, error_message text) returns graphile_worker.jobs as $$
+create function :WORKER_SCHEMA.fail_job(worker_id text, job_id bigint, error_message text) returns :WORKER_SCHEMA.jobs as $$
 declare
-  v_row graphile_worker.jobs;
+  v_row :WORKER_SCHEMA.jobs;
 begin
-  update graphile_worker.jobs
+  update :WORKER_SCHEMA.jobs
     set
       last_error = error_message,
       run_at = greatest(now(), run_at) + (exp(least(attempts, 10))::text || ' seconds')::interval
     where id = job_id
     returning * into v_row;
 
-  update graphile_worker.job_queues
+  update :WORKER_SCHEMA.job_queues
     set locked_by = null, locked_at = null
     where queue_name = v_row.queue_name and locked_by = worker_id;
 

--- a/sql/000001.sql
+++ b/sql/000001.sql
@@ -1,13 +1,13 @@
 -- Create the tables
-create table :WORKER_SCHEMA.job_queues (
+create table :GRAPHILE_WORKER_SCHEMA.job_queues (
   queue_name text not null primary key,
   job_count int not null,
   locked_at timestamptz,
   locked_by text
 );
-alter table :WORKER_SCHEMA.job_queues enable row level security;
+alter table :GRAPHILE_WORKER_SCHEMA.job_queues enable row level security;
 
-create table :WORKER_SCHEMA.jobs (
+create table :GRAPHILE_WORKER_SCHEMA.jobs (
   id bigserial primary key,
   queue_name text default (public.gen_random_uuid())::text not null,
   task_identifier text not null,
@@ -20,39 +20,39 @@ create table :WORKER_SCHEMA.jobs (
   created_at timestamp with time zone not null default now(),
   updated_at timestamp with time zone not null default now()
 );
-alter table :WORKER_SCHEMA.jobs enable row level security;
+alter table :GRAPHILE_WORKER_SCHEMA.jobs enable row level security;
 
-create index on :WORKER_SCHEMA.jobs (priority, run_at, id);
+create index on :GRAPHILE_WORKER_SCHEMA.jobs (priority, run_at, id);
 
 -- Keep updated_at up to date
-create function :WORKER_SCHEMA.tg__update_timestamp() returns trigger as $$
+create function :GRAPHILE_WORKER_SCHEMA.tg__update_timestamp() returns trigger as $$
 begin
   new.updated_at = greatest(now(), old.updated_at + interval '1 millisecond');
   return new;
 end;
 $$ language plpgsql;
-create trigger _100_timestamps before update on :WORKER_SCHEMA.jobs for each row execute procedure :WORKER_SCHEMA.tg__update_timestamp();
+create trigger _100_timestamps before update on :GRAPHILE_WORKER_SCHEMA.jobs for each row execute procedure :GRAPHILE_WORKER_SCHEMA.tg__update_timestamp();
 
 -- Manage the job_queues table - creating and deleting entries as appropriate
-create function :WORKER_SCHEMA.jobs__decrease_job_queue_count() returns trigger as $$
+create function :GRAPHILE_WORKER_SCHEMA.jobs__decrease_job_queue_count() returns trigger as $$
 declare
   v_new_job_count int;
 begin
-  update :WORKER_SCHEMA.job_queues
+  update :GRAPHILE_WORKER_SCHEMA.job_queues
     set job_count = job_queues.job_count - 1
     where queue_name = old.queue_name
     returning job_count into v_new_job_count;
 
   if v_new_job_count <= 0 then
-    delete from :WORKER_SCHEMA.job_queues where queue_name = old.queue_name and job_count <= 0;
+    delete from :GRAPHILE_WORKER_SCHEMA.job_queues where queue_name = old.queue_name and job_count <= 0;
   end if;
 
   return old;
 end;
 $$ language plpgsql;
-create function :WORKER_SCHEMA.jobs__increase_job_queue_count() returns trigger as $$
+create function :GRAPHILE_WORKER_SCHEMA.jobs__increase_job_queue_count() returns trigger as $$
 begin
-  insert into :WORKER_SCHEMA.job_queues(queue_name, job_count)
+  insert into :GRAPHILE_WORKER_SCHEMA.job_queues(queue_name, job_count)
     values(new.queue_name, 1)
     on conflict (queue_name)
     do update
@@ -61,40 +61,40 @@ begin
   return new;
 end;
 $$ language plpgsql;
-create trigger _500_increase_job_queue_count after insert on :WORKER_SCHEMA.jobs for each row execute procedure :WORKER_SCHEMA.jobs__increase_job_queue_count();
-create trigger _500_decrease_job_queue_count after delete on :WORKER_SCHEMA.jobs for each row execute procedure :WORKER_SCHEMA.jobs__decrease_job_queue_count();
-create trigger _500_increase_job_queue_count_update after update of queue_name on :WORKER_SCHEMA.jobs for each row execute procedure :WORKER_SCHEMA.jobs__increase_job_queue_count();
-create trigger _500_decrease_job_queue_count_update after update of queue_name on :WORKER_SCHEMA.jobs for each row execute procedure :WORKER_SCHEMA.jobs__decrease_job_queue_count();
+create trigger _500_increase_job_queue_count after insert on :GRAPHILE_WORKER_SCHEMA.jobs for each row execute procedure :GRAPHILE_WORKER_SCHEMA.jobs__increase_job_queue_count();
+create trigger _500_decrease_job_queue_count after delete on :GRAPHILE_WORKER_SCHEMA.jobs for each row execute procedure :GRAPHILE_WORKER_SCHEMA.jobs__decrease_job_queue_count();
+create trigger _500_increase_job_queue_count_update after update of queue_name on :GRAPHILE_WORKER_SCHEMA.jobs for each row execute procedure :GRAPHILE_WORKER_SCHEMA.jobs__increase_job_queue_count();
+create trigger _500_decrease_job_queue_count_update after update of queue_name on :GRAPHILE_WORKER_SCHEMA.jobs for each row execute procedure :GRAPHILE_WORKER_SCHEMA.jobs__decrease_job_queue_count();
 
 -- Notify worker of new jobs
-create function :WORKER_SCHEMA.tg_jobs__notify_new_jobs() returns trigger as $$
+create function :GRAPHILE_WORKER_SCHEMA.tg_jobs__notify_new_jobs() returns trigger as $$
 begin
   perform pg_notify('jobs:insert', '');
   return new;
 end;
 $$ language plpgsql;
-create trigger _900_notify_worker after insert on :WORKER_SCHEMA.jobs for each statement execute procedure :WORKER_SCHEMA.tg_jobs__notify_new_jobs();
+create trigger _900_notify_worker after insert on :GRAPHILE_WORKER_SCHEMA.jobs for each statement execute procedure :GRAPHILE_WORKER_SCHEMA.tg_jobs__notify_new_jobs();
 
 -- Function to queue a job
-create function :WORKER_SCHEMA.add_job(identifier text, payload json = '{}', queue_name text = public.gen_random_uuid()::text, run_at timestamptz = now(), max_attempts int = 25) returns :WORKER_SCHEMA.jobs as $$
-  insert into :WORKER_SCHEMA.jobs(task_identifier, payload, queue_name, run_at, max_attempts) values(identifier, payload, queue_name, run_at, max_attempts) returning *;
+create function :GRAPHILE_WORKER_SCHEMA.add_job(identifier text, payload json = '{}', queue_name text = public.gen_random_uuid()::text, run_at timestamptz = now(), max_attempts int = 25) returns :GRAPHILE_WORKER_SCHEMA.jobs as $$
+  insert into :GRAPHILE_WORKER_SCHEMA.jobs(task_identifier, payload, queue_name, run_at, max_attempts) values(identifier, payload, queue_name, run_at, max_attempts) returning *;
 $$ language sql;
 
 -- The main function - find me a job to do!
-create function :WORKER_SCHEMA.get_job(worker_id text, task_identifiers text[] = null, job_expiry interval = interval '4 hours') returns :WORKER_SCHEMA.jobs as $$
+create function :GRAPHILE_WORKER_SCHEMA.get_job(worker_id text, task_identifiers text[] = null, job_expiry interval = interval '4 hours') returns :GRAPHILE_WORKER_SCHEMA.jobs as $$
 declare
   v_job_id bigint;
   v_queue_name text;
   v_default_job_max_attempts text = '25';
-  v_row :WORKER_SCHEMA.jobs;
+  v_row :GRAPHILE_WORKER_SCHEMA.jobs;
 begin
   if worker_id is null or length(worker_id) < 10 then
     raise exception 'invalid worker id';
   end if;
 
   select job_queues.queue_name, jobs.id into v_queue_name, v_job_id
-    from :WORKER_SCHEMA.jobs
-    inner join :WORKER_SCHEMA.job_queues using (queue_name)
+    from :GRAPHILE_WORKER_SCHEMA.jobs
+    inner join :GRAPHILE_WORKER_SCHEMA.job_queues using (queue_name)
     where (locked_at is null or locked_at < (now() - job_expiry))
     and run_at <= now()
     and attempts < max_attempts
@@ -108,13 +108,13 @@ begin
     return null;
   end if;
 
-  update :WORKER_SCHEMA.job_queues
+  update :GRAPHILE_WORKER_SCHEMA.job_queues
     set
       locked_by = worker_id,
       locked_at = now()
     where job_queues.queue_name = v_queue_name;
 
-  update :WORKER_SCHEMA.jobs
+  update :GRAPHILE_WORKER_SCHEMA.jobs
     set attempts = attempts + 1
     where id = v_job_id
     returning * into v_row;
@@ -124,15 +124,15 @@ end;
 $$ language plpgsql;
 
 -- I was successful, mark the job as completed
-create function :WORKER_SCHEMA.complete_job(worker_id text, job_id bigint) returns :WORKER_SCHEMA.jobs as $$
+create function :GRAPHILE_WORKER_SCHEMA.complete_job(worker_id text, job_id bigint) returns :GRAPHILE_WORKER_SCHEMA.jobs as $$
 declare
-  v_row :WORKER_SCHEMA.jobs;
+  v_row :GRAPHILE_WORKER_SCHEMA.jobs;
 begin
-  delete from :WORKER_SCHEMA.jobs
+  delete from :GRAPHILE_WORKER_SCHEMA.jobs
     where id = job_id
     returning * into v_row;
 
-  update :WORKER_SCHEMA.job_queues
+  update :GRAPHILE_WORKER_SCHEMA.job_queues
     set locked_by = null, locked_at = null
     where queue_name = v_row.queue_name and locked_by = worker_id;
 
@@ -141,18 +141,18 @@ end;
 $$ language plpgsql;
 
 -- I was unsuccessful, re-schedule the job please
-create function :WORKER_SCHEMA.fail_job(worker_id text, job_id bigint, error_message text) returns :WORKER_SCHEMA.jobs as $$
+create function :GRAPHILE_WORKER_SCHEMA.fail_job(worker_id text, job_id bigint, error_message text) returns :GRAPHILE_WORKER_SCHEMA.jobs as $$
 declare
-  v_row :WORKER_SCHEMA.jobs;
+  v_row :GRAPHILE_WORKER_SCHEMA.jobs;
 begin
-  update :WORKER_SCHEMA.jobs
+  update :GRAPHILE_WORKER_SCHEMA.jobs
     set
       last_error = error_message,
       run_at = greatest(now(), run_at) + (exp(least(attempts, 10))::text || ' seconds')::interval
     where id = job_id
     returning * into v_row;
 
-  update :WORKER_SCHEMA.job_queues
+  update :GRAPHILE_WORKER_SCHEMA.job_queues
     set locked_by = null, locked_at = null
     where queue_name = v_row.queue_name and locked_by = worker_id;
 

--- a/sql/000002.sql
+++ b/sql/000002.sql
@@ -1,36 +1,36 @@
-alter table graphile_worker.jobs add column key text unique check(length(key) > 0);
+alter table :WORKER_SCHEMA.jobs add column key text unique check(length(key) > 0);
 
-alter table graphile_worker.jobs add locked_at timestamptz;
-alter table graphile_worker.jobs add locked_by text;
+alter table :WORKER_SCHEMA.jobs add locked_at timestamptz;
+alter table :WORKER_SCHEMA.jobs add locked_by text;
 
 -- update any in-flight jobs
-update graphile_worker.jobs
+update :WORKER_SCHEMA.jobs
   set locked_at = q.locked_at, locked_by = q.locked_by
-  from graphile_worker.job_queues q
+  from :WORKER_SCHEMA.job_queues q
   where q.queue_name = jobs.queue_name
   and q.locked_at is not null;
 
 -- update add_job behaviour to meet new requirements
-drop function if exists graphile_worker.add_job(identifier text,
+drop function if exists :WORKER_SCHEMA.add_job(identifier text,
   payload json,
   queue_name text,
   run_at timestamptz,
   max_attempts int
 );
-create function graphile_worker.add_job(
+create function :WORKER_SCHEMA.add_job(
   identifier text,
   payload json = '{}',
   queue_name text = null,
   run_at timestamptz = now(),
   max_attempts int = 25,
   job_key text = null
-) returns graphile_worker.jobs as $$
+) returns :WORKER_SCHEMA.jobs as $$
 declare
-  v_job graphile_worker.jobs;
+  v_job :WORKER_SCHEMA.jobs;
 begin
   if job_key is not null then
     -- Upsert job
-    insert into graphile_worker.jobs (task_identifier, payload, queue_name, run_at, max_attempts, key)
+    insert into :WORKER_SCHEMA.jobs (task_identifier, payload, queue_name, run_at, max_attempts, key)
       values(
         identifier,
         payload,
@@ -63,7 +63,7 @@ begin
     -- Upsert failed -> there must be an existing job that is locked. Remove
     -- existing key to allow a new one to be inserted, and prevent any
     -- subsequent retries by bumping attempts to the max allowed.
-    update graphile_worker.jobs
+    update :WORKER_SCHEMA.jobs
       set
         key = null,
         attempts = jobs.max_attempts
@@ -71,7 +71,7 @@ begin
   end if;
 
   -- insert the new job. Assume no conflicts due to the update above
-  insert into graphile_worker.jobs(task_identifier, payload, queue_name, run_at, max_attempts, key)
+  insert into :WORKER_SCHEMA.jobs(task_identifier, payload, queue_name, run_at, max_attempts, key)
     values(
       identifier,
       payload,
@@ -89,10 +89,10 @@ $$ language plpgsql volatile;
 
 --- implement new remove_job function
 
-create function graphile_worker.remove_job(
+create function :WORKER_SCHEMA.remove_job(
   job_key text
-) returns graphile_worker.jobs as $$
-  delete from graphile_worker.jobs
+) returns :WORKER_SCHEMA.jobs as $$
+  delete from :WORKER_SCHEMA.jobs
     where key = job_key
     and locked_at is null
   returning *;
@@ -100,11 +100,11 @@ $$ language sql strict volatile;
 
 -- Update other functions to handle locked_at denormalisation
 
-create or replace function graphile_worker.get_job(worker_id text, task_identifiers text[] = null, job_expiry interval = interval '4 hours') returns graphile_worker.jobs as $$
+create or replace function :WORKER_SCHEMA.get_job(worker_id text, task_identifiers text[] = null, job_expiry interval = interval '4 hours') returns :WORKER_SCHEMA.jobs as $$
 declare
   v_job_id bigint;
   v_queue_name text;
-  v_row graphile_worker.jobs;
+  v_row :WORKER_SCHEMA.jobs;
   v_now timestamptz = now();
 begin
   if worker_id is null or length(worker_id) < 10 then
@@ -112,8 +112,8 @@ begin
   end if;
 
   select job_queues.queue_name, jobs.id into v_queue_name, v_job_id
-    from graphile_worker.jobs
-    inner join graphile_worker.job_queues using (queue_name)
+    from :WORKER_SCHEMA.jobs
+    inner join :WORKER_SCHEMA.job_queues using (queue_name)
     where (job_queues.locked_at is null or job_queues.locked_at < (v_now - job_expiry))
     and run_at <= v_now
     and attempts < max_attempts
@@ -127,13 +127,13 @@ begin
     return null;
   end if;
 
-  update graphile_worker.job_queues
+  update :WORKER_SCHEMA.job_queues
     set
       locked_by = worker_id,
       locked_at = v_now
     where job_queues.queue_name = v_queue_name;
 
-  update graphile_worker.jobs
+  update :WORKER_SCHEMA.jobs
     set
       attempts = attempts + 1,
       locked_by = worker_id,
@@ -146,11 +146,11 @@ end;
 $$ language plpgsql volatile;
 
 -- I was unsuccessful, re-schedule the job please
-create or replace function graphile_worker.fail_job(worker_id text, job_id bigint, error_message text) returns graphile_worker.jobs as $$
+create or replace function :WORKER_SCHEMA.fail_job(worker_id text, job_id bigint, error_message text) returns :WORKER_SCHEMA.jobs as $$
 declare
-  v_row graphile_worker.jobs;
+  v_row :WORKER_SCHEMA.jobs;
 begin
-  update graphile_worker.jobs
+  update :WORKER_SCHEMA.jobs
     set
       last_error = error_message,
       run_at = greatest(now(), run_at) + (exp(least(attempts, 10))::text || ' seconds')::interval,
@@ -159,7 +159,7 @@ begin
     where id = job_id and locked_by = worker_id
     returning * into v_row;
 
-  update graphile_worker.job_queues
+  update :WORKER_SCHEMA.job_queues
     set locked_by = null, locked_at = null
     where queue_name = v_row.queue_name and locked_by = worker_id;
 

--- a/sql/000002.sql
+++ b/sql/000002.sql
@@ -1,36 +1,36 @@
-alter table :WORKER_SCHEMA.jobs add column key text unique check(length(key) > 0);
+alter table :GRAPHILE_WORKER_SCHEMA.jobs add column key text unique check(length(key) > 0);
 
-alter table :WORKER_SCHEMA.jobs add locked_at timestamptz;
-alter table :WORKER_SCHEMA.jobs add locked_by text;
+alter table :GRAPHILE_WORKER_SCHEMA.jobs add locked_at timestamptz;
+alter table :GRAPHILE_WORKER_SCHEMA.jobs add locked_by text;
 
 -- update any in-flight jobs
-update :WORKER_SCHEMA.jobs
+update :GRAPHILE_WORKER_SCHEMA.jobs
   set locked_at = q.locked_at, locked_by = q.locked_by
-  from :WORKER_SCHEMA.job_queues q
+  from :GRAPHILE_WORKER_SCHEMA.job_queues q
   where q.queue_name = jobs.queue_name
   and q.locked_at is not null;
 
 -- update add_job behaviour to meet new requirements
-drop function if exists :WORKER_SCHEMA.add_job(identifier text,
+drop function if exists :GRAPHILE_WORKER_SCHEMA.add_job(identifier text,
   payload json,
   queue_name text,
   run_at timestamptz,
   max_attempts int
 );
-create function :WORKER_SCHEMA.add_job(
+create function :GRAPHILE_WORKER_SCHEMA.add_job(
   identifier text,
   payload json = '{}',
   queue_name text = null,
   run_at timestamptz = now(),
   max_attempts int = 25,
   job_key text = null
-) returns :WORKER_SCHEMA.jobs as $$
+) returns :GRAPHILE_WORKER_SCHEMA.jobs as $$
 declare
-  v_job :WORKER_SCHEMA.jobs;
+  v_job :GRAPHILE_WORKER_SCHEMA.jobs;
 begin
   if job_key is not null then
     -- Upsert job
-    insert into :WORKER_SCHEMA.jobs (task_identifier, payload, queue_name, run_at, max_attempts, key)
+    insert into :GRAPHILE_WORKER_SCHEMA.jobs (task_identifier, payload, queue_name, run_at, max_attempts, key)
       values(
         identifier,
         payload,
@@ -63,7 +63,7 @@ begin
     -- Upsert failed -> there must be an existing job that is locked. Remove
     -- existing key to allow a new one to be inserted, and prevent any
     -- subsequent retries by bumping attempts to the max allowed.
-    update :WORKER_SCHEMA.jobs
+    update :GRAPHILE_WORKER_SCHEMA.jobs
       set
         key = null,
         attempts = jobs.max_attempts
@@ -71,7 +71,7 @@ begin
   end if;
 
   -- insert the new job. Assume no conflicts due to the update above
-  insert into :WORKER_SCHEMA.jobs(task_identifier, payload, queue_name, run_at, max_attempts, key)
+  insert into :GRAPHILE_WORKER_SCHEMA.jobs(task_identifier, payload, queue_name, run_at, max_attempts, key)
     values(
       identifier,
       payload,
@@ -89,10 +89,10 @@ $$ language plpgsql volatile;
 
 --- implement new remove_job function
 
-create function :WORKER_SCHEMA.remove_job(
+create function :GRAPHILE_WORKER_SCHEMA.remove_job(
   job_key text
-) returns :WORKER_SCHEMA.jobs as $$
-  delete from :WORKER_SCHEMA.jobs
+) returns :GRAPHILE_WORKER_SCHEMA.jobs as $$
+  delete from :GRAPHILE_WORKER_SCHEMA.jobs
     where key = job_key
     and locked_at is null
   returning *;
@@ -100,11 +100,11 @@ $$ language sql strict volatile;
 
 -- Update other functions to handle locked_at denormalisation
 
-create or replace function :WORKER_SCHEMA.get_job(worker_id text, task_identifiers text[] = null, job_expiry interval = interval '4 hours') returns :WORKER_SCHEMA.jobs as $$
+create or replace function :GRAPHILE_WORKER_SCHEMA.get_job(worker_id text, task_identifiers text[] = null, job_expiry interval = interval '4 hours') returns :GRAPHILE_WORKER_SCHEMA.jobs as $$
 declare
   v_job_id bigint;
   v_queue_name text;
-  v_row :WORKER_SCHEMA.jobs;
+  v_row :GRAPHILE_WORKER_SCHEMA.jobs;
   v_now timestamptz = now();
 begin
   if worker_id is null or length(worker_id) < 10 then
@@ -112,8 +112,8 @@ begin
   end if;
 
   select job_queues.queue_name, jobs.id into v_queue_name, v_job_id
-    from :WORKER_SCHEMA.jobs
-    inner join :WORKER_SCHEMA.job_queues using (queue_name)
+    from :GRAPHILE_WORKER_SCHEMA.jobs
+    inner join :GRAPHILE_WORKER_SCHEMA.job_queues using (queue_name)
     where (job_queues.locked_at is null or job_queues.locked_at < (v_now - job_expiry))
     and run_at <= v_now
     and attempts < max_attempts
@@ -127,13 +127,13 @@ begin
     return null;
   end if;
 
-  update :WORKER_SCHEMA.job_queues
+  update :GRAPHILE_WORKER_SCHEMA.job_queues
     set
       locked_by = worker_id,
       locked_at = v_now
     where job_queues.queue_name = v_queue_name;
 
-  update :WORKER_SCHEMA.jobs
+  update :GRAPHILE_WORKER_SCHEMA.jobs
     set
       attempts = attempts + 1,
       locked_by = worker_id,
@@ -146,11 +146,11 @@ end;
 $$ language plpgsql volatile;
 
 -- I was unsuccessful, re-schedule the job please
-create or replace function :WORKER_SCHEMA.fail_job(worker_id text, job_id bigint, error_message text) returns :WORKER_SCHEMA.jobs as $$
+create or replace function :GRAPHILE_WORKER_SCHEMA.fail_job(worker_id text, job_id bigint, error_message text) returns :GRAPHILE_WORKER_SCHEMA.jobs as $$
 declare
-  v_row :WORKER_SCHEMA.jobs;
+  v_row :GRAPHILE_WORKER_SCHEMA.jobs;
 begin
-  update :WORKER_SCHEMA.jobs
+  update :GRAPHILE_WORKER_SCHEMA.jobs
     set
       last_error = error_message,
       run_at = greatest(now(), run_at) + (exp(least(attempts, 10))::text || ' seconds')::interval,
@@ -159,7 +159,7 @@ begin
     where id = job_id and locked_by = worker_id
     returning * into v_row;
 
-  update :WORKER_SCHEMA.job_queues
+  update :GRAPHILE_WORKER_SCHEMA.job_queues
     set locked_by = null, locked_at = null
     where queue_name = v_row.queue_name and locked_by = worker_id;
 

--- a/sql/000003.sql
+++ b/sql/000003.sql
@@ -1,19 +1,19 @@
-alter table :WORKER_SCHEMA.jobs alter column queue_name drop not null;
+alter table :GRAPHILE_WORKER_SCHEMA.jobs alter column queue_name drop not null;
 
-create or replace function :WORKER_SCHEMA.add_job(
+create or replace function :GRAPHILE_WORKER_SCHEMA.add_job(
   identifier text,
   payload json = '{}',
   queue_name text = null,
   run_at timestamptz = now(),
   max_attempts int = 25,
   job_key text = null
-) returns :WORKER_SCHEMA.jobs as $$
+) returns :GRAPHILE_WORKER_SCHEMA.jobs as $$
 declare
-  v_job :WORKER_SCHEMA.jobs;
+  v_job :GRAPHILE_WORKER_SCHEMA.jobs;
 begin
   if job_key is not null then
     -- Upsert job
-    insert into :WORKER_SCHEMA.jobs (task_identifier, payload, queue_name, run_at, max_attempts, key)
+    insert into :GRAPHILE_WORKER_SCHEMA.jobs (task_identifier, payload, queue_name, run_at, max_attempts, key)
       values(
         identifier,
         payload,
@@ -44,7 +44,7 @@ begin
     -- Upsert failed -> there must be an existing job that is locked. Remove
     -- existing key to allow a new one to be inserted, and prevent any
     -- subsequent retries by bumping attempts to the max allowed.
-    update :WORKER_SCHEMA.jobs
+    update :GRAPHILE_WORKER_SCHEMA.jobs
       set
         key = null,
         attempts = jobs.max_attempts
@@ -52,7 +52,7 @@ begin
   end if;
 
   -- insert the new job. Assume no conflicts due to the update above
-  insert into :WORKER_SCHEMA.jobs(task_identifier, payload, queue_name, run_at, max_attempts, key)
+  insert into :GRAPHILE_WORKER_SCHEMA.jobs(task_identifier, payload, queue_name, run_at, max_attempts, key)
     values(
       identifier,
       payload,
@@ -68,11 +68,11 @@ begin
 end;
 $$ language plpgsql volatile;
 
-create or replace function :WORKER_SCHEMA.get_job(worker_id text, task_identifiers text[] = null, job_expiry interval = interval '4 hours') returns :WORKER_SCHEMA.jobs as $$
+create or replace function :GRAPHILE_WORKER_SCHEMA.get_job(worker_id text, task_identifiers text[] = null, job_expiry interval = interval '4 hours') returns :GRAPHILE_WORKER_SCHEMA.jobs as $$
 declare
   v_job_id bigint;
   v_queue_name text;
-  v_row :WORKER_SCHEMA.jobs;
+  v_row :GRAPHILE_WORKER_SCHEMA.jobs;
   v_now timestamptz = now();
 begin
   if worker_id is null or length(worker_id) < 10 then
@@ -80,14 +80,14 @@ begin
   end if;
 
   select jobs.queue_name, jobs.id into v_queue_name, v_job_id
-    from :WORKER_SCHEMA.jobs
+    from :GRAPHILE_WORKER_SCHEMA.jobs
     where (jobs.locked_at is null or jobs.locked_at < (v_now - job_expiry))
     and (
       jobs.queue_name is null
     or
       exists (
         select 1
-        from :WORKER_SCHEMA.job_queues
+        from :GRAPHILE_WORKER_SCHEMA.job_queues
         where job_queues.queue_name = jobs.queue_name
         and (job_queues.locked_at is null or job_queues.locked_at < (v_now - job_expiry))
         for update
@@ -107,14 +107,14 @@ begin
   end if;
 
   if v_queue_name is not null then
-    update :WORKER_SCHEMA.job_queues
+    update :GRAPHILE_WORKER_SCHEMA.job_queues
       set
         locked_by = worker_id,
         locked_at = v_now
       where job_queues.queue_name = v_queue_name;
   end if;
 
-  update :WORKER_SCHEMA.jobs
+  update :GRAPHILE_WORKER_SCHEMA.jobs
     set
       attempts = attempts + 1,
       locked_by = worker_id,
@@ -126,11 +126,11 @@ begin
 end;
 $$ language plpgsql volatile;
 
-create or replace function :WORKER_SCHEMA.fail_job(worker_id text, job_id bigint, error_message text) returns :WORKER_SCHEMA.jobs as $$
+create or replace function :GRAPHILE_WORKER_SCHEMA.fail_job(worker_id text, job_id bigint, error_message text) returns :GRAPHILE_WORKER_SCHEMA.jobs as $$
 declare
-  v_row :WORKER_SCHEMA.jobs;
+  v_row :GRAPHILE_WORKER_SCHEMA.jobs;
 begin
-  update :WORKER_SCHEMA.jobs
+  update :GRAPHILE_WORKER_SCHEMA.jobs
     set
       last_error = error_message,
       run_at = greatest(now(), run_at) + (exp(least(attempts, 10))::text || ' seconds')::interval,
@@ -140,7 +140,7 @@ begin
     returning * into v_row;
 
   if v_row.queue_name is not null then
-    update :WORKER_SCHEMA.job_queues
+    update :GRAPHILE_WORKER_SCHEMA.job_queues
       set locked_by = null, locked_at = null
       where queue_name = v_row.queue_name and locked_by = worker_id;
   end if;
@@ -149,16 +149,16 @@ begin
 end;
 $$ language plpgsql volatile strict;
 
-create or replace function :WORKER_SCHEMA.complete_job(worker_id text, job_id bigint) returns :WORKER_SCHEMA.jobs as $$
+create or replace function :GRAPHILE_WORKER_SCHEMA.complete_job(worker_id text, job_id bigint) returns :GRAPHILE_WORKER_SCHEMA.jobs as $$
 declare
-  v_row :WORKER_SCHEMA.jobs;
+  v_row :GRAPHILE_WORKER_SCHEMA.jobs;
 begin
-  delete from :WORKER_SCHEMA.jobs
+  delete from :GRAPHILE_WORKER_SCHEMA.jobs
     where id = job_id
     returning * into v_row;
 
   if v_row.queue_name is not null then
-    update :WORKER_SCHEMA.job_queues
+    update :GRAPHILE_WORKER_SCHEMA.job_queues
       set locked_by = null, locked_at = null
       where queue_name = v_row.queue_name and locked_by = worker_id;
   end if;
@@ -167,11 +167,11 @@ begin
 end;
 $$ language plpgsql;
 
-drop trigger _500_increase_job_queue_count on :WORKER_SCHEMA.jobs;
-drop trigger _500_decrease_job_queue_count on :WORKER_SCHEMA.jobs;
-drop trigger _500_increase_job_queue_count_update on :WORKER_SCHEMA.jobs;
-drop trigger _500_decrease_job_queue_count_update on :WORKER_SCHEMA.jobs;
-create trigger _500_increase_job_queue_count after insert on :WORKER_SCHEMA.jobs for each row when (NEW.queue_name is not null) execute procedure :WORKER_SCHEMA.jobs__increase_job_queue_count();
-create trigger _500_decrease_job_queue_count after delete on :WORKER_SCHEMA.jobs for each row when (OLD.queue_name is not null) execute procedure :WORKER_SCHEMA.jobs__decrease_job_queue_count();
-create trigger _500_increase_job_queue_count_update after update of queue_name on :WORKER_SCHEMA.jobs for each row when (NEW.queue_name is distinct from OLD.queue_name AND NEW.queue_name is not null) execute procedure :WORKER_SCHEMA.jobs__increase_job_queue_count();
-create trigger _500_decrease_job_queue_count_update after update of queue_name on :WORKER_SCHEMA.jobs for each row when (NEW.queue_name is distinct from OLD.queue_name AND OLD.queue_name is not null) execute procedure :WORKER_SCHEMA.jobs__decrease_job_queue_count();
+drop trigger _500_increase_job_queue_count on :GRAPHILE_WORKER_SCHEMA.jobs;
+drop trigger _500_decrease_job_queue_count on :GRAPHILE_WORKER_SCHEMA.jobs;
+drop trigger _500_increase_job_queue_count_update on :GRAPHILE_WORKER_SCHEMA.jobs;
+drop trigger _500_decrease_job_queue_count_update on :GRAPHILE_WORKER_SCHEMA.jobs;
+create trigger _500_increase_job_queue_count after insert on :GRAPHILE_WORKER_SCHEMA.jobs for each row when (NEW.queue_name is not null) execute procedure :GRAPHILE_WORKER_SCHEMA.jobs__increase_job_queue_count();
+create trigger _500_decrease_job_queue_count after delete on :GRAPHILE_WORKER_SCHEMA.jobs for each row when (OLD.queue_name is not null) execute procedure :GRAPHILE_WORKER_SCHEMA.jobs__decrease_job_queue_count();
+create trigger _500_increase_job_queue_count_update after update of queue_name on :GRAPHILE_WORKER_SCHEMA.jobs for each row when (NEW.queue_name is distinct from OLD.queue_name AND NEW.queue_name is not null) execute procedure :GRAPHILE_WORKER_SCHEMA.jobs__increase_job_queue_count();
+create trigger _500_decrease_job_queue_count_update after update of queue_name on :GRAPHILE_WORKER_SCHEMA.jobs for each row when (NEW.queue_name is distinct from OLD.queue_name AND OLD.queue_name is not null) execute procedure :GRAPHILE_WORKER_SCHEMA.jobs__decrease_job_queue_count();

--- a/sql/000003.sql
+++ b/sql/000003.sql
@@ -1,19 +1,19 @@
-alter table graphile_worker.jobs alter column queue_name drop not null;
+alter table :WORKER_SCHEMA.jobs alter column queue_name drop not null;
 
-create or replace function graphile_worker.add_job(
+create or replace function :WORKER_SCHEMA.add_job(
   identifier text,
   payload json = '{}',
   queue_name text = null,
   run_at timestamptz = now(),
   max_attempts int = 25,
   job_key text = null
-) returns graphile_worker.jobs as $$
+) returns :WORKER_SCHEMA.jobs as $$
 declare
-  v_job graphile_worker.jobs;
+  v_job :WORKER_SCHEMA.jobs;
 begin
   if job_key is not null then
     -- Upsert job
-    insert into graphile_worker.jobs (task_identifier, payload, queue_name, run_at, max_attempts, key)
+    insert into :WORKER_SCHEMA.jobs (task_identifier, payload, queue_name, run_at, max_attempts, key)
       values(
         identifier,
         payload,
@@ -44,7 +44,7 @@ begin
     -- Upsert failed -> there must be an existing job that is locked. Remove
     -- existing key to allow a new one to be inserted, and prevent any
     -- subsequent retries by bumping attempts to the max allowed.
-    update graphile_worker.jobs
+    update :WORKER_SCHEMA.jobs
       set
         key = null,
         attempts = jobs.max_attempts
@@ -52,7 +52,7 @@ begin
   end if;
 
   -- insert the new job. Assume no conflicts due to the update above
-  insert into graphile_worker.jobs(task_identifier, payload, queue_name, run_at, max_attempts, key)
+  insert into :WORKER_SCHEMA.jobs(task_identifier, payload, queue_name, run_at, max_attempts, key)
     values(
       identifier,
       payload,
@@ -68,11 +68,11 @@ begin
 end;
 $$ language plpgsql volatile;
 
-create or replace function graphile_worker.get_job(worker_id text, task_identifiers text[] = null, job_expiry interval = interval '4 hours') returns graphile_worker.jobs as $$
+create or replace function :WORKER_SCHEMA.get_job(worker_id text, task_identifiers text[] = null, job_expiry interval = interval '4 hours') returns :WORKER_SCHEMA.jobs as $$
 declare
   v_job_id bigint;
   v_queue_name text;
-  v_row graphile_worker.jobs;
+  v_row :WORKER_SCHEMA.jobs;
   v_now timestamptz = now();
 begin
   if worker_id is null or length(worker_id) < 10 then
@@ -80,14 +80,14 @@ begin
   end if;
 
   select jobs.queue_name, jobs.id into v_queue_name, v_job_id
-    from graphile_worker.jobs
+    from :WORKER_SCHEMA.jobs
     where (jobs.locked_at is null or jobs.locked_at < (v_now - job_expiry))
     and (
       jobs.queue_name is null
     or
       exists (
         select 1
-        from graphile_worker.job_queues
+        from :WORKER_SCHEMA.job_queues
         where job_queues.queue_name = jobs.queue_name
         and (job_queues.locked_at is null or job_queues.locked_at < (v_now - job_expiry))
         for update
@@ -107,14 +107,14 @@ begin
   end if;
 
   if v_queue_name is not null then
-    update graphile_worker.job_queues
+    update :WORKER_SCHEMA.job_queues
       set
         locked_by = worker_id,
         locked_at = v_now
       where job_queues.queue_name = v_queue_name;
   end if;
 
-  update graphile_worker.jobs
+  update :WORKER_SCHEMA.jobs
     set
       attempts = attempts + 1,
       locked_by = worker_id,
@@ -126,11 +126,11 @@ begin
 end;
 $$ language plpgsql volatile;
 
-create or replace function graphile_worker.fail_job(worker_id text, job_id bigint, error_message text) returns graphile_worker.jobs as $$
+create or replace function :WORKER_SCHEMA.fail_job(worker_id text, job_id bigint, error_message text) returns :WORKER_SCHEMA.jobs as $$
 declare
-  v_row graphile_worker.jobs;
+  v_row :WORKER_SCHEMA.jobs;
 begin
-  update graphile_worker.jobs
+  update :WORKER_SCHEMA.jobs
     set
       last_error = error_message,
       run_at = greatest(now(), run_at) + (exp(least(attempts, 10))::text || ' seconds')::interval,
@@ -140,7 +140,7 @@ begin
     returning * into v_row;
 
   if v_row.queue_name is not null then
-    update graphile_worker.job_queues
+    update :WORKER_SCHEMA.job_queues
       set locked_by = null, locked_at = null
       where queue_name = v_row.queue_name and locked_by = worker_id;
   end if;
@@ -149,16 +149,16 @@ begin
 end;
 $$ language plpgsql volatile strict;
 
-create or replace function graphile_worker.complete_job(worker_id text, job_id bigint) returns graphile_worker.jobs as $$
+create or replace function :WORKER_SCHEMA.complete_job(worker_id text, job_id bigint) returns :WORKER_SCHEMA.jobs as $$
 declare
-  v_row graphile_worker.jobs;
+  v_row :WORKER_SCHEMA.jobs;
 begin
-  delete from graphile_worker.jobs
+  delete from :WORKER_SCHEMA.jobs
     where id = job_id
     returning * into v_row;
 
   if v_row.queue_name is not null then
-    update graphile_worker.job_queues
+    update :WORKER_SCHEMA.job_queues
       set locked_by = null, locked_at = null
       where queue_name = v_row.queue_name and locked_by = worker_id;
   end if;
@@ -167,11 +167,11 @@ begin
 end;
 $$ language plpgsql;
 
-drop trigger _500_increase_job_queue_count on graphile_worker.jobs;
-drop trigger _500_decrease_job_queue_count on graphile_worker.jobs;
-drop trigger _500_increase_job_queue_count_update on graphile_worker.jobs;
-drop trigger _500_decrease_job_queue_count_update on graphile_worker.jobs;
-create trigger _500_increase_job_queue_count after insert on graphile_worker.jobs for each row when (NEW.queue_name is not null) execute procedure graphile_worker.jobs__increase_job_queue_count();
-create trigger _500_decrease_job_queue_count after delete on graphile_worker.jobs for each row when (OLD.queue_name is not null) execute procedure graphile_worker.jobs__decrease_job_queue_count();
-create trigger _500_increase_job_queue_count_update after update of queue_name on graphile_worker.jobs for each row when (NEW.queue_name is distinct from OLD.queue_name AND NEW.queue_name is not null) execute procedure graphile_worker.jobs__increase_job_queue_count();
-create trigger _500_decrease_job_queue_count_update after update of queue_name on graphile_worker.jobs for each row when (NEW.queue_name is distinct from OLD.queue_name AND OLD.queue_name is not null) execute procedure graphile_worker.jobs__decrease_job_queue_count();
+drop trigger _500_increase_job_queue_count on :WORKER_SCHEMA.jobs;
+drop trigger _500_decrease_job_queue_count on :WORKER_SCHEMA.jobs;
+drop trigger _500_increase_job_queue_count_update on :WORKER_SCHEMA.jobs;
+drop trigger _500_decrease_job_queue_count_update on :WORKER_SCHEMA.jobs;
+create trigger _500_increase_job_queue_count after insert on :WORKER_SCHEMA.jobs for each row when (NEW.queue_name is not null) execute procedure :WORKER_SCHEMA.jobs__increase_job_queue_count();
+create trigger _500_decrease_job_queue_count after delete on :WORKER_SCHEMA.jobs for each row when (OLD.queue_name is not null) execute procedure :WORKER_SCHEMA.jobs__decrease_job_queue_count();
+create trigger _500_increase_job_queue_count_update after update of queue_name on :WORKER_SCHEMA.jobs for each row when (NEW.queue_name is distinct from OLD.queue_name AND NEW.queue_name is not null) execute procedure :WORKER_SCHEMA.jobs__increase_job_queue_count();
+create trigger _500_decrease_job_queue_count_update after update of queue_name on :WORKER_SCHEMA.jobs for each row when (NEW.queue_name is distinct from OLD.queue_name AND OLD.queue_name is not null) execute procedure :WORKER_SCHEMA.jobs__decrease_job_queue_count();

--- a/sql/000004.sql
+++ b/sql/000004.sql
@@ -1,6 +1,6 @@
-drop function graphile_worker.add_job(text, json, text, timestamptz, int, text);
+drop function :WORKER_SCHEMA.add_job(text, json, text, timestamptz, int, text);
 
-create function graphile_worker.add_job(
+create function :WORKER_SCHEMA.add_job(
   identifier text,
   payload json = null,
   queue_name text = null,
@@ -8,9 +8,9 @@ create function graphile_worker.add_job(
   max_attempts int = null,
   job_key text = null,
   priority int = null
-) returns graphile_worker.jobs as $$
+) returns :WORKER_SCHEMA.jobs as $$
 declare
-  v_job graphile_worker.jobs;
+  v_job :WORKER_SCHEMA.jobs;
 begin
   -- Apply rationality checks
   if length(identifier) > 128 then
@@ -28,7 +28,7 @@ begin
 
   if job_key is not null then
     -- Upsert job
-    insert into graphile_worker.jobs (
+    insert into :WORKER_SCHEMA.jobs (
       task_identifier,
       payload,
       queue_name,
@@ -69,7 +69,7 @@ begin
     -- Upsert failed -> there must be an existing job that is locked. Remove
     -- existing key to allow a new one to be inserted, and prevent any
     -- subsequent retries by bumping attempts to the max allowed.
-    update graphile_worker.jobs
+    update :WORKER_SCHEMA.jobs
       set
         key = null,
         attempts = jobs.max_attempts
@@ -77,7 +77,7 @@ begin
   end if;
 
   -- insert the new job. Assume no conflicts due to the update above
-  insert into graphile_worker.jobs(
+  insert into :WORKER_SCHEMA.jobs(
     task_identifier,
     payload,
     queue_name,
@@ -102,10 +102,10 @@ begin
 end;
 $$ language plpgsql volatile;
 
-create function graphile_worker.complete_jobs(
+create function :WORKER_SCHEMA.complete_jobs(
   job_ids bigint[]
-) returns setof graphile_worker.jobs as $$
-  delete from graphile_worker.jobs
+) returns setof :WORKER_SCHEMA.jobs as $$
+  delete from :WORKER_SCHEMA.jobs
     where id = any(job_ids)
     and (
       locked_by is null
@@ -115,11 +115,11 @@ create function graphile_worker.complete_jobs(
     returning *;
 $$ language sql volatile;
 
-create function graphile_worker.permanently_fail_jobs(
+create function :WORKER_SCHEMA.permanently_fail_jobs(
   job_ids bigint[],
   error_message text = null
-) returns setof graphile_worker.jobs as $$
-  update graphile_worker.jobs
+) returns setof :WORKER_SCHEMA.jobs as $$
+  update :WORKER_SCHEMA.jobs
     set
       last_error = coalesce(error_message, 'Manually marked as failed'),
       attempts = max_attempts
@@ -132,14 +132,14 @@ create function graphile_worker.permanently_fail_jobs(
     returning *;
 $$ language sql volatile;
 
-create function graphile_worker.reschedule_jobs(
+create function :WORKER_SCHEMA.reschedule_jobs(
   job_ids bigint[],
   run_at timestamptz = null,
   priority int = null,
   attempts int = null,
   max_attempts int = null
-) returns setof graphile_worker.jobs as $$
-  update graphile_worker.jobs
+) returns setof :WORKER_SCHEMA.jobs as $$
+  update :WORKER_SCHEMA.jobs
     set
       run_at = coalesce(reschedule_jobs.run_at, jobs.run_at),
       priority = coalesce(reschedule_jobs.priority, jobs.priority),

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -3,8 +3,8 @@ import getTasks from "./getTasks";
 import { RunnerOptions } from "./interfaces";
 import { run, runOnce } from "./index";
 import * as yargs from "yargs";
-import { POLL_INTERVAL, CONCURRENT_JOBS } from "./config";
 import { runMigrations } from "./runner";
+import { defaults } from "./config";
 
 const argv = yargs
   .option("connection", {
@@ -33,7 +33,7 @@ const argv = yargs
   .option("jobs", {
     description: "number of jobs to run concurrently",
     alias: "j",
-    default: CONCURRENT_JOBS,
+    default: defaults.concurrentJobs,
   })
   .number("jobs")
   .option("max-pool-size", {
@@ -45,7 +45,7 @@ const argv = yargs
   .option("poll-interval", {
     description:
       "how long to wait between polling for jobs in milliseconds (for jobs scheduled in the future/retries)",
-    default: POLL_INTERVAL,
+    default: defaults.pollInterval,
   })
   .number("poll-interval")
   .strict(true).argv;
@@ -84,11 +84,13 @@ async function main() {
   }
 
   const baseOptions: RunnerOptions = {
-    concurrency: isInteger(argv.jobs) ? argv.jobs : CONCURRENT_JOBS,
-    maxPoolSize: isInteger(argv["max-pool-size"]) ? argv["max-pool-size"] : 10,
+    concurrency: isInteger(argv.jobs) ? argv.jobs : defaults.concurrentJobs,
+    maxPoolSize: isInteger(argv["max-pool-size"])
+      ? argv["max-pool-size"]
+      : defaults.maxPoolSize,
     pollInterval: isInteger(argv["poll-interval"])
       ? argv["poll-interval"]
-      : POLL_INTERVAL,
+      : defaults.pollInterval,
     connectionString: DATABASE_URL,
   };
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -91,7 +91,7 @@ async function main() {
     );
   }
 
-  const baseOptions: RunnerOptions = {
+  const options: RunnerOptions = {
     schema: SCHEMA || defaults.schema,
     concurrency: isInteger(argv.jobs) ? argv.jobs : defaults.concurrentJobs,
     maxPoolSize: isInteger(argv["max-pool-size"])
@@ -104,26 +104,17 @@ async function main() {
   };
 
   if (SCHEMA_ONLY) {
-    await runMigrations(baseOptions);
+    await runMigrations(options);
     console.log("Schema updated");
     return;
   }
 
-  const watchedTasks = await getTasks(
-    baseOptions,
-    `${process.cwd()}/tasks`,
-    WATCH
-  );
-
-  const options: RunnerOptions = {
-    ...baseOptions,
-    taskList: watchedTasks.tasks,
-  };
+  const watchedTasks = await getTasks(options, `${process.cwd()}/tasks`, WATCH);
 
   if (ONCE) {
-    await runOnce(options);
+    await runOnce(options, watchedTasks.tasks);
   } else {
-    const { promise } = await run(options);
+    const { promise } = await run(options, watchedTasks.tasks);
     // Continue forever(ish)
     await promise;
   }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -13,6 +13,13 @@ const argv = yargs
     alias: "c",
   })
   .string("connection")
+  .option("schema", {
+    description:
+      "The database schema in which Graphile Worker is (to be) located",
+    alias: "s",
+    default: defaults.schema,
+  })
+  .string("schema")
   .option("schema-only", {
     description: "Just install (or update) the database schema, then exit",
     default: false,
@@ -63,6 +70,7 @@ const isInteger = (n: number): boolean => {
 
 async function main() {
   const DATABASE_URL = argv.connection || process.env.DATABASE_URL || undefined;
+  const SCHEMA = argv.schema || undefined;
   const ONCE = argv.once;
   const SCHEMA_ONLY = argv["schema-only"];
   const WATCH = argv.watch;
@@ -84,6 +92,7 @@ async function main() {
   }
 
   const baseOptions: RunnerOptions = {
+    schema: SCHEMA || defaults.schema,
     concurrency: isInteger(argv.jobs) ? argv.jobs : defaults.concurrentJobs,
     maxPoolSize: isInteger(argv["max-pool-size"])
       ? argv["max-pool-size"]

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,20 +1,100 @@
-/**
- * How long to wait between polling for jobs.
- *
- * Note: this does NOT need to be short, because we use LISTEN/NOTIFY to be
- * notified when new jobs are added - this is just used for jobs scheduled in
- * the future, retried jobs, and in the case where LISTEN/NOTIFY fails for
- * whatever reason.
- */
-export const POLL_INTERVAL = 2000;
+import { cosmiconfigSync } from "cosmiconfig";
+
+const cosmiconfigResult = cosmiconfigSync("graphile-worker").search();
+const cosmiconfig = cosmiconfigResult?.config;
 
 /**
- * How many errors in a row can we get fetching a job before we raise a higher
- * exception?
+ * Defaults to use for various options throughout the codebase, sourced from
+ * environmental variables, cosmiconfig, and finally sensible defaults.
  */
-export const MAX_CONTIGUOUS_ERRORS = 10;
+interface WorkerDefaults {
+  /**
+   * How long to wait between polling for jobs.
+   *
+   * Note: this does NOT need to be short, because we use LISTEN/NOTIFY to be
+   * notified when new jobs are added - this is just used for jobs scheduled in
+   * the future, retried jobs, and in the case where LISTEN/NOTIFY fails for
+   * whatever reason.
+   */
+  pollInterval: number;
 
-/**
- * Number of jobs to run concurrently
- */
-export const CONCURRENT_JOBS = 1;
+  /**
+   * Which PostgreSQL schema should Graphile Worker use? Defaults to 'graphile_worker'.
+   */
+  schema: string;
+
+  /**
+   * How many errors in a row can we get fetching a job before we raise a higher
+   * exception?
+   */
+  maxContiguousErrors: number;
+
+  /**
+   * Number of jobs to run concurrently
+   */
+  concurrentJobs: number;
+
+  /**
+   * The maximum size of the PostgreSQL pool. Defaults to the node-postgres
+   * default (10). Only useful when `connectionString` is given.
+   */
+  maxPoolSize: number;
+}
+
+export const defaults: WorkerDefaults = {
+  schema:
+    process.env.GRAPHILE_WORKER_SCHEMA ||
+    enforceStringOrUndefined("schema", cosmiconfig?.schema) ||
+    "graphile_worker",
+  maxContiguousErrors:
+    enforceNumberOrUndefined(
+      "maxContiguousErrors",
+      cosmiconfig?.maxContiguousErrors
+    ) || 10,
+  pollInterval:
+    enforceNumberOrUndefined("pollInterval", cosmiconfig?.pollInterval) || 2000,
+  concurrentJobs:
+    enforceNumberOrUndefined("concurrentJobs", cosmiconfig?.concurrentJobs) ||
+    1,
+  maxPoolSize:
+    enforceNumberOrUndefined("maxPoolSize", cosmiconfig?.maxPoolSize) || 10,
+};
+
+function enforceStringOrUndefined(
+  keyName: String,
+  str: unknown
+): string | undefined {
+  if (typeof str === "string") {
+    return str;
+  } else if (!str) {
+    return undefined;
+  } else {
+    throw new Error(
+      `Expected '${keyName}' to be a string (or not set), but received ${typeof str}`
+    );
+  }
+}
+
+function enforceNumberOrUndefined(
+  keyName: String,
+  nr: unknown
+): number | undefined {
+  if (typeof nr === "number") {
+    return nr;
+  } else if (typeof nr === "string") {
+    const val = parseFloat(nr);
+    if (isFinite(val)) {
+      return val;
+    } else {
+      throw new Error(
+        `Expected '${keyName}' to be a number (or not set), but received ${nr}`
+      );
+    }
+  } else if (!nr) {
+    return undefined;
+  } else {
+    throw new Error(
+      `Expected '${keyName}' to be a number (or not set), but received ${typeof nr}`
+    );
+  }
+}

--- a/src/getTasks.ts
+++ b/src/getTasks.ts
@@ -1,9 +1,15 @@
 import { basename } from "path";
 import * as chokidar from "chokidar";
-import { isValidTask, TaskList, WatchedTaskList } from "./interfaces";
+import {
+  isValidTask,
+  TaskList,
+  WatchedTaskList,
+  SharedOptions,
+} from "./interfaces";
 import { tryStat, readdir } from "./fs";
 import { fauxRequire } from "./module";
-import { defaultLogger, Logger } from "./logger";
+import { Logger } from "./logger";
+import { processSharedOptions } from "./lib";
 
 function validTasks(
   logger: Logger,
@@ -72,10 +78,11 @@ async function loadFileIntoTasks(
 }
 
 export default async function getTasks(
+  options: SharedOptions,
   taskPath: string,
-  watch = false,
-  logger = defaultLogger
+  watch = false
 ): Promise<WatchedTaskList> {
+  const { logger } = await processSharedOptions(options);
   const pathStat = await tryStat(taskPath);
   if (!pathStat) {
     throw new Error(

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -9,8 +9,8 @@ import { Pool, PoolClient } from "pg";
 import { processSharedOptions } from "./lib";
 
 export function makeAddJob(
-  withPgClient: WithPgClient,
-  options: WorkerSharedOptions
+  options: WorkerSharedOptions,
+  withPgClient: WithPgClient
 ) {
   const { escapedWorkerSchema } = processSharedOptions(options);
   return (identifier: string, payload: any = {}, spec: TaskSpec = {}) => {
@@ -61,7 +61,7 @@ export function makeJobHelpers(
     withPgClient,
     query: (queryText, values) =>
       withPgClient(pgClient => pgClient.query(queryText, values)),
-    addJob: makeAddJob(withPgClient, options),
+    addJob: makeAddJob(options, withPgClient),
 
     // TODO: add an API for giving workers more helpers
   };

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -5,15 +5,15 @@ import {
   JobHelpers,
   WorkerSharedOptions,
 } from "./interfaces";
-import { Pool, PoolClient, Client } from "pg";
+import { Pool, PoolClient } from "pg";
 import { defaultLogger } from "./logger";
+import { processSharedOptions } from "./lib";
 
 export function makeAddJob(
   withPgClient: WithPgClient,
   options: WorkerSharedOptions
 ) {
-  const { schema: workerSchema = "graphile_worker" } = options;
-  const escapedWorkerSchema = Client.prototype.escapeIdentifier(workerSchema);
+  const { escapedWorkerSchema } = processSharedOptions(options);
   return (identifier: string, payload: any = {}, spec: TaskSpec = {}) => {
     return withPgClient(async pgClient => {
       const { rows } = await pgClient.query(

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -15,7 +15,7 @@ export function makeAddJob(
   withPgClient: WithPgClient
 ) {
   const { escapedWorkerSchema } = processSharedOptions(options);
-  return (identifier: string, payload: any = {}, spec: TaskSpec = {}) => {
+  return (identifier: string, payload: unknown = {}, spec: TaskSpec = {}) => {
     return withPgClient(async pgClient => {
       const { rows } = await pgClient.query(
         `

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -4,9 +4,11 @@ import {
   TaskSpec,
   JobHelpers,
   WorkerSharedOptions,
+  SharedOptions,
 } from "./interfaces";
 import { Pool, PoolClient } from "pg";
 import { processSharedOptions } from "./lib";
+import { Logger } from "./logger";
 
 export function makeAddJob(
   options: WorkerSharedOptions,
@@ -44,16 +46,18 @@ export function makeAddJob(
 }
 
 export function makeJobHelpers(
+  options: SharedOptions,
   job: Job,
-  { withPgClient }: { withPgClient: WithPgClient },
-  options: WorkerSharedOptions
+  {
+    withPgClient,
+    logger: overrideLogger,
+  }: { withPgClient: WithPgClient; logger?: Logger }
 ): JobHelpers {
-  const { logger } = processSharedOptions(options, {
-    scope: {
-      label: "job",
-      taskIdentifier: job.task_identifier,
-      jobId: job.id,
-    },
+  const baseLogger = overrideLogger || processSharedOptions(options).logger;
+  const logger = baseLogger.scope({
+    label: "job",
+    taskIdentifier: job.task_identifier,
+    jobId: job.id,
   });
   const helpers: JobHelpers = {
     job,

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -224,6 +224,9 @@ export interface TaskSpec {
   jobKey?: string;
 }
 
+/**
+ * These options are common Graphile Worker pools, workers, and utils.
+ */
 export interface WorkerSharedOptions {
   /**
    * How long to wait between polling for jobs in milliseconds (for jobs scheduled in the future/retries)
@@ -234,6 +237,11 @@ export interface WorkerSharedOptions {
    * How should messages be logged out? Defaults to using the console logger.
    */
   logger?: Logger;
+
+  /**
+   * Which PostgreSQL schema should Graphile Worker use? Defaults to 'graphile_worker'.
+   */
+  schema?: string;
 }
 
 export interface WorkerOptions extends WorkerSharedOptions {
@@ -280,7 +288,7 @@ export interface RunnerOptions extends WorkerPoolOptions {
   maxPoolSize?: number;
 }
 
-export interface WorkerUtilsOptions {
+export interface WorkerUtilsOptions extends WorkerSharedOptions {
   /**
    * A PostgreSQL connection string to the database containing the job queue
    */
@@ -290,9 +298,4 @@ export interface WorkerUtilsOptions {
    * A pg.Pool instance to use instead of the `connectionString`
    */
   pgPool?: Pool;
-
-  /**
-   * How should messages be logged out? Defaults to using the console logger.
-   */
-  logger?: Logger;
 }

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -1,6 +1,6 @@
 import { PoolClient, Pool, QueryResultRow, QueryResult } from "pg";
 import { Logger } from "./logger";
-import { Release } from "./runner";
+import { Release } from "./lib";
 
 /*
  * Terminology:

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -33,7 +33,7 @@ export type AddJobFunction = (
   /**
    * The payload (typically a JSON object) that will be passed to the task executor.
    */
-  payload?: any,
+  payload?: unknown,
 
   /**
    * Additional details about how the job should be handled.
@@ -73,7 +73,7 @@ export interface JobHelpers extends Helpers {
   /**
    * A shorthand for running an SQL query within the job.
    */
-  query<R extends QueryResultRow = any>(
+  query<R extends QueryResultRow>(
     queryText: string,
     values?: any[]
   ): Promise<QueryResult<R>>;

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -227,12 +227,7 @@ export interface TaskSpec {
 /**
  * These options are common Graphile Worker pools, workers, and utils.
  */
-export interface WorkerSharedOptions {
-  /**
-   * How long to wait between polling for jobs in milliseconds (for jobs scheduled in the future/retries)
-   */
-  pollInterval?: number;
-
+export interface SharedOptions {
   /**
    * How should messages be logged out? Defaults to using the console logger.
    */
@@ -244,6 +239,19 @@ export interface WorkerSharedOptions {
   schema?: string;
 }
 
+/**
+ * Shared between pools and individual workers.
+ */
+export interface WorkerSharedOptions extends SharedOptions {
+  /**
+   * How long to wait between polling for jobs in milliseconds (for jobs scheduled in the future/retries)
+   */
+  pollInterval?: number;
+}
+
+/**
+ * Options for an individual worker
+ */
 export interface WorkerOptions extends WorkerSharedOptions {
   /**
    * An identifier for this specific worker; if unset then a random ID will be assigned. Do not assign multiple workers the same worker ID!
@@ -251,6 +259,9 @@ export interface WorkerOptions extends WorkerSharedOptions {
   workerId?: string;
 }
 
+/**
+ * Options for a worker pool.
+ */
 export interface WorkerPoolOptions extends WorkerSharedOptions {
   /**
    * Number of jobs to run concurrently
@@ -264,23 +275,30 @@ export interface WorkerPoolOptions extends WorkerSharedOptions {
   noHandleSignals?: boolean;
 }
 
+/**
+ * Options for the `run`, `runOnce` and `runMigrations` methods.
+ */
 export interface RunnerOptions extends WorkerPoolOptions {
   /**
    * Task names and handler, e.g. from `getTasks` (use this if you need watch mode)
    */
   taskList?: TaskList;
+
   /**
    * Each file in this directory will be used as a task handler
    */
   taskDirectory?: string;
+
   /**
    * A PostgreSQL connection string to the database containing the job queue
    */
   connectionString?: string;
+
   /**
    * A pg.Pool instance to use instead of the `connectionString`
    */
   pgPool?: Pool;
+
   /**
    * The maximum size of the PostgreSQL pool. Defaults to the node-postgres
    * default (10).
@@ -288,7 +306,7 @@ export interface RunnerOptions extends WorkerPoolOptions {
   maxPoolSize?: number;
 }
 
-export interface WorkerUtilsOptions extends WorkerSharedOptions {
+export interface WorkerUtilsOptions extends SharedOptions {
   /**
    * A PostgreSQL connection string to the database containing the job queue
    */

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -237,6 +237,22 @@ export interface SharedOptions {
    * Which PostgreSQL schema should Graphile Worker use? Defaults to 'graphile_worker'.
    */
   schema?: string;
+
+  /**
+   * A PostgreSQL connection string to the database containing the job queue
+   */
+  connectionString?: string;
+
+  /**
+   * The maximum size of the PostgreSQL pool. Defaults to the node-postgres
+   * default (10). Only useful when `connectionString` is given.
+   */
+  maxPoolSize?: number;
+
+  /**
+   * A pg.Pool instance to use instead of the `connectionString`
+   */
+  pgPool?: Pool;
 }
 
 /**
@@ -288,32 +304,6 @@ export interface RunnerOptions extends WorkerPoolOptions {
    * Each file in this directory will be used as a task handler
    */
   taskDirectory?: string;
-
-  /**
-   * A PostgreSQL connection string to the database containing the job queue
-   */
-  connectionString?: string;
-
-  /**
-   * A pg.Pool instance to use instead of the `connectionString`
-   */
-  pgPool?: Pool;
-
-  /**
-   * The maximum size of the PostgreSQL pool. Defaults to the node-postgres
-   * default (10).
-   */
-  maxPoolSize?: number;
 }
 
-export interface WorkerUtilsOptions extends SharedOptions {
-  /**
-   * A PostgreSQL connection string to the database containing the job queue
-   */
-  connectionString?: string;
-
-  /**
-   * A pg.Pool instance to use instead of the `connectionString`
-   */
-  pgPool?: Pool;
-}
+export interface WorkerUtilsOptions extends SharedOptions {}

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -7,9 +7,9 @@ import {
 } from "./interfaces";
 import { Logger, defaultLogger, LogScope } from "./logger";
 import { Client, Pool } from "pg";
-import { MAX_CONTIGUOUS_ERRORS, CONCURRENT_JOBS } from "./config";
 import { makeWithPgClientFromPool, makeAddJob } from "./helpers";
 import { migrate } from "./migrate";
+import { defaults } from "./config";
 
 interface CompiledSharedOptions {
   logger: Logger;
@@ -31,15 +31,14 @@ export function processSharedOptions(
   if (!compiled) {
     const {
       logger = defaultLogger,
-      schema: workerSchema = process.env.GRAPHILE_WORKER_SCHEMA ||
-        "graphile_worker",
+      schema: workerSchema = defaults.schema,
     } = options;
     const escapedWorkerSchema = Client.prototype.escapeIdentifier(workerSchema);
     compiled = {
       logger,
       workerSchema,
       escapedWorkerSchema,
-      maxContiguousErrors: MAX_CONTIGUOUS_ERRORS,
+      maxContiguousErrors: defaults.maxContiguousErrors,
     };
     _sharedOptionsCache.set(options, compiled);
   }
@@ -139,7 +138,7 @@ export const getUtilsAndReleasersFromOptions = async (
   settings: ProcessSharedOptionsSettings = {}
 ): Promise<CompiledOptions> => {
   const shared = processSharedOptions(options, settings);
-  const { concurrency = CONCURRENT_JOBS } = options;
+  const { concurrency = defaults.concurrentJobs } = options;
   return withReleasers(
     async (releasers, release): Promise<CompiledOptions> => {
       const pgPool: Pool = await assertPool(options, releasers);

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -154,7 +154,7 @@ export const getUtilsAndReleasersFromOptions = async (
       const withPgClient = makeWithPgClientFromPool(pgPool);
 
       // Migrate
-      await withPgClient(client => migrate(client, options));
+      await withPgClient(client => migrate(options, client));
       const addJob = makeAddJob(options, withPgClient);
 
       return {

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -1,32 +1,49 @@
 import { WorkerSharedOptions } from "./interfaces";
-import { Logger, defaultLogger } from "./logger";
+import { Logger, defaultLogger, LogScope } from "./logger";
 import { Client } from "pg";
+import { POLL_INTERVAL, MAX_CONTIGUOUS_ERRORS } from "./config";
 
 interface CompiledOptions {
   logger: Logger;
   workerSchema: string;
   escapedWorkerSchema: string;
+  pollInterval: number;
+  maxContiguousErrors: number;
 }
 
 const _sharedOptionsCache = new WeakMap<WorkerSharedOptions, CompiledOptions>();
 
 export function processSharedOptions(
-  options: WorkerSharedOptions
+  options: WorkerSharedOptions,
+  {
+    scope,
+  }: {
+    scope?: LogScope;
+  } = {}
 ): CompiledOptions {
   let compiled = _sharedOptionsCache.get(options);
-  if (compiled) {
+  if (!compiled) {
+    const {
+      logger = defaultLogger,
+      schema: workerSchema = "graphile_worker",
+      pollInterval = POLL_INTERVAL,
+    } = options;
+    const escapedWorkerSchema = Client.prototype.escapeIdentifier(workerSchema);
+    compiled = {
+      logger,
+      workerSchema,
+      escapedWorkerSchema,
+      pollInterval,
+      maxContiguousErrors: MAX_CONTIGUOUS_ERRORS,
+    };
+    _sharedOptionsCache.set(options, compiled);
+  }
+  if (scope) {
+    return {
+      ...compiled,
+      logger: compiled.logger.scope(scope),
+    };
+  } else {
     return compiled;
   }
-  const {
-    logger = defaultLogger,
-    schema: workerSchema = "graphile_worker",
-  } = options;
-  const escapedWorkerSchema = Client.prototype.escapeIdentifier(workerSchema);
-  compiled = {
-    logger,
-    workerSchema,
-    escapedWorkerSchema,
-  };
-  _sharedOptionsCache.set(options, compiled);
-  return compiled;
 }

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -1,0 +1,32 @@
+import { WorkerSharedOptions } from "./interfaces";
+import { Logger, defaultLogger } from "./logger";
+import { Client } from "pg";
+
+interface CompiledOptions {
+  logger: Logger;
+  workerSchema: string;
+  escapedWorkerSchema: string;
+}
+
+const _sharedOptionsCache = new WeakMap<WorkerSharedOptions, CompiledOptions>();
+
+export function processSharedOptions(
+  options: WorkerSharedOptions
+): CompiledOptions {
+  let compiled = _sharedOptionsCache.get(options);
+  if (compiled) {
+    return compiled;
+  }
+  const {
+    logger = defaultLogger,
+    schema: workerSchema = "graphile_worker",
+  } = options;
+  const escapedWorkerSchema = Client.prototype.escapeIdentifier(workerSchema);
+  compiled = {
+    logger,
+    workerSchema,
+    escapedWorkerSchema,
+  };
+  _sharedOptionsCache.set(options, compiled);
+  return compiled;
+}

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -1,20 +1,18 @@
-import { WorkerSharedOptions } from "./interfaces";
+import { SharedOptions } from "./interfaces";
 import { Logger, defaultLogger, LogScope } from "./logger";
 import { Client } from "pg";
-import { POLL_INTERVAL, MAX_CONTIGUOUS_ERRORS } from "./config";
+import { MAX_CONTIGUOUS_ERRORS } from "./config";
 
 interface CompiledOptions {
   logger: Logger;
   workerSchema: string;
   escapedWorkerSchema: string;
-  pollInterval: number;
   maxContiguousErrors: number;
 }
 
-const _sharedOptionsCache = new WeakMap<WorkerSharedOptions, CompiledOptions>();
-
+const _sharedOptionsCache = new WeakMap<SharedOptions, CompiledOptions>();
 export function processSharedOptions(
-  options: WorkerSharedOptions,
+  options: SharedOptions,
   {
     scope,
   }: {
@@ -27,14 +25,12 @@ export function processSharedOptions(
       logger = defaultLogger,
       schema: workerSchema = process.env.GRAPHILE_WORKER_SCHEMA ||
         "graphile_worker",
-      pollInterval = POLL_INTERVAL,
     } = options;
     const escapedWorkerSchema = Client.prototype.escapeIdentifier(workerSchema);
     compiled = {
       logger,
       workerSchema,
       escapedWorkerSchema,
-      pollInterval,
       maxContiguousErrors: MAX_CONTIGUOUS_ERRORS,
     };
     _sharedOptionsCache.set(options, compiled);

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -1,24 +1,32 @@
-import { SharedOptions } from "./interfaces";
+import * as assert from "assert";
+import {
+  SharedOptions,
+  RunnerOptions,
+  AddJobFunction,
+  WithPgClient,
+} from "./interfaces";
 import { Logger, defaultLogger, LogScope } from "./logger";
-import { Client } from "pg";
-import { MAX_CONTIGUOUS_ERRORS } from "./config";
+import { Client, Pool } from "pg";
+import { MAX_CONTIGUOUS_ERRORS, CONCURRENT_JOBS } from "./config";
+import { makeWithPgClientFromPool, makeAddJob } from "./helpers";
+import { migrate } from "./migrate";
 
-interface CompiledOptions {
+interface CompiledSharedOptions {
   logger: Logger;
   workerSchema: string;
   escapedWorkerSchema: string;
   maxContiguousErrors: number;
 }
 
-const _sharedOptionsCache = new WeakMap<SharedOptions, CompiledOptions>();
+interface ProcessSharedOptionsSettings {
+  scope?: LogScope;
+}
+
+const _sharedOptionsCache = new WeakMap<SharedOptions, CompiledSharedOptions>();
 export function processSharedOptions(
   options: SharedOptions,
-  {
-    scope,
-  }: {
-    scope?: LogScope;
-  } = {}
-): CompiledOptions {
+  { scope }: ProcessSharedOptionsSettings = {}
+): CompiledSharedOptions {
   let compiled = _sharedOptionsCache.get(options);
   if (!compiled) {
     const {
@@ -44,3 +52,135 @@ export function processSharedOptions(
     return compiled;
   }
 }
+
+export type Releasers = Array<() => void | Promise<void>>;
+
+export async function assertPool(
+  options: SharedOptions,
+  releasers: Releasers
+): Promise<Pool> {
+  const { logger } = processSharedOptions(options);
+  assert(
+    !options.pgPool || !options.connectionString,
+    "Both `pgPool` and `connectionString` are set, at most one of these options should be provided"
+  );
+  let pgPool: Pool;
+  if (options.pgPool) {
+    pgPool = options.pgPool;
+  } else if (options.connectionString) {
+    pgPool = new Pool({
+      connectionString: options.connectionString,
+      max: options.maxPoolSize,
+    });
+    releasers.push(() => pgPool.end());
+  } else if (process.env.DATABASE_URL) {
+    pgPool = new Pool({
+      connectionString: process.env.DATABASE_URL,
+      max: options.maxPoolSize,
+    });
+    releasers.push(() => pgPool.end());
+  } else {
+    throw new Error(
+      "You must either specify `pgPool` or `connectionString`, or you must make the `DATABASE_URL` environmental variable available."
+    );
+  }
+
+  pgPool.on("error", err => {
+    /*
+     * This handler is required so that client connection errors don't bring
+     * the server down (via `unhandledError`).
+     *
+     * `pg` will automatically terminate the client and remove it from the
+     * pool, so we don't actually need to take any action here, just ensure
+     * that the event listener is registered.
+     */
+    logger.error(`PostgreSQL client generated error: ${err.message}`, {
+      error: err,
+    });
+  });
+  return pgPool;
+}
+
+export type Release = () => Promise<void>;
+
+export async function withReleasers<T>(
+  callback: (releasers: Releasers, release: Release) => Promise<T>
+): Promise<T> {
+  const releasers: Releasers = [];
+  const release: Release = async () => {
+    await Promise.all(releasers.map(fn => fn()));
+  };
+  try {
+    return await callback(releasers, release);
+  } catch (e) {
+    try {
+      await release();
+    } catch (e2) {
+      /* noop */
+    }
+    throw e;
+  }
+}
+
+interface ProcessOptionsExtensions {
+  pgPool: Pool;
+  withPgClient: WithPgClient;
+  addJob: AddJobFunction;
+  release: Release;
+  releasers: Releasers;
+}
+
+export interface CompiledOptions
+  extends CompiledSharedOptions,
+    ProcessOptionsExtensions {}
+
+const processOptionsCache: Map<
+  RunnerOptions,
+  Promise<ProcessOptionsExtensions>
+> = new Map();
+export const getUtilsAndReleasersFromOptions = async (
+  options: RunnerOptions,
+  settings: ProcessSharedOptionsSettings = {}
+): Promise<CompiledOptions> => {
+  const shared = processSharedOptions(options, settings);
+  let extensionsPromise:
+    | Promise<ProcessOptionsExtensions>
+    | undefined = processOptionsCache.get(options);
+  if (!extensionsPromise) {
+    const { concurrency = CONCURRENT_JOBS } = options;
+    extensionsPromise = withReleasers(
+      async (releasers, release): Promise<ProcessOptionsExtensions> => {
+        releasers.push(() => {
+          processOptionsCache.delete(options);
+        });
+        const pgPool: Pool = await assertPool(options, releasers);
+        // @ts-ignore
+        const max = pgPool?.options?.max || 10;
+        if (max < concurrency) {
+          console.warn(
+            `WARNING: having maxPoolSize (${max}) smaller than concurrency (${concurrency}) may lead to non-optimal performance.`
+          );
+        }
+
+        const withPgClient = makeWithPgClientFromPool(pgPool);
+
+        // Migrate
+        await withPgClient(client => migrate(client, options));
+        const addJob = makeAddJob(options, withPgClient);
+
+        return {
+          pgPool,
+          withPgClient,
+          addJob,
+          release,
+          releasers,
+        };
+      }
+    );
+    processOptionsCache.set(options, extensionsPromise);
+  }
+  return {
+    ...shared,
+    ...(await extensionsPromise),
+  };
+};

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -25,7 +25,8 @@ export function processSharedOptions(
   if (!compiled) {
     const {
       logger = defaultLogger,
-      schema: workerSchema = "graphile_worker",
+      schema: workerSchema = process.env.GRAPHILE_WORKER_SCHEMA ||
+        "graphile_worker",
       pollInterval = POLL_INTERVAL,
     } = options;
     const escapedWorkerSchema = Client.prototype.escapeIdentifier(workerSchema);

--- a/src/main.ts
+++ b/src/main.ts
@@ -69,9 +69,9 @@ function registerSignalHandlers(logger: Logger) {
 }
 
 export function runTaskList(
+  options: WorkerPoolOptions,
   tasks: TaskList,
-  pgPool: Pool,
-  options: WorkerPoolOptions = {}
+  pgPool: Pool
 ): WorkerPool {
   const { logger, escapedWorkerSchema } = processSharedOptions(options);
   logger.debug(`Worker pool options are ${inspect(options)}`, { options });
@@ -215,7 +215,7 @@ export function runTaskList(
   // Spawn our workers; they can share clients from the pool.
   const withPgClient = makeWithPgClientFromPool(pgPool);
   for (let i = 0; i < concurrency; i++) {
-    workers.push(makeNewWorker(tasks, withPgClient, workerOptions));
+    workers.push(makeNewWorker(workerOptions, tasks, withPgClient));
   }
 
   // TODO: handle when a worker shuts down (spawn a new one)
@@ -224,9 +224,9 @@ export function runTaskList(
 }
 
 export const runTaskListOnce = (
+  options: WorkerOptions,
   tasks: TaskList,
-  client: PoolClient,
-  options: WorkerOptions = {}
+  client: PoolClient
 ) =>
-  makeNewWorker(tasks, makeWithPgClientFromClient(client), options, false)
+  makeNewWorker(options, tasks, makeWithPgClientFromClient(client), false)
     .promise;

--- a/src/main.ts
+++ b/src/main.ts
@@ -16,7 +16,7 @@ import {
   makeWithPgClientFromPool,
   makeWithPgClientFromClient,
 } from "./helpers";
-import { CONCURRENT_JOBS } from "./config";
+import { defaults } from "./config";
 import { Logger } from "./logger";
 import { processSharedOptions } from "./lib";
 
@@ -76,7 +76,7 @@ export function runTaskList(
   const { logger, escapedWorkerSchema } = processSharedOptions(options);
   logger.debug(`Worker pool options are ${inspect(options)}`, { options });
   const {
-    concurrency = CONCURRENT_JOBS,
+    concurrency = defaults.concurrentJobs,
     noHandleSignals,
     ...workerOptions
   } = options;

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,4 +1,4 @@
-import { Pool, PoolClient, Client } from "pg";
+import { Pool, PoolClient } from "pg";
 import { inspect } from "util";
 import {
   TaskList,
@@ -17,7 +17,8 @@ import {
   makeWithPgClientFromClient,
 } from "./helpers";
 import { CONCURRENT_JOBS } from "./config";
-import { defaultLogger, Logger } from "./logger";
+import { Logger } from "./logger";
+import { processSharedOptions } from "./lib";
 
 const allWorkerPools: Array<WorkerPool> = [];
 
@@ -72,16 +73,13 @@ export function runTaskList(
   pgPool: Pool,
   options: WorkerPoolOptions = {}
 ): WorkerPool {
-  const { logger = defaultLogger } = options;
+  const { logger, escapedWorkerSchema } = processSharedOptions(options);
   logger.debug(`Worker pool options are ${inspect(options)}`, { options });
   const {
     concurrency = CONCURRENT_JOBS,
     noHandleSignals,
     ...workerOptions
   } = options;
-
-  const { schema: workerSchema = "graphile_worker" } = workerOptions;
-  const escapedWorkerSchema = Client.prototype.escapeIdentifier(workerSchema);
 
   if (!noHandleSignals) {
     // Clean up when certain signals occur

--- a/src/migrate.ts
+++ b/src/migrate.ts
@@ -26,7 +26,10 @@ async function runMigration(
     `${__dirname}/../sql/${migrationFile}`,
     "utf8"
   );
-  const text = rawText.replace(/:WORKER_SCHEMA\b/g, escapedWorkerSchema);
+  const text = rawText.replace(
+    /:GRAPHILE_WORKER_SCHEMA\b/g,
+    escapedWorkerSchema
+  );
   await client.query("begin");
   try {
     await client.query({

--- a/src/migrate.ts
+++ b/src/migrate.ts
@@ -1,10 +1,10 @@
-import { PoolClient, Client } from "pg";
+import { PoolClient } from "pg";
 import { readdir, readFile } from "./fs";
 import { WorkerSharedOptions } from "./interfaces";
+import { processSharedOptions } from "./lib";
 
 async function installSchema(client: PoolClient, options: WorkerSharedOptions) {
-  const { schema: workerSchema = "graphile_worker" } = options;
-  const escapedWorkerSchema = Client.prototype.escapeIdentifier(workerSchema);
+  const { escapedWorkerSchema } = processSharedOptions(options);
   await client.query(`
     create extension if not exists pgcrypto with schema public;
     create schema ${escapedWorkerSchema};
@@ -21,8 +21,7 @@ async function runMigration(
   migrationNumber: number,
   options: WorkerSharedOptions
 ) {
-  const { schema: workerSchema = "graphile_worker" } = options;
-  const escapedWorkerSchema = Client.prototype.escapeIdentifier(workerSchema);
+  const { escapedWorkerSchema } = processSharedOptions(options);
   const rawText = await readFile(
     `${__dirname}/../sql/${migrationFile}`,
     "utf8"
@@ -48,8 +47,7 @@ export async function migrate(
   client: PoolClient,
   options: WorkerSharedOptions
 ) {
-  const { schema: workerSchema = "graphile_worker" } = options;
-  const escapedWorkerSchema = Client.prototype.escapeIdentifier(workerSchema);
+  const { escapedWorkerSchema } = processSharedOptions(options);
   let latestMigration: number | null = null;
   try {
     const {

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -52,7 +52,7 @@ export const runOnce = async (options: RunnerOptions): Promise<void> => {
     const promises: Promise<void>[] = [];
     for (let i = 0; i < concurrency; i++) {
       promises.push(
-        withPgClient(client => runTaskListOnce(taskList, client, options))
+        withPgClient(client => runTaskListOnce(options, taskList, client))
       );
     }
     await Promise.all(promises);
@@ -72,7 +72,7 @@ export const run = async (options: RunnerOptions): Promise<Runner> => {
   try {
     const taskList = await assertTaskList(options, releasers);
 
-    const workerPool = runTaskList(taskList, pgPool, options);
+    const workerPool = runTaskList(options, taskList, pgPool);
     releasers.push(() => workerPool.release());
 
     let running = true;

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -116,7 +116,7 @@ const processOptions = async (options: RunnerOptions) => {
     const withPgClient = makeWithPgClientFromPool(pgPool);
 
     // Migrate
-    await withPgClient(client => migrate(client));
+    await withPgClient(client => migrate(client, options));
 
     return { taskList, pgPool, withPgClient, release, logger };
   });
@@ -129,7 +129,7 @@ export const runMigrations = async (options: RunnerOptions): Promise<void> => {
     const withPgClient = makeWithPgClientFromPool(pgPool);
 
     // Migrate
-    await withPgClient(client => migrate(client));
+    await withPgClient(client => migrate(client, options));
 
     await release();
 
@@ -167,7 +167,7 @@ export const run = async (options: RunnerOptions): Promise<Runner> => {
         throw new Error("Runner is already stopped");
       }
     },
-    addJob: makeAddJob(withPgClient),
+    addJob: makeAddJob(withPgClient, options),
     promise: workerPool.promise,
   };
 };

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -1,14 +1,20 @@
 import * as assert from "assert";
-import { Pool } from "pg";
 import getTasks from "./getTasks";
 import { Runner, RunnerOptions, TaskList } from "./interfaces";
 import { runTaskList, runTaskListOnce } from "./main";
-import { makeWithPgClientFromPool, makeAddJob } from "./helpers";
 import { migrate } from "./migrate";
-import { defaultLogger, Logger } from "./logger";
-import { CONCURRENT_JOBS } from "./config";
+import { getUtilsAndReleasersFromOptions, Releasers } from "./lib";
 
-type Releasers = Array<() => void | Promise<void>>;
+export const runMigrations = async (options: RunnerOptions): Promise<void> => {
+  const { withPgClient, release } = await getUtilsAndReleasersFromOptions(
+    options
+  );
+  try {
+    await withPgClient(client => migrate(client, options));
+  } finally {
+    await release();
+  }
+};
 
 async function assertTaskList(
   options: RunnerOptions,
@@ -33,141 +39,57 @@ async function assertTaskList(
   return taskList;
 }
 
-export async function assertPool(
-  options: RunnerOptions,
-  releasers: Releasers,
-  logger: Logger
-): Promise<Pool> {
-  assert(
-    !options.pgPool || !options.connectionString,
-    "Both `pgPool` and `connectionString` are set, at most one of these options should be provided"
-  );
-  let pgPool: Pool;
-  if (options.pgPool) {
-    pgPool = options.pgPool;
-  } else if (options.connectionString) {
-    pgPool = new Pool({
-      connectionString: options.connectionString,
-      max: options.maxPoolSize,
-    });
-    releasers.push(() => pgPool.end());
-  } else if (process.env.DATABASE_URL) {
-    pgPool = new Pool({
-      connectionString: process.env.DATABASE_URL,
-      max: options.maxPoolSize,
-    });
-    releasers.push(() => pgPool.end());
-  } else {
-    throw new Error(
-      "You must either specify `pgPool` or `connectionString`, or you must make the `DATABASE_URL` environmental variable available."
-    );
-  }
-
-  pgPool.on("error", err => {
-    /*
-     * This handler is required so that client connection errors don't bring
-     * the server down (via `unhandledError`).
-     *
-     * `pg` will automatically terminate the client and remove it from the
-     * pool, so we don't actually need to take any action here, just ensure
-     * that the event listener is registered.
-     */
-    logger.error(`PostgreSQL client generated error: ${err.message}`, {
-      error: err,
-    });
-  });
-  return pgPool;
-}
-
-export type Release = () => Promise<void>;
-
-export async function withReleasers<T>(
-  callback: (releasers: Releasers, release: Release) => Promise<T>
-): Promise<T> {
-  const releasers: Releasers = [];
-  const release: Release = async () => {
-    await Promise.all(releasers.map(fn => fn()));
-  };
-  try {
-    return await callback(releasers, release);
-  } catch (e) {
-    try {
-      await release();
-    } catch (e2) {
-      /* noop */
-    }
-    throw e;
-  }
-}
-
-const processOptions = async (options: RunnerOptions) => {
-  const { logger = defaultLogger, concurrency = CONCURRENT_JOBS } = options;
-  return withReleasers(async (releasers, release) => {
-    const taskList = await assertTaskList(options, releasers);
-    const pgPool: Pool = await assertPool(options, releasers, logger);
-    // @ts-ignore
-    const max = pgPool?.options?.max || 10;
-    if (max < concurrency) {
-      console.warn(
-        `WARNING: having maxPoolSize (${max}) smaller than concurrency (${concurrency}) may lead to non-optimal performance.`
-      );
-    }
-
-    const withPgClient = makeWithPgClientFromPool(pgPool);
-
-    // Migrate
-    await withPgClient(client => migrate(client, options));
-
-    return { taskList, pgPool, withPgClient, release, logger };
-  });
-};
-
-export const runMigrations = async (options: RunnerOptions): Promise<void> => {
-  const { logger = defaultLogger } = options;
-  return withReleasers(async (releasers, release) => {
-    const pgPool: Pool = await assertPool(options, releasers, logger);
-    const withPgClient = makeWithPgClientFromPool(pgPool);
-
-    // Migrate
-    await withPgClient(client => migrate(client, options));
-
-    await release();
-
-    return;
-  });
-};
-
 export const runOnce = async (options: RunnerOptions): Promise<void> => {
   const { concurrency = 1 } = options;
-  const { taskList, withPgClient, release } = await processOptions(options);
-  const promises: Promise<void>[] = [];
-  for (let i = 0; i < concurrency; i++) {
-    promises.push(
-      withPgClient(client => runTaskListOnce(taskList, client, options))
-    );
+  const {
+    withPgClient,
+    release,
+    releasers,
+  } = await getUtilsAndReleasersFromOptions(options);
+  try {
+    const taskList = await assertTaskList(options, releasers);
+
+    const promises: Promise<void>[] = [];
+    for (let i = 0; i < concurrency; i++) {
+      promises.push(
+        withPgClient(client => runTaskListOnce(taskList, client, options))
+      );
+    }
+    await Promise.all(promises);
+  } finally {
+    await release();
   }
-  await Promise.all(promises);
-  await release();
 };
 
 export const run = async (options: RunnerOptions): Promise<Runner> => {
-  const { taskList, pgPool, withPgClient, release } = await processOptions(
-    options
-  );
+  const {
+    pgPool,
+    release,
+    releasers,
+    addJob,
+  } = await getUtilsAndReleasersFromOptions(options);
 
-  const workerPool = runTaskList(taskList, pgPool, options);
-  let running = true;
-  return {
-    async stop() {
-      if (running) {
-        running = false;
-        await workerPool.release();
-        await release();
-      } else {
-        throw new Error("Runner is already stopped");
-      }
-    },
-    addJob: makeAddJob(withPgClient, options),
-    promise: workerPool.promise,
-  };
+  try {
+    const taskList = await assertTaskList(options, releasers);
+
+    const workerPool = runTaskList(taskList, pgPool, options);
+    releasers.push(() => workerPool.release());
+
+    let running = true;
+    return {
+      async stop() {
+        if (running) {
+          running = false;
+          await release();
+        } else {
+          throw new Error("Runner is already stopped");
+        }
+      },
+      addJob,
+      promise: workerPool.promise,
+    };
+  } catch (e) {
+    await release();
+    throw e;
+  }
 };

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -22,7 +22,7 @@ async function assertTaskList(
   if (options.taskList) {
     taskList = options.taskList;
   } else if (options.taskDirectory) {
-    const watchedTasks = await getTasks(options.taskDirectory, false);
+    const watchedTasks = await getTasks(options, options.taskDirectory, false);
     releasers.push(() => watchedTasks.release());
     taskList = watchedTasks.tasks;
   } else {

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -39,7 +39,10 @@ async function assertTaskList(
   return taskList;
 }
 
-export const runOnce = async (options: RunnerOptions): Promise<void> => {
+export const runOnce = async (
+  options: RunnerOptions,
+  overrideTaskList?: TaskList
+): Promise<void> => {
   const { concurrency = 1 } = options;
   const {
     withPgClient,
@@ -47,7 +50,8 @@ export const runOnce = async (options: RunnerOptions): Promise<void> => {
     releasers,
   } = await getUtilsAndReleasersFromOptions(options);
   try {
-    const taskList = await assertTaskList(options, releasers);
+    const taskList =
+      overrideTaskList || (await assertTaskList(options, releasers));
 
     const promises: Promise<void>[] = [];
     for (let i = 0; i < concurrency; i++) {
@@ -61,7 +65,10 @@ export const runOnce = async (options: RunnerOptions): Promise<void> => {
   }
 };
 
-export const run = async (options: RunnerOptions): Promise<Runner> => {
+export const run = async (
+  options: RunnerOptions,
+  overrideTaskList?: TaskList
+): Promise<Runner> => {
   const {
     pgPool,
     release,
@@ -70,7 +77,8 @@ export const run = async (options: RunnerOptions): Promise<Runner> => {
   } = await getUtilsAndReleasersFromOptions(options);
 
   try {
-    const taskList = await assertTaskList(options, releasers);
+    const taskList =
+      overrideTaskList || (await assertTaskList(options, releasers));
 
     const workerPool = runTaskList(options, taskList, pgPool);
     releasers.push(() => workerPool.release());

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -10,7 +10,7 @@ export const runMigrations = async (options: RunnerOptions): Promise<void> => {
     options
   );
   try {
-    await withPgClient(client => migrate(client, options));
+    await withPgClient(client => migrate(options, client));
   } finally {
     await release();
   }

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -10,7 +10,7 @@ import { randomBytes } from "crypto";
 import deferred from "./deferred";
 import { makeJobHelpers } from "./helpers";
 import { processSharedOptions } from "./lib";
-import { POLL_INTERVAL } from "./config";
+import { defaults } from "./config";
 
 export function makeNewWorker(
   options: WorkerOptions,
@@ -20,7 +20,7 @@ export function makeNewWorker(
 ): Worker {
   const {
     workerId = `worker-${randomBytes(9).toString("hex")}`,
-    pollInterval = POLL_INTERVAL,
+    pollInterval = defaults.pollInterval,
   } = options;
   const {
     workerSchema,

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -10,6 +10,7 @@ import { randomBytes } from "crypto";
 import deferred from "./deferred";
 import { makeJobHelpers } from "./helpers";
 import { processSharedOptions } from "./lib";
+import { POLL_INTERVAL } from "./config";
 
 export function makeNewWorker(
   tasks: TaskList,
@@ -17,12 +18,14 @@ export function makeNewWorker(
   options: WorkerOptions = {},
   continuous = true
 ): Worker {
-  const { workerId = `worker-${randomBytes(9).toString("hex")}` } = options;
+  const {
+    workerId = `worker-${randomBytes(9).toString("hex")}`,
+    pollInterval = POLL_INTERVAL,
+  } = options;
   const {
     workerSchema,
     escapedWorkerSchema,
     logger,
-    pollInterval,
     maxContiguousErrors,
   } = processSharedOptions(options, {
     scope: {

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -159,14 +159,7 @@ export function makeNewWorker(
         logger.debug(`Found task ${job.id} (${job.task_identifier})`);
         const task = tasks[job.task_identifier];
         assert(task, `Unsupported task '${job.task_identifier}'`);
-        const helpers = makeJobHelpers(
-          job,
-          { withPgClient },
-          {
-            ...options,
-            logger,
-          }
-        );
+        const helpers = makeJobHelpers(options, job, { withPgClient, logger });
         await task(job.payload, helpers);
       } catch (error) {
         err = error;

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -10,8 +10,7 @@ import * as assert from "assert";
 import { randomBytes } from "crypto";
 import deferred from "./deferred";
 import { makeJobHelpers } from "./helpers";
-import { defaultLogger } from "./logger";
-import { Client } from "pg";
+import { processSharedOptions } from "./lib";
 
 export function makeNewWorker(
   tasks: TaskList,
@@ -19,12 +18,14 @@ export function makeNewWorker(
   options: WorkerOptions = {},
   continuous = true
 ): Worker {
-  const { schema: workerSchema = "graphile_worker" } = options;
-  const escapedWorkerSchema = Client.prototype.escapeIdentifier(workerSchema);
+  const {
+    workerSchema,
+    escapedWorkerSchema,
+    logger: baseLogger,
+  } = processSharedOptions(options);
   const {
     pollInterval = POLL_INTERVAL,
     workerId = `worker-${randomBytes(9).toString("hex")}`,
-    logger: baseLogger = defaultLogger,
   } = options;
   const promise = deferred();
   let activeJob: Job | null = null;

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -11,6 +11,7 @@ import { randomBytes } from "crypto";
 import deferred from "./deferred";
 import { makeJobHelpers } from "./helpers";
 import { defaultLogger } from "./logger";
+import { Client } from "pg";
 
 export function makeNewWorker(
   tasks: TaskList,
@@ -18,6 +19,8 @@ export function makeNewWorker(
   options: WorkerOptions = {},
   continuous = true
 ): Worker {
+  const { schema: workerSchema = "graphile_worker" } = options;
+  const escapedWorkerSchema = Client.prototype.escapeIdentifier(workerSchema);
   const {
     pollInterval = POLL_INTERVAL,
     workerId = `worker-${randomBytes(9).toString("hex")}`,
@@ -76,10 +79,10 @@ export function makeNewWorker(
         client.query({
           text:
             // TODO: breaking change; change this to more optimal:
-            // "SELECT id, queue_name, task_identifier, payload FROM graphile_worker.get_job($1, $2);",
-            "SELECT * FROM graphile_worker.get_job($1, $2);",
+            // `SELECT id, queue_name, task_identifier, payload FROM ${escapedWorkerSchema}.get_job($1, $2);`,
+            `SELECT * FROM ${escapedWorkerSchema}.get_job($1, $2);`,
           values: [workerId, supportedTaskNames],
-          name: "get_job",
+          name: `get_job/${workerSchema}`,
         })
       );
 
@@ -154,7 +157,14 @@ export function makeNewWorker(
         logger.debug(`Found task ${job.id} (${job.task_identifier})`);
         const task = tasks[job.task_identifier];
         assert(task, `Unsupported task '${job.task_identifier}'`);
-        const helpers = makeJobHelpers(job, { withPgClient }, logger);
+        const helpers = makeJobHelpers(
+          job,
+          { withPgClient },
+          {
+            ...options,
+            logger,
+          }
+        );
         await task(job.payload, helpers);
       } catch (error) {
         err = error;
@@ -178,9 +188,9 @@ export function makeNewWorker(
         // TODO: retry logic, in case of server connection interruption
         await withPgClient(client =>
           client.query({
-            text: "SELECT FROM graphile_worker.fail_job($1, $2, $3);",
+            text: `SELECT FROM ${escapedWorkerSchema}.fail_job($1, $2, $3);`,
             values: [workerId, job.id, message],
-            name: "fail_job",
+            name: `fail_job/${workerSchema}`,
           })
         );
       } else {
@@ -195,9 +205,9 @@ export function makeNewWorker(
         // TODO: retry logic, in case of server connection interruption
         await withPgClient(client =>
           client.query({
-            text: "SELECT FROM graphile_worker.complete_job($1, $2);",
+            text: `SELECT FROM ${escapedWorkerSchema}.complete_job($1, $2);`,
             values: [workerId, job.id],
-            name: "complete_job",
+            name: `complete_job/${workerSchema}`,
           })
         );
       }

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -13,9 +13,9 @@ import { processSharedOptions } from "./lib";
 import { POLL_INTERVAL } from "./config";
 
 export function makeNewWorker(
+  options: WorkerOptions,
   tasks: TaskList,
   withPgClient: WithPgClient,
-  options: WorkerOptions = {},
   continuous = true
 ): Worker {
   const {

--- a/src/workerUtils.ts
+++ b/src/workerUtils.ts
@@ -25,7 +25,7 @@ export async function makeWorkerUtils(
     logger,
     release,
     addJob,
-    migrate: () => withPgClient(pgClient => migrate(pgClient, options)),
+    migrate: () => withPgClient(pgClient => migrate(options, pgClient)),
 
     async completeJobs(ids) {
       const { rows } = await withPgClient(client =>

--- a/src/workerUtils.ts
+++ b/src/workerUtils.ts
@@ -1,8 +1,6 @@
 import { WorkerUtilsOptions, TaskSpec, WorkerUtils, Job } from "./interfaces";
-import { makeWithPgClientFromPool, makeAddJob } from "./helpers";
-import { withReleasers, assertPool } from "./runner";
+import { getUtilsAndReleasersFromOptions } from "./lib";
 import { migrate } from "./migrate";
-import { processSharedOptions } from "./lib";
 
 /**
  * Construct (asynchronously) a new WorkerUtils instance.
@@ -10,21 +8,17 @@ import { processSharedOptions } from "./lib";
 export async function makeWorkerUtils(
   options: WorkerUtilsOptions
 ): Promise<WorkerUtils> {
-  const { logger, escapedWorkerSchema } = processSharedOptions(options, {
+  const {
+    logger,
+    escapedWorkerSchema,
+    release,
+    withPgClient,
+    addJob,
+  } = await getUtilsAndReleasersFromOptions(options, {
     scope: {
       label: "WorkerUtils",
     },
   });
-
-  const { pgPool, release } = await withReleasers(
-    async (releasers, release) => ({
-      pgPool: await assertPool(options, releasers, logger),
-      release,
-    })
-  );
-
-  const withPgClient = makeWithPgClientFromPool(pgPool);
-  const addJob = makeAddJob(withPgClient, options);
 
   return {
     withPgClient,

--- a/src/workerUtils.ts
+++ b/src/workerUtils.ts
@@ -1,9 +1,8 @@
 import { WorkerUtilsOptions, TaskSpec, WorkerUtils, Job } from "./interfaces";
 import { makeWithPgClientFromPool, makeAddJob } from "./helpers";
-import { defaultLogger } from "./logger";
 import { withReleasers, assertPool } from "./runner";
 import { migrate } from "./migrate";
-import { Client } from "pg";
+import { processSharedOptions } from "./lib";
 
 /**
  * Construct (asynchronously) a new WorkerUtils instance.
@@ -11,13 +10,12 @@ import { Client } from "pg";
 export async function makeWorkerUtils(
   options: WorkerUtilsOptions
 ): Promise<WorkerUtils> {
-  const { logger: baseLogger = defaultLogger } = options;
+  const { logger: baseLogger, escapedWorkerSchema } = processSharedOptions(
+    options
+  );
   const logger = baseLogger.scope({
     label: "WorkerUtils",
   });
-
-  const { schema: workerSchema = "graphile_worker" } = options;
-  const escapedWorkerSchema = Client.prototype.escapeIdentifier(workerSchema);
 
   const { pgPool, release } = await withReleasers(
     async (releasers, release) => ({

--- a/src/workerUtils.ts
+++ b/src/workerUtils.ts
@@ -79,7 +79,7 @@ export async function makeWorkerUtils(
 export async function quickAddJob(
   options: WorkerUtilsOptions,
   identifier: string,
-  payload: any = {},
+  payload: unknown = {},
   spec: TaskSpec = {}
 ) {
   const utils = await makeWorkerUtils(options);

--- a/src/workerUtils.ts
+++ b/src/workerUtils.ts
@@ -10,11 +10,10 @@ import { processSharedOptions } from "./lib";
 export async function makeWorkerUtils(
   options: WorkerUtilsOptions
 ): Promise<WorkerUtils> {
-  const { logger: baseLogger, escapedWorkerSchema } = processSharedOptions(
-    options
-  );
-  const logger = baseLogger.scope({
-    label: "WorkerUtils",
+  const { logger, escapedWorkerSchema } = processSharedOptions(options, {
+    scope: {
+      label: "WorkerUtils",
+    },
   });
 
   const { pgPool, release } = await withReleasers(

--- a/yarn.lock
+++ b/yarn.lock
@@ -105,6 +105,13 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.8.0"
 
+"@babel/runtime@^7.6.3":
+  version "7.8.4"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.8.4.tgz#d79f5a2040f7caa24d53e563aad49cbc05581308"
+  integrity sha512-neAp3zt80trRVBI1x0azq6c57aNBqYZH8KhMm3TaB7wEI5Q4A2SHfBHE8w9gOhI/lrqxtEbXZgQIrHP+wvSGwQ==
+  dependencies:
+    regenerator-runtime "^0.13.2"
+
 "@babel/template@^7.7.4", "@babel/template@^7.8.3":
   version "7.8.3"
   resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.8.3.tgz#e02ad04fe262a657809327f578056ca15fd4d1b8"
@@ -417,6 +424,11 @@
   version "13.7.0"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-13.7.0.tgz#b417deda18cf8400f278733499ad5547ed1abec4"
   integrity sha512-GnZbirvmqZUzMgkFn70c74OQpTTUcCzlhQliTzYjQMqg+hVKcDnxdL19Ne3UdYzdMA/+W3eb646FWn/ZaT1NfQ==
+
+"@types/parse-json@^4.0.0":
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/@types/parse-json/-/parse-json-4.0.0.tgz#2f8bb441434d163b35fb8ffdccd7138927ffb8c0"
+  integrity sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA==
 
 "@types/pg-types@*":
   version "1.11.5"
@@ -991,6 +1003,17 @@ core_d@^1.0.1:
   dependencies:
     supports-color "^5.5.0"
 
+cosmiconfig@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/cosmiconfig/-/cosmiconfig-6.0.0.tgz#da4fee853c52f6b1e6935f41c1a2fc50bd4a9982"
+  integrity sha512-xb3ZL6+L8b9JLLCx3ZdoZy4+2ECphCMo2PwqgP1tlfVq6M6YReyzBJtvWWtbDSpNr9hn96pkCiZqUcFEc+54Qg==
+  dependencies:
+    "@types/parse-json" "^4.0.0"
+    import-fresh "^3.1.0"
+    parse-json "^5.0.0"
+    path-type "^4.0.0"
+    yaml "^1.7.2"
+
 cross-spawn@^6.0.0, cross-spawn@^6.0.5:
   version "6.0.5"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-6.0.5.tgz#4a5ec7c64dfae22c3a14124dbacdee846d80cbc4"
@@ -1155,6 +1178,13 @@ end-of-stream@^1.1.0:
   integrity sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==
   dependencies:
     once "^1.4.0"
+
+error-ex@^1.3.1:
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/error-ex/-/error-ex-1.3.2.tgz#b4ac40648107fdcdcfae242f428bea8a14d4f1bf"
+  integrity sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==
+  dependencies:
+    is-arrayish "^0.2.1"
 
 es-abstract@^1.17.0-next.1, es-abstract@^1.17.2:
   version "1.17.4"
@@ -1762,7 +1792,7 @@ ignore@^4.0.6:
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-4.0.6.tgz#750e3db5862087b4737ebac8207ffd1ef27b25fc"
   integrity sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==
 
-import-fresh@^3.0.0:
+import-fresh@^3.0.0, import-fresh@^3.1.0:
   version "3.2.1"
   resolved "https://registry.yarnpkg.com/import-fresh/-/import-fresh-3.2.1.tgz#633ff618506e793af5ac91bf48b72677e15cbe66"
   integrity sha512-6e1q1cnWP2RXD9/keSkxHScg508CdXqXWgWBaETNhyuBFz+kUZlKboh+ISK+bU++DmbHimVBrOz/zzPe0sZ3sQ==
@@ -1833,6 +1863,11 @@ is-accessor-descriptor@^1.0.0:
   integrity sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==
   dependencies:
     kind-of "^6.0.0"
+
+is-arrayish@^0.2.1:
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/is-arrayish/-/is-arrayish-0.2.1.tgz#77c99840527aa8ecb1a8ba697b80645a7a926a9d"
+  integrity sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=
 
 is-binary-path@~2.1.0:
   version "2.1.0"
@@ -2471,6 +2506,11 @@ jsesc@^2.5.1:
   resolved "https://registry.yarnpkg.com/jsesc/-/jsesc-2.5.2.tgz#80564d2e483dacf6e8ef209650a67df3f0c283a4"
   integrity sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==
 
+json-parse-better-errors@^1.0.1:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz#bb867cfb3450e69107c131d1c514bab3dc8bcaa9"
+  integrity sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==
+
 json-schema-traverse@^0.4.1:
   version "0.4.1"
   resolved "https://registry.yarnpkg.com/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz#69f6a87d9513ab8bb8fe63bdb0979c448e684660"
@@ -2549,6 +2589,11 @@ levn@^0.3.0, levn@~0.3.0:
   dependencies:
     prelude-ls "~1.1.2"
     type-check "~0.3.2"
+
+lines-and-columns@^1.1.6:
+  version "1.1.6"
+  resolved "https://registry.yarnpkg.com/lines-and-columns/-/lines-and-columns-1.1.6.tgz#1c00c743b433cd0a4e80758f7b64a57440d9ff00"
+  integrity sha1-HADHQ7QzzQpOgHWPe2SldEDZ/wA=
 
 locate-path@^5.0.0:
   version "5.0.0"
@@ -2923,6 +2968,16 @@ parent-module@^1.0.0:
   dependencies:
     callsites "^3.0.0"
 
+parse-json@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/parse-json/-/parse-json-5.0.0.tgz#73e5114c986d143efa3712d4ea24db9a4266f60f"
+  integrity sha512-OOY5b7PAEFV0E2Fir1KOkxchnZNCdowAJgQ5NuxjpBKTRP3pQhwkrkxqQjeoKJ+fO7bCpmIZaogI4eZGDMEGOw==
+  dependencies:
+    "@babel/code-frame" "^7.0.0"
+    error-ex "^1.3.1"
+    json-parse-better-errors "^1.0.1"
+    lines-and-columns "^1.1.6"
+
 parse5@5.1.0:
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/parse5/-/parse5-5.1.0.tgz#c59341c9723f414c452975564c7c00a68d58acd2"
@@ -2957,6 +3012,11 @@ path-parse@^1.0.6:
   version "1.0.6"
   resolved "https://registry.yarnpkg.com/path-parse/-/path-parse-1.0.6.tgz#d62dbb5679405d72c4737ec58600e9ddcf06d24c"
   integrity sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==
+
+path-type@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/path-type/-/path-type-4.0.0.tgz#84ed01c0a7ba380afe09d90a8c180dcd9d03043b"
+  integrity sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==
 
 performance-now@^2.1.0:
   version "2.1.0"
@@ -3157,6 +3217,11 @@ realpath-native@^1.1.0:
   integrity sha512-wlgPA6cCIIg9gKz0fgAPjnzh4yR/LnXovwuo9hvyGvx3h8nX4+/iLZplfUWasXpqD8BdnGnP5njOFjkUwPzvjA==
   dependencies:
     util.promisify "^1.0.0"
+
+regenerator-runtime@^0.13.2:
+  version "0.13.3"
+  resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.13.3.tgz#7cf6a77d8f5c6f60eb73c5fc1955b2ceb01e6bf5"
+  integrity sha512-naKIZz2GQ8JWh///G7L3X6LaQUAMp2lvb1rvwwsURe/VXwD6VMfr+/1NuNw3ag8v2kY1aQ/go5SNn79O9JU7yw==
 
 regex-not@^1.0.0, regex-not@^1.0.2:
   version "1.0.2"
@@ -4072,6 +4137,13 @@ y18n@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/y18n/-/y18n-4.0.0.tgz#95ef94f85ecc81d007c264e190a120f0a3c8566b"
   integrity sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==
+
+yaml@^1.7.2:
+  version "1.7.2"
+  resolved "https://registry.yarnpkg.com/yaml/-/yaml-1.7.2.tgz#f26aabf738590ab61efaca502358e48dc9f348b2"
+  integrity sha512-qXROVp90sb83XtAoqE8bP9RwAkTTZbugRUTm5YeFCBfNRPEp2YzTeqWiz7m5OORHzEvrA/qcGS8hp/E+MMROYw==
+  dependencies:
+    "@babel/runtime" "^7.6.3"
 
 yargs-parser@10.x:
   version "10.1.0"


### PR DESCRIPTION
Fixes #65 (fao @demianuco)

~~Currently this is only configurable via `GRAPHILE_WORKER_SCHEMA` envvar, but we could/should add `cosmiconfig` or similar for the settings defaults.~~

### :sparkles: Features

- Can override the default `graphile_worker` schema of your choice using the `schema` option, `GRAPHILE_WORKER_SCHEMA` envvar or `schema` config
- Cosmiconfig added for overriding defaults for `pollInterval` or `concurrentJobs`

### :rotating_light: Changed API signatures:

NOTE: if you use the CLI then you are unaffected by this change; only library users will be affected.

Overriding the SQL schema to use means that everything in the codebase needs to know this setting. To achieve this:

- all major APIs now accept `options` as a configuration parameter
- where this was optional before it is now required
- where options was not the first argument, it has been moved to the first argument (for consistency)

As such the following APIs (most of which are internal) have been changed:

- `getTasks(taskPath, watch, logger)` -> `getTasks(options, taskPath, watch)`
- `runTaskList(tasks, pgPool, options?)` -> `runTaskList(options, tasks, pgPool)`
- `runTaskListOnce(tasks, client, options?)` -> `runTaskList(options, tasks, client)`
- `migrate(client)` -> `migrate(options, client)`
- `makeAddJob(withPgClient)` -> `makeAddJob(options, withPgClient)`
- `makeJobHelpers(job, { withPgClient }, baseLogger)` -> `makeJobHelpers(options, job, { withPgClient, logger? })`
- `makeNewWorker(tasks, withPgClient, options, continuous)` -> `makeNewWorker(options, tasks, withPgClient, continuous)`

Also if you're a TypeScript user: we've renamed `WorkerSharedOptions` to `SharedOptions` and added a new `WorkerSharedOptions`. This is particularly relevant if you're using the WorkerUtils class.
