### PR TITLE
chore: lint improvements

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,2 @@
+node_modules
+dist

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -2,10 +2,12 @@ module.exports = {
   parser: "@typescript-eslint/parser",
   extends: [
     "eslint:recommended",
+    "plugin:import/errors",
+    "plugin:import/typescript",
+    "prettier",
     "prettier/@typescript-eslint",
-    "plugin:prettier/recommended",
   ],
-  plugins: ["jest", "@typescript-eslint", "prettier"],
+  plugins: ["jest", "@typescript-eslint", "simple-import-sort", "import"],
   parserOptions: {
     ecmaVersion: 2018,
     sourceType: "module",
@@ -13,7 +15,7 @@ module.exports = {
   env: {
     node: true,
     jest: true,
-    es6: true
+    es6: true,
   },
   rules: {
     "@typescript-eslint/no-unused-vars": [
@@ -22,10 +24,10 @@ module.exports = {
         argsIgnorePattern: "^_",
         varsIgnorePattern: "^_",
         args: "after-used",
-        ignoreRestSiblings: true
-      }
+        ignoreRestSiblings: true,
+      },
     ],
-    "curly": "error",
+    curly: "error",
     "no-else-return": 0,
     "no-return-assign": [2, "except-parens"],
     "no-underscore-dangle": 0,
@@ -35,19 +37,30 @@ module.exports = {
     "prefer-arrow-callback": [
       "error",
       {
-        allowNamedFunctions: true
-      }
+        allowNamedFunctions: true,
+      },
     ],
     "class-methods-use-this": 0,
     "no-restricted-syntax": 0,
     "no-param-reassign": [
       "error",
       {
-        props: false
-      }
+        props: false,
+      },
     ],
 
     "arrow-body-style": 0,
     "no-nested-ternary": 0,
-  }
+
+    /*
+     * simple-import-sort seems to be the most stable import sorting currently,
+     * disable others
+     */
+    "simple-import-sort/sort": "error",
+    "sort-imports": "off",
+    "import/order": "off",
+
+    "import/no-deprecated": "warn",
+    "import/no-duplicates": "error",
+  },
 };

--- a/.prettierrc.js
+++ b/.prettierrc.js
@@ -1,3 +1,3 @@
 module.exports = {
-  trailingComma: "es5"
-}
+  trailingComma: "es5",
+};

--- a/__tests__/fixtures/tasksFile_default.js
+++ b/__tests__/fixtures/tasksFile_default.js
@@ -1,4 +1,4 @@
 module.exports.default = {
   t1: () => "come with me",
-  t2: () => "if you want to live"
+  t2: () => "if you want to live",
 };

--- a/__tests__/getTasks.test.ts
+++ b/__tests__/getTasks.test.ts
@@ -1,7 +1,7 @@
-import getTasks from "../src/getTasks";
-import { makeMockJob, withPgClient } from "./helpers";
-import { makeJobHelpers, makeWithPgClientFromClient } from "../src/helpers";
 import { WorkerSharedOptions } from "../src";
+import getTasks from "../src/getTasks";
+import { makeJobHelpers, makeWithPgClientFromClient } from "../src/helpers";
+import { makeMockJob, withPgClient } from "./helpers";
 
 const options: WorkerSharedOptions = {};
 

--- a/__tests__/helpers.ts
+++ b/__tests__/helpers.ts
@@ -1,5 +1,6 @@
 import * as pg from "pg";
-import { Job, WorkerUtils, WorkerPoolOptions } from "../src/interfaces";
+
+import { Job, WorkerPoolOptions, WorkerUtils } from "../src/interfaces";
 import { migrate } from "../src/migrate";
 
 // Sometimes CI's clock can get interrupted (it is shared infra!) so this

--- a/__tests__/main.runTaskList.test.ts
+++ b/__tests__/main.runTaskList.test.ts
@@ -1,16 +1,17 @@
 // See also main.runTaskListOnce.test.ts
-import {
-  reset,
-  withPgPool,
-  sleepUntil,
-  sleep,
-  jobCount,
-  ESCAPED_GRAPHILE_WORKER_SCHEMA,
-} from "./helpers";
-import { TaskList, Task, WorkerSharedOptions } from "../src/interfaces";
-import { runTaskList } from "../src/main";
-import deferred, { Deferred } from "../src/deferred";
 import { Pool } from "pg";
+
+import deferred, { Deferred } from "../src/deferred";
+import { Task, TaskList, WorkerSharedOptions } from "../src/interfaces";
+import { runTaskList } from "../src/main";
+import {
+  ESCAPED_GRAPHILE_WORKER_SCHEMA,
+  jobCount,
+  reset,
+  sleep,
+  sleepUntil,
+  withPgPool,
+} from "./helpers";
 
 const addJob = (pgPool: Pool, id?: string | number) =>
   pgPool.query(

--- a/__tests__/main.runTaskListOnce.test.ts
+++ b/__tests__/main.runTaskListOnce.test.ts
@@ -1,13 +1,13 @@
+import defer, { Deferred } from "../src/deferred";
+import { Task, TaskList, Worker, WorkerSharedOptions } from "../src/interfaces";
+import { runTaskListOnce } from "../src/main";
 import {
-  withPgClient,
+  ESCAPED_GRAPHILE_WORKER_SCHEMA,
+  jobCount,
   reset,
   sleepUntil,
-  jobCount,
-  ESCAPED_GRAPHILE_WORKER_SCHEMA,
+  withPgClient,
 } from "./helpers";
-import { TaskList, Task, Worker, WorkerSharedOptions } from "../src/interfaces";
-import { runTaskListOnce } from "../src/main";
-import defer, { Deferred } from "../src/deferred";
 
 const sleep = (ms: number) => new Promise(resolve => setTimeout(resolve, ms));
 

--- a/__tests__/migrate.test.ts
+++ b/__tests__/migrate.test.ts
@@ -1,10 +1,10 @@
+import { WorkerSharedOptions } from "../src";
 import { migrate } from "../src/migrate";
 import {
-  withPgClient,
   ESCAPED_GRAPHILE_WORKER_SCHEMA,
   GRAPHILE_WORKER_SCHEMA,
+  withPgClient,
 } from "./helpers";
-import { WorkerSharedOptions } from "../src";
 
 const options: WorkerSharedOptions = {};
 

--- a/__tests__/runner.runOnce.test.ts
+++ b/__tests__/runner.runOnce.test.ts
@@ -1,7 +1,8 @@
-import { runOnce } from "../src/runner";
-import { RunnerOptions } from "../src/interfaces";
 import { Pool } from "pg";
-import { withPgPool, TEST_CONNECTION_STRING } from "./helpers";
+
+import { RunnerOptions } from "../src/interfaces";
+import { runOnce } from "../src/runner";
+import { TEST_CONNECTION_STRING, withPgPool } from "./helpers";
 
 async function runOnceErrorAssertion(options: RunnerOptions, message: string) {
   expect.assertions(1);

--- a/__tests__/workerUtils.addJob.test.ts
+++ b/__tests__/workerUtils.addJob.test.ts
@@ -1,16 +1,16 @@
 import {
-  withPgClient,
-  reset,
-  TEST_CONNECTION_STRING,
-  ESCAPED_GRAPHILE_WORKER_SCHEMA,
-} from "./helpers";
-import {
   makeWorkerUtils,
   quickAddJob,
   runTaskListOnce,
   Task,
   WorkerSharedOptions,
 } from "../src/index";
+import {
+  ESCAPED_GRAPHILE_WORKER_SCHEMA,
+  reset,
+  TEST_CONNECTION_STRING,
+  withPgClient,
+} from "./helpers";
 
 const options: WorkerSharedOptions = {};
 

--- a/__tests__/workerUtils.completeJobs.test.ts
+++ b/__tests__/workerUtils.completeJobs.test.ts
@@ -1,11 +1,11 @@
+import { makeWorkerUtils, WorkerSharedOptions } from "../src/index";
 import {
-  withPgClient,
+  ESCAPED_GRAPHILE_WORKER_SCHEMA,
+  makeSelectionOfJobs,
   reset,
   TEST_CONNECTION_STRING,
-  makeSelectionOfJobs,
-  ESCAPED_GRAPHILE_WORKER_SCHEMA,
+  withPgClient,
 } from "./helpers";
-import { makeWorkerUtils, WorkerSharedOptions } from "../src/index";
 
 /** For sorting arrays of numbers or numeric strings */
 function numerically(a: string | number, b: string | number) {

--- a/__tests__/workerUtils.permanentlyFailJobs.test.ts
+++ b/__tests__/workerUtils.permanentlyFailJobs.test.ts
@@ -1,11 +1,11 @@
+import { makeWorkerUtils, WorkerSharedOptions } from "../src/index";
 import {
-  withPgClient,
+  ESCAPED_GRAPHILE_WORKER_SCHEMA,
+  makeSelectionOfJobs,
   reset,
   TEST_CONNECTION_STRING,
-  makeSelectionOfJobs,
-  ESCAPED_GRAPHILE_WORKER_SCHEMA,
+  withPgClient,
 } from "./helpers";
-import { makeWorkerUtils, WorkerSharedOptions } from "../src/index";
 
 /** For sorting arrays of numbers or numeric strings */
 function numerically(a: string | number, b: string | number) {

--- a/__tests__/workerUtils.rescheduleJobs.test.ts
+++ b/__tests__/workerUtils.rescheduleJobs.test.ts
@@ -1,11 +1,11 @@
+import { Job, makeWorkerUtils, WorkerSharedOptions } from "../src/index";
 import {
-  withPgClient,
+  ESCAPED_GRAPHILE_WORKER_SCHEMA,
+  makeSelectionOfJobs,
   reset,
   TEST_CONNECTION_STRING,
-  makeSelectionOfJobs,
-  ESCAPED_GRAPHILE_WORKER_SCHEMA,
+  withPgClient,
 } from "./helpers";
-import { makeWorkerUtils, Job, WorkerSharedOptions } from "../src/index";
 
 /** For sorting arrays of numbers or numeric strings */
 function numerically(a: string | number, b: string | number) {

--- a/examples/README.md
+++ b/examples/README.md
@@ -2,6 +2,6 @@
 
 This directory contains examples of use cases for `graphile-worker`.
 
-* [worker-faktory-exporter](./worker-faktory-exporter): A way of exporting jobs to the [Faktory](https://github.com/contribsys/faktory) work server. 
+- [worker-faktory-exporter](./worker-faktory-exporter): A way of exporting jobs to the [Faktory](https://github.com/contribsys/faktory) work server.
 
-* [worker-cloud-tasks-exporter](./worker-cloud-tasks-exporter): A way of exporting jobs to GCP [Cloud Tasks](https://cloud.google.com/tasks/) task queue.
+- [worker-cloud-tasks-exporter](./worker-cloud-tasks-exporter): A way of exporting jobs to GCP [Cloud Tasks](https://cloud.google.com/tasks/) task queue.

--- a/examples/worker-cloud-tasks-exporter/README.md
+++ b/examples/worker-cloud-tasks-exporter/README.md
@@ -16,8 +16,8 @@ There are several reasons you might want to delegate from Graphile Worker to Clo
 - You will need a GCP project with billing enabled
 - Set up Cloud Tasks following the [official docs](https://googleapis.dev/nodejs/tasks/latest/index.html)
 
-
 ## Install Node dependencies
+
 On your project add Graphile worker and Cloud Tasks client library
 
     yarn add @google-cloud/tasks
@@ -29,32 +29,34 @@ or if you use npm
     npm i graphile-worker
 
 ## Start a Postgres instance
-Make sure your database is running. You can use a locally installed  database, run Postgres on Docker or use Cloud SQL through a proxy. How to set up your database is out of the scope of this tutorial.
+
+Make sure your database is running. You can use a locally installed database, run Postgres on Docker or use Cloud SQL through a proxy. How to set up your database is out of the scope of this tutorial.
 
 ## Create a task file
 
 To create tasks in Cloud Tasks
+
 ```js
 // tasks/cloud-tasks-exporter.js
-const { CloudTasksClient } = require('@google-cloud/tasks')
+const { CloudTasksClient } = require("@google-cloud/tasks");
 
-const client = new CloudTasksClient()
+const client = new CloudTasksClient();
 
 // TODO(developer) configure your queue
-const project = process.env.GOOGLE_CLOUD_TASKS_PROJECT
-const location = process.env.GOOGLE_CLOUD_TASKS_LOCATION
-const queue = process.env.GOOGLE_CLOUD_TASKS_QUEUE
+const project = process.env.GOOGLE_CLOUD_TASKS_PROJECT;
+const location = process.env.GOOGLE_CLOUD_TASKS_LOCATION;
+const queue = process.env.GOOGLE_CLOUD_TASKS_QUEUE;
 
 // Construct the fully qualified queue name.
-const parent = client.queuePath(project, location, queue)
+const parent = client.queuePath(project, location, queue);
 
-async function createTask ({
+async function createTask({
   logger,
   endpoint,
   payload,
   delay,
-  service = 'default',
-  httpMethod = 'POST'
+  service = "default",
+  httpMethod = "POST",
 }) {
   // For details on how to create a Task Object check
   // https://googleapis.dev/nodejs/tasks/latest/google.cloud.tasks.v2beta2.html#.Task
@@ -63,54 +65,55 @@ async function createTask ({
       httpMethod,
       relativeUri: `/${endpoint}`,
       appEngineRouting: {
-        service
-      }
-    }
-  }
+        service,
+      },
+    },
+  };
 
   if (payload) {
-    if (typeof payload === 'object') {
-      payload = JSON.stringify(payload)
+    if (typeof payload === "object") {
+      payload = JSON.stringify(payload);
     }
-    task.appEngineHttpRequest.body = Buffer.from(payload).toString('base64')
+    task.appEngineHttpRequest.body = Buffer.from(payload).toString("base64");
   }
 
   if (delay) {
     // The time when the task is scheduled to be attempted.
     task.scheduleTime = {
-      seconds: delay + Date.now() / 1000
-    }
+      seconds: delay + Date.now() / 1000,
+    };
   }
 
   // Send create task request.
-  logger.info('Sending task')
+  logger.info("Sending task");
 
-  const request = { parent, task }
-  const [response] = await client.createTask(request)
-  const name = response.name
+  const request = { parent, task };
+  const [response] = await client.createTask(request);
+  const name = response.name;
 
-  logger.info(`Created task ${name}`)
+  logger.info(`Created task ${name}`);
 
-  return name
+  return name;
 }
 ```
 
 To run Graphile Worker task
+
 ```js
 // tasks/cloud-tasks-exporter.js
 module.exports = async (payload, { logger }) => {
   logger.info(
     `Delegating task to Cloud Tasks with payload ${JSON.stringify(payload)}`
-  )
+  );
 
   await createTask({
-    endpoint: 'your-task-endpoint',
+    endpoint: "your-task-endpoint",
     payload,
-    logger
-  })
+    logger,
+  });
 
-  logger.info('Done!')
-}
+  logger.info("Done!");
+};
 ```
 
 ## Run the worker and add a job

--- a/examples/worker-cloud-tasks-exporter/tasks/cloud-tasks-exporter.js
+++ b/examples/worker-cloud-tasks-exporter/tasks/cloud-tasks-exporter.js
@@ -1,22 +1,22 @@
-const { CloudTasksClient } = require('@google-cloud/tasks')
+const { CloudTasksClient } = require("@google-cloud/tasks");
 
-const client = new CloudTasksClient()
+const client = new CloudTasksClient();
 
 // TODO(developer) configure your queue
-const project = process.env.GOOGLE_CLOUD_TASKS_PROJECT
-const location = process.env.GOOGLE_CLOUD_TASKS_LOCATION
-const queue = process.env.GOOGLE_CLOUD_TASKS_QUEUE
+const project = process.env.GOOGLE_CLOUD_TASKS_PROJECT;
+const location = process.env.GOOGLE_CLOUD_TASKS_LOCATION;
+const queue = process.env.GOOGLE_CLOUD_TASKS_QUEUE;
 
 // Construct the fully qualified queue name.
-const parent = client.queuePath(project, location, queue)
+const parent = client.queuePath(project, location, queue);
 
-async function createTask ({
+async function createTask({
   logger,
   endpoint,
   payload,
   delay,
-  service = 'default',
-  httpMethod = 'POST'
+  service = "default",
+  httpMethod = "POST",
 }) {
   // For details on how to create a Task Object check
   // https://googleapis.dev/nodejs/tasks/latest/google.cloud.tasks.v2beta2.html#.Task
@@ -25,48 +25,47 @@ async function createTask ({
       httpMethod,
       relativeUri: `/${endpoint}`,
       appEngineRouting: {
-        service
-      }
-    }
-  }
+        service,
+      },
+    },
+  };
 
   if (payload) {
-    if (typeof payload === 'object') {
-      payload = JSON.stringify(payload)
-    }
-    task.appEngineHttpRequest.body = Buffer.from(payload).toString('base64')
+    const toEncode =
+      typeof payload === "object" ? JSON.stringify(payload) : payload;
+    task.appEngineHttpRequest.body = Buffer.from(toEncode).toString("base64");
   }
 
   if (delay) {
     // The time when the task is scheduled to be attempted.
     task.scheduleTime = {
-      seconds: delay + Date.now() / 1000
-    }
+      seconds: delay + Date.now() / 1000,
+    };
   }
 
   // Send create task request.
-  logger.info('Sending task')
+  logger.info("Sending task");
 
-  const request = { parent, task }
-  const [response] = await client.createTask(request)
-  const name = response.name
+  const request = { parent, task };
+  const [response] = await client.createTask(request);
+  const name = response.name;
 
-  logger.info(`Created task ${name}`)
+  logger.info(`Created task ${name}`);
 
-  return name
+  return name;
 }
 
 // Graphile Worker Task
 module.exports = async (payload, { logger }) => {
   logger.info(
     `Delegating task to Cloud Tasks with payload ${JSON.stringify(payload)}`
-  )
+  );
 
   await createTask({
-    endpoint: 'your-task-endpoint',
+    endpoint: "your-task-endpoint",
     payload,
-    logger
-  })
+    logger,
+  });
 
-  logger.info('Done!')
-}
+  logger.info("Done!");
+};

--- a/package.json
+++ b/package.json
@@ -6,8 +6,10 @@
   "scripts": {
     "prepack": "rm -Rf dist && tsc && chmod +x dist/cli.js",
     "watch": "mkdir -p dist && touch dist/cli.js && chmod +x dist/cli.js && tsc --watch",
-    "lint": "eslint 'src/**/*'",
-    "test": "createdb graphile_worker_test || true && psql -X -v GRAPHILE_WORKER_SCHEMA=\"${GRAPHILE_WORKER_SCHEMA:-graphile_worker}\" -v ON_ERROR_STOP=1 -f __tests__/reset-db.sql graphile_worker_test && jest -i",
+    "lint": "yarn prettier:check && eslint --ext .js,.jsx,.ts,.tsx,.graphql .",
+    "lint:fix": "eslint --ext .js,.jsx,.ts,.tsx,.graphql . --fix; prettier --ignore-path .eslintignore --write '**/*.{js,jsx,ts,tsx,graphql,md,json}'",
+    "prettier:check": "prettier --ignore-path .eslintignore --check '**/*.{js,jsx,ts,tsx,graphql,md,json}'",
+    "test": "yarn prepack && depcheck && createdb graphile_worker_test || true && psql -X -v GRAPHILE_WORKER_SCHEMA=\"${GRAPHILE_WORKER_SCHEMA:-graphile_worker}\" -v ON_ERROR_STOP=1 -f __tests__/reset-db.sql graphile_worker_test && jest -i",
     "perfTest": "cd perfTest && node ./run.js"
   },
   "bin": {
@@ -48,10 +50,12 @@
     "@types/jest": "^25.1.1",
     "@typescript-eslint/eslint-plugin": "^2.19.0",
     "@typescript-eslint/parser": "^2.19.0",
+    "depcheck": "^0.9.2",
     "eslint": "^6.8.0",
     "eslint-config-prettier": "^6.10.0",
+    "eslint-plugin-import": "^2.20.1",
     "eslint-plugin-jest": "^23.6.0",
-    "eslint-plugin-prettier": "^3.1.2",
+    "eslint-plugin-simple-import-sort": "^5.0.1",
     "eslint_d": "^8.0.0",
     "jest": "^25.1.0",
     "pg-connection-string": "^2.0.0",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,10 +1,11 @@
 #!/usr/bin/env node
-import getTasks from "./getTasks";
-import { RunnerOptions } from "./interfaces";
-import { run, runOnce } from "./index";
 import * as yargs from "yargs";
-import { runMigrations } from "./runner";
+
 import { defaults } from "./config";
+import getTasks from "./getTasks";
+import { run, runOnce } from "./index";
+import { RunnerOptions } from "./interfaces";
+import { runMigrations } from "./runner";
 
 const argv = yargs
   .option("connection", {

--- a/src/getTasks.ts
+++ b/src/getTasks.ts
@@ -1,15 +1,16 @@
-import { basename } from "path";
 import * as chokidar from "chokidar";
+import { basename } from "path";
+
+import { readdir, tryStat } from "./fs";
 import {
   isValidTask,
+  SharedOptions,
   TaskList,
   WatchedTaskList,
-  SharedOptions,
 } from "./interfaces";
-import { tryStat, readdir } from "./fs";
-import { fauxRequire } from "./module";
-import { Logger } from "./logger";
 import { processSharedOptions } from "./lib";
+import { Logger } from "./logger";
+import { fauxRequire } from "./module";
 
 function validTasks(
   logger: Logger,

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -1,12 +1,13 @@
-import {
-  WithPgClient,
-  Job,
-  TaskSpec,
-  JobHelpers,
-  WorkerSharedOptions,
-  SharedOptions,
-} from "./interfaces";
 import { Pool, PoolClient } from "pg";
+
+import {
+  Job,
+  JobHelpers,
+  SharedOptions,
+  TaskSpec,
+  WithPgClient,
+  WorkerSharedOptions,
+} from "./interfaces";
 import { processSharedOptions } from "./lib";
 import { Logger } from "./logger";
 

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -1,6 +1,7 @@
-import { PoolClient, Pool, QueryResultRow, QueryResult } from "pg";
-import { Logger } from "./logger";
+import { Pool, PoolClient, QueryResult, QueryResultRow } from "pg";
+
 import { Release } from "./lib";
+import { Logger } from "./logger";
 
 /*
  * Terminology:

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -1,15 +1,16 @@
 import * as assert from "assert";
+import { Client, Pool } from "pg";
+
+import { defaults } from "./config";
+import { makeAddJob, makeWithPgClientFromPool } from "./helpers";
 import {
-  SharedOptions,
-  RunnerOptions,
   AddJobFunction,
+  RunnerOptions,
+  SharedOptions,
   WithPgClient,
 } from "./interfaces";
-import { Logger, defaultLogger, LogScope } from "./logger";
-import { Client, Pool } from "pg";
-import { makeWithPgClientFromPool, makeAddJob } from "./helpers";
+import { defaultLogger, Logger, LogScope } from "./logger";
 import { migrate } from "./migrate";
-import { defaults } from "./config";
 
 interface CompiledSharedOptions {
   logger: Logger;

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,24 +1,24 @@
 import { Pool, PoolClient } from "pg";
 import { inspect } from "util";
+
+import { defaults } from "./config";
+import deferred from "./deferred";
 import {
+  makeWithPgClientFromClient,
+  makeWithPgClientFromPool,
+} from "./helpers";
+import {
+  Job,
   TaskList,
   Worker,
-  Job,
-  WorkerPool,
   WorkerOptions,
+  WorkerPool,
   WorkerPoolOptions,
 } from "./interfaces";
-import deferred from "./deferred";
+import { processSharedOptions } from "./lib";
+import { Logger } from "./logger";
 import SIGNALS from "./signals";
 import { makeNewWorker } from "./worker";
-
-import {
-  makeWithPgClientFromPool,
-  makeWithPgClientFromClient,
-} from "./helpers";
-import { defaults } from "./config";
-import { Logger } from "./logger";
-import { processSharedOptions } from "./lib";
 
 const allWorkerPools: Array<WorkerPool> = [];
 

--- a/src/migrate.ts
+++ b/src/migrate.ts
@@ -1,4 +1,5 @@
 import { PoolClient } from "pg";
+
 import { readdir, readFile } from "./fs";
 import { WorkerSharedOptions } from "./interfaces";
 import { processSharedOptions } from "./lib";

--- a/src/module.ts
+++ b/src/module.ts
@@ -1,4 +1,5 @@
 import { dirname } from "path";
+
 import { readFile } from "./fs";
 import _module = require("module");
 const { Module } = _module;

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -1,9 +1,10 @@
 import * as assert from "assert";
+
 import getTasks from "./getTasks";
 import { Runner, RunnerOptions, TaskList } from "./interfaces";
+import { getUtilsAndReleasersFromOptions, Releasers } from "./lib";
 import { runTaskList, runTaskListOnce } from "./main";
 import { migrate } from "./migrate";
-import { getUtilsAndReleasersFromOptions, Releasers } from "./lib";
 
 export const runMigrations = async (options: RunnerOptions): Promise<void> => {
   const { withPgClient, release } = await getUtilsAndReleasersFromOptions(

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -1,16 +1,17 @@
-import {
-  TaskList,
-  Worker,
-  Job,
-  WithPgClient,
-  WorkerOptions,
-} from "./interfaces";
 import * as assert from "assert";
 import { randomBytes } from "crypto";
+
+import { defaults } from "./config";
 import deferred from "./deferred";
 import { makeJobHelpers } from "./helpers";
+import {
+  Job,
+  TaskList,
+  WithPgClient,
+  Worker,
+  WorkerOptions,
+} from "./interfaces";
 import { processSharedOptions } from "./lib";
-import { defaults } from "./config";
 
 export function makeNewWorker(
   options: WorkerOptions,

--- a/src/workerUtils.ts
+++ b/src/workerUtils.ts
@@ -1,4 +1,4 @@
-import { WorkerUtilsOptions, TaskSpec, WorkerUtils, Job } from "./interfaces";
+import { Job, TaskSpec, WorkerUtils, WorkerUtilsOptions } from "./interfaces";
 import { getUtilsAndReleasersFromOptions } from "./lib";
 import { migrate } from "./migrate";
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -91,6 +91,11 @@
   resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.8.4.tgz#d1dbe64691d60358a974295fa53da074dd2ce8e8"
   integrity sha512-0fKu/QqildpXmPVaRBoXOlyBb3MC+J0A66x97qEfLOMkn3u6nfY5esWogQwi/K0BjASYy4DbnsEWnpNL6qT5Mw==
 
+"@babel/parser@^7.7.7":
+  version "7.8.6"
+  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.8.6.tgz#ba5c9910cddb77685a008e3c587af8d27b67962c"
+  integrity sha512-trGNYSfwq5s0SgM1BMEB8hX3NDmO7EP2wsDGDexiaKMB92BaRpS+qZfpkMqUBhcsOTBwNy9B/jieo4ad/t/z2g==
+
 "@babel/plugin-syntax-bigint@^7.0.0":
   version "7.8.3"
   resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-bigint/-/plugin-syntax-bigint-7.8.3.tgz#4c9a6f669f5d0cdf1b90a1671e9a146be5300cea"
@@ -621,10 +626,27 @@ array-equal@^1.0.0:
   resolved "https://registry.yarnpkg.com/array-equal/-/array-equal-1.0.0.tgz#8c2a5ef2472fd9ea742b04c77a75093ba2757c93"
   integrity sha1-jCpe8kcv2ep0KwTHenUJO6J1fJM=
 
+array-includes@^3.0.3:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/array-includes/-/array-includes-3.1.1.tgz#cdd67e6852bdf9c1215460786732255ed2459348"
+  integrity sha512-c2VXaCHl7zPsvpkFsw4nxvFie4fh1ur9bpcgsVkIjqn0H/Xwdg+7fv3n2r/isyS8EBj5b06M9kHyZuIr4El6WQ==
+  dependencies:
+    define-properties "^1.1.3"
+    es-abstract "^1.17.0"
+    is-string "^1.0.5"
+
 array-unique@^0.3.2:
   version "0.3.2"
   resolved "https://registry.yarnpkg.com/array-unique/-/array-unique-0.3.2.tgz#a894b75d4bc4f6cd679ef3244a9fd8f46ae2d428"
   integrity sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=
+
+array.prototype.flat@^1.2.1:
+  version "1.2.3"
+  resolved "https://registry.yarnpkg.com/array.prototype.flat/-/array.prototype.flat-1.2.3.tgz#0de82b426b0318dbfdb940089e38b043d37f6c7b"
+  integrity sha512-gBlRZV0VSmfPIeWfuuy56XZMvbVfbEUnOXUvt3F/eUUUSyzlgLxhEX4YAEpxNAogRGehPSnfXyPtYyKAhkzQhQ==
+  dependencies:
+    define-properties "^1.1.3"
+    es-abstract "^1.17.0-next.1"
 
 asn1@~0.2.3:
   version "0.2.4"
@@ -805,6 +827,11 @@ buffer-writer@2.0.0:
   resolved "https://registry.yarnpkg.com/buffer-writer/-/buffer-writer-2.0.0.tgz#ce7eb81a38f7829db09c873f2fbb792c0c98ec04"
   integrity sha512-a7ZpuTZU1TRtnwyCNW3I5dc0wWNC3VR9S++Ewyk2HHZdrO3CQJqSpd+95Us590V6AL7JqUAH2IwZ/398PmNFgw==
 
+builtin-modules@^3.0.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/builtin-modules/-/builtin-modules-3.1.0.tgz#aad97c15131eb76b65b50ef208e7584cd76a7484"
+  integrity sha512-k0KL0aWZuBt2lrxrcASWDfwOLMnodeQjodT/1SxEQAXsHANgo6ZC/VEaSEHCXt7aSTZ4/4H5LKa+tBXmW7Vtvw==
+
 cache-base@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/cache-base/-/cache-base-1.0.1.tgz#0a7f46416831c8b662ee36fe4e7c59d76f666ab2"
@@ -819,6 +846,25 @@ cache-base@^1.0.1:
     to-object-path "^0.3.0"
     union-value "^1.0.0"
     unset-value "^1.0.0"
+
+caller-callsite@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/caller-callsite/-/caller-callsite-2.0.0.tgz#847e0fce0a223750a9a027c54b33731ad3154134"
+  integrity sha1-hH4PzgoiN1CpoCfFSzNzGtMVQTQ=
+  dependencies:
+    callsites "^2.0.0"
+
+caller-path@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/caller-path/-/caller-path-2.0.0.tgz#468f83044e369ab2010fac5f06ceee15bb2cb1f4"
+  integrity sha1-Ro+DBE42mrIBD6xfBs7uFbsssfQ=
+  dependencies:
+    caller-callsite "^2.0.0"
+
+callsites@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/callsites/-/callsites-2.0.0.tgz#06eb84f00eea413da86affefacbffb36093b3c50"
+  integrity sha1-BuuE8A7qQT2oav/vrL/7Ngk7PFA=
 
 callsites@^3.0.0:
   version "3.1.0"
@@ -979,6 +1025,11 @@ concat-map@0.0.1:
   resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
   integrity sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=
 
+contains-path@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/contains-path/-/contains-path-0.1.0.tgz#fe8cf184ff6670b6baef01a9d4861a5cbec4120a"
+  integrity sha1-/ozxhP9mcLa67wGp1IYaXL7EEgo=
+
 convert-source-map@^1.4.0, convert-source-map@^1.6.0, convert-source-map@^1.7.0:
   version "1.7.0"
   resolved "https://registry.yarnpkg.com/convert-source-map/-/convert-source-map-1.7.0.tgz#17a2cb882d7f77d3490585e2ce6c524424a3a442"
@@ -1002,6 +1053,16 @@ core_d@^1.0.1:
   integrity sha512-Uge+GU4vDha5IEf0PxX/NdBZBMAE69t93OKasRfWlr+tylp5DDhRQSb7QDDFw/EySwgdS0HV9bsN9iFk6SBDHg==
   dependencies:
     supports-color "^5.5.0"
+
+cosmiconfig@^5.2.1:
+  version "5.2.1"
+  resolved "https://registry.yarnpkg.com/cosmiconfig/-/cosmiconfig-5.2.1.tgz#040f726809c591e77a17c0a3626ca45b4f168b1a"
+  integrity sha512-H65gsXo1SKjf8zmrJ67eJk8aIRKV5ff2D4uKZIBZShbhGSpEmsQOPW/SKMKYhSTrqR7ufy6RP69rPogdaPh/kA==
+  dependencies:
+    import-fresh "^2.0.0"
+    is-directory "^0.3.1"
+    js-yaml "^3.13.1"
+    parse-json "^4.0.0"
 
 cosmiconfig@^6.0.0:
   version "6.0.0"
@@ -1067,7 +1128,12 @@ data-urls@^1.1.0:
     whatwg-mimetype "^2.2.0"
     whatwg-url "^7.0.0"
 
-debug@^2.2.0, debug@^2.3.3:
+de-indent@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/de-indent/-/de-indent-1.0.2.tgz#b2038e846dc33baa5796128d0804b455b8c1e21d"
+  integrity sha1-sgOOhG3DO6pXlhKNCAS0VbjB4h0=
+
+debug@^2.2.0, debug@^2.3.3, debug@^2.6.9:
   version "2.6.9"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"
   integrity sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==
@@ -1130,6 +1196,34 @@ delayed-stream@~1.0.0:
   resolved "https://registry.yarnpkg.com/delayed-stream/-/delayed-stream-1.0.0.tgz#df3ae199acadfb7d440aaae0b29e2272b24ec619"
   integrity sha1-3zrhmayt+31ECqrgsp4icrJOxhk=
 
+depcheck@^0.9.2:
+  version "0.9.2"
+  resolved "https://registry.yarnpkg.com/depcheck/-/depcheck-0.9.2.tgz#9e3198b44a527836914c61ba5395479c62ecbaf4"
+  integrity sha512-w5f+lSZqLJJkk58s44eOd0Vor7hLZot4PlFL0y2JsIX5LuHQ2eAjHlDVeGBD4Mj6ZQSKakvKWRRCcPlvrdU2Sg==
+  dependencies:
+    "@babel/parser" "^7.7.7"
+    "@babel/traverse" "^7.7.4"
+    builtin-modules "^3.0.0"
+    camelcase "^5.3.1"
+    cosmiconfig "^5.2.1"
+    debug "^4.1.1"
+    deps-regex "^0.1.4"
+    js-yaml "^3.4.2"
+    lodash "^4.17.15"
+    minimatch "^3.0.2"
+    node-sass-tilde-importer "^1.0.2"
+    please-upgrade-node "^3.2.0"
+    require-package-name "^2.0.1"
+    resolve "^1.14.1"
+    vue-template-compiler "^2.6.11"
+    walkdir "^0.4.1"
+    yargs "^15.0.2"
+
+deps-regex@^0.1.4:
+  version "0.1.4"
+  resolved "https://registry.yarnpkg.com/deps-regex/-/deps-regex-0.1.4.tgz#518667b7691460a5e7e0a341be76eb7ce8090184"
+  integrity sha1-UYZnt2kUYKXn4KNBvnbrfOgJAYQ=
+
 detect-newline@^3.0.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/detect-newline/-/detect-newline-3.1.0.tgz#576f5dfc63ae1a192ff192d8ad3af6308991b651"
@@ -1139,6 +1233,14 @@ diff-sequences@^25.1.0:
   version "25.1.0"
   resolved "https://registry.yarnpkg.com/diff-sequences/-/diff-sequences-25.1.0.tgz#fd29a46f1c913fd66c22645dc75bffbe43051f32"
   integrity sha512-nFIfVk5B/NStCsJ+zaPO4vYuLjlzQ6uFvPxzYyHlejNZ/UGa7G/n7peOXVrVNvRuyfstt+mZQYGpjxg9Z6N8Kw==
+
+doctrine@1.5.0:
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/doctrine/-/doctrine-1.5.0.tgz#379dce730f6166f76cefa4e6707a159b02c5a6fa"
+  integrity sha1-N53Ocw9hZvds76TmcHoVmwLFpvo=
+  dependencies:
+    esutils "^2.0.2"
+    isarray "^1.0.0"
 
 doctrine@^3.0.0:
   version "3.0.0"
@@ -1179,14 +1281,14 @@ end-of-stream@^1.1.0:
   dependencies:
     once "^1.4.0"
 
-error-ex@^1.3.1:
+error-ex@^1.2.0, error-ex@^1.3.1:
   version "1.3.2"
   resolved "https://registry.yarnpkg.com/error-ex/-/error-ex-1.3.2.tgz#b4ac40648107fdcdcfae242f428bea8a14d4f1bf"
   integrity sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==
   dependencies:
     is-arrayish "^0.2.1"
 
-es-abstract@^1.17.0-next.1, es-abstract@^1.17.2:
+es-abstract@^1.17.0, es-abstract@^1.17.0-next.1, es-abstract@^1.17.2:
   version "1.17.4"
   resolved "https://registry.yarnpkg.com/es-abstract/-/es-abstract-1.17.4.tgz#e3aedf19706b20e7c2594c35fc0d57605a79e184"
   integrity sha512-Ae3um/gb8F0mui/jPL+QiqmglkUsaQf7FwBEHYIFkztkneosu9imhqHpBzQ3h1vit8t5iQ74t6PEVvphBZiuiQ==
@@ -1236,6 +1338,40 @@ eslint-config-prettier@^6.10.0:
   dependencies:
     get-stdin "^6.0.0"
 
+eslint-import-resolver-node@^0.3.2:
+  version "0.3.3"
+  resolved "https://registry.yarnpkg.com/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.3.tgz#dbaa52b6b2816b50bc6711af75422de808e98404"
+  integrity sha512-b8crLDo0M5RSe5YG8Pu2DYBj71tSB6OvXkfzwbJU2w7y8P4/yo0MyF8jU26IEuEuHF2K5/gcAJE3LhQGqBBbVg==
+  dependencies:
+    debug "^2.6.9"
+    resolve "^1.13.1"
+
+eslint-module-utils@^2.4.1:
+  version "2.5.2"
+  resolved "https://registry.yarnpkg.com/eslint-module-utils/-/eslint-module-utils-2.5.2.tgz#7878f7504824e1b857dd2505b59a8e5eda26a708"
+  integrity sha512-LGScZ/JSlqGKiT8OC+cYRxseMjyqt6QO54nl281CK93unD89ijSeRV6An8Ci/2nvWVKe8K/Tqdm75RQoIOCr+Q==
+  dependencies:
+    debug "^2.6.9"
+    pkg-dir "^2.0.0"
+
+eslint-plugin-import@^2.20.1:
+  version "2.20.1"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-import/-/eslint-plugin-import-2.20.1.tgz#802423196dcb11d9ce8435a5fc02a6d3b46939b3"
+  integrity sha512-qQHgFOTjguR+LnYRoToeZWT62XM55MBVXObHM6SKFd1VzDcX/vqT1kAz8ssqigh5eMj8qXcRoXXGZpPP6RfdCw==
+  dependencies:
+    array-includes "^3.0.3"
+    array.prototype.flat "^1.2.1"
+    contains-path "^0.1.0"
+    debug "^2.6.9"
+    doctrine "1.5.0"
+    eslint-import-resolver-node "^0.3.2"
+    eslint-module-utils "^2.4.1"
+    has "^1.0.3"
+    minimatch "^3.0.4"
+    object.values "^1.1.0"
+    read-pkg-up "^2.0.0"
+    resolve "^1.12.0"
+
 eslint-plugin-jest@^23.6.0:
   version "23.6.0"
   resolved "https://registry.yarnpkg.com/eslint-plugin-jest/-/eslint-plugin-jest-23.6.0.tgz#508b32f80d44058c8c01257c0ee718cfbd521e9d"
@@ -1244,12 +1380,10 @@ eslint-plugin-jest@^23.6.0:
     "@typescript-eslint/experimental-utils" "^2.5.0"
     micromatch "^4.0.2"
 
-eslint-plugin-prettier@^3.1.2:
-  version "3.1.2"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-prettier/-/eslint-plugin-prettier-3.1.2.tgz#432e5a667666ab84ce72f945c72f77d996a5c9ba"
-  integrity sha512-GlolCC9y3XZfv3RQfwGew7NnuFDKsfI4lbvRK+PIIo23SFH+LemGs4cKwzAaRa+Mdb+lQO/STaIayno8T5sJJA==
-  dependencies:
-    prettier-linter-helpers "^1.0.0"
+eslint-plugin-simple-import-sort@^5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-simple-import-sort/-/eslint-plugin-simple-import-sort-5.0.1.tgz#fd47d3ed2af30db3dd2cadaed285ad510dde479b"
+  integrity sha512-s6Hjp9rcIDYT1h7tuTulblbY7+XQNZK+014uUkNJSKRXEHZO2i7CTr16HOpfgD9HDnUOpl0fwphPsr0oxZqgGg==
 
 eslint-scope@^5.0.0:
   version "5.0.0"
@@ -1485,11 +1619,6 @@ fast-deep-equal@^3.1.1:
   resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-3.1.1.tgz#545145077c501491e33b15ec408c294376e94ae4"
   integrity sha512-8UEa58QDLauDNfpbrX55Q9jrGHThw2ZMdOky5Gl1CDtVeJDPVrG4Jxx1N8jw2gkWaff5UUuX1KJd+9zGe2B+ZA==
 
-fast-diff@^1.1.2:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/fast-diff/-/fast-diff-1.2.0.tgz#73ee11982d86caaf7959828d519cfe927fac5f03"
-  integrity sha512-xJuoT5+L99XlZ8twedaRf6Ax2TgQVxvgZOYoPKqZufmJib0tL2tegPBOZb1pVNgIhlqDlA0eO0c3wBvQcmzx4w==
-
 fast-json-stable-stringify@2.x, fast-json-stable-stringify@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz#874bf69c6f404c2b5d99c481341399fd55892633"
@@ -1537,6 +1666,18 @@ fill-range@^7.0.1:
   integrity sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==
   dependencies:
     to-regex-range "^5.0.1"
+
+find-parent-dir@^0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/find-parent-dir/-/find-parent-dir-0.3.0.tgz#33c44b429ab2b2f0646299c5f9f718f376ff8d54"
+  integrity sha1-M8RLQpqysvBkYpnF+fcY83b/jVQ=
+
+find-up@^2.0.0, find-up@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/find-up/-/find-up-2.1.0.tgz#45d1b7e506c717ddd482775a2b77920a3c0c57a7"
+  integrity sha1-RdG35QbHF93UgndaK3eSCjwMV6c=
+  dependencies:
+    locate-path "^2.0.0"
 
 find-up@^4.0.0, find-up@^4.1.0:
   version "4.1.0"
@@ -1678,7 +1819,7 @@ globals@^12.1.0:
   dependencies:
     type-fest "^0.8.1"
 
-graceful-fs@^4.2.3:
+graceful-fs@^4.1.2, graceful-fs@^4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.3.tgz#4a12ff1b60376ef09862c2093edd908328be8423"
   integrity sha512-a30VEBm4PEdx1dRB7MFK7BejejvCvBronbLjht+sHuGYj8PHs7M/5Z+rt5lw551vZ7yfTCj4Vuyy3mSJytDWRQ==
@@ -1754,6 +1895,16 @@ has@^1.0.3:
   dependencies:
     function-bind "^1.1.1"
 
+he@^1.1.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/he/-/he-1.2.0.tgz#84ae65fa7eafb165fddb61566ae14baf05664f0f"
+  integrity sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==
+
+hosted-git-info@^2.1.4:
+  version "2.8.8"
+  resolved "https://registry.yarnpkg.com/hosted-git-info/-/hosted-git-info-2.8.8.tgz#7539bd4bc1e0e0a895815a2e0262420b12858488"
+  integrity sha512-f/wzC2QaWBs7t9IYqB4T3sR1xviIViXJRJTWBlx2Gf3g0Xi5vI7Yy4koXQ1c9OYDGHN9sBy1DQ2AB8fqZBWhUg==
+
 html-encoding-sniffer@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/html-encoding-sniffer/-/html-encoding-sniffer-1.0.2.tgz#e70d84b94da53aa375e11fe3a351be6642ca46f8"
@@ -1791,6 +1942,14 @@ ignore@^4.0.6:
   version "4.0.6"
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-4.0.6.tgz#750e3db5862087b4737ebac8207ffd1ef27b25fc"
   integrity sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==
+
+import-fresh@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/import-fresh/-/import-fresh-2.0.0.tgz#d81355c15612d386c61f9ddd3922d4304822a546"
+  integrity sha1-2BNVwVYS04bGH53dOSLUMEgipUY=
+  dependencies:
+    caller-path "^2.0.0"
+    resolve-from "^3.0.0"
 
 import-fresh@^3.0.0, import-fresh@^3.1.0:
   version "3.2.1"
@@ -1930,6 +2089,11 @@ is-descriptor@^1.0.0, is-descriptor@^1.0.2:
     is-data-descriptor "^1.0.0"
     kind-of "^6.0.2"
 
+is-directory@^0.3.1:
+  version "0.3.1"
+  resolved "https://registry.yarnpkg.com/is-directory/-/is-directory-0.3.1.tgz#61339b6f2475fc772fd9c9d83f5c8575dc154ae1"
+  integrity sha1-YTObbyR1/Hcv2cnYP1yFddwVSuE=
+
 is-extendable@^0.1.0, is-extendable@^0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/is-extendable/-/is-extendable-0.1.1.tgz#62b110e289a471418e3ec36a617d472e301dfc89"
@@ -2010,6 +2174,11 @@ is-stream@^2.0.0:
   resolved "https://registry.yarnpkg.com/is-stream/-/is-stream-2.0.0.tgz#bde9c32680d6fae04129d6ac9d921ce7815f78e3"
   integrity sha512-XCoy+WlUr7d1+Z8GgSuXmpuUFC9fOhRXglJMx+dwLKTkL44Cjd4W1Z5P+BQZpr+cR93aGP4S/s7Ftw6Nd/kiEw==
 
+is-string@^1.0.5:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/is-string/-/is-string-1.0.5.tgz#40493ed198ef3ff477b8c7f92f644ec82a5cd3a6"
+  integrity sha512-buY6VNRjhQMiF1qWDouloZlQbRhDPCebwxSjxMjxgemYT46YMd2NR0/H+fBhEfWX4A/w9TBJ+ol+okqJKFE6vQ==
+
 is-symbol@^1.0.2:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/is-symbol/-/is-symbol-1.0.3.tgz#38e1014b9e6329be0de9d24a414fd7441ec61937"
@@ -2032,7 +2201,7 @@ is-wsl@^2.1.1:
   resolved "https://registry.yarnpkg.com/is-wsl/-/is-wsl-2.1.1.tgz#4a1c152d429df3d441669498e2486d3596ebaf1d"
   integrity sha512-umZHcSrwlDHo2TGMXv0DZ8dIUGunZ2Iv68YZnrmCiBPkZ4aaOhtv7pXJKeki9k3qJ3RJr0cDyitcl5wEH3AYog==
 
-isarray@1.0.0:
+isarray@1.0.0, isarray@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/isarray/-/isarray-1.0.0.tgz#bb935d48582cba168c06834957a54a3e07124f11"
   integrity sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=
@@ -2456,7 +2625,7 @@ js-tokens@^4.0.0:
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"
   integrity sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==
 
-js-yaml@^3.13.1:
+js-yaml@^3.13.1, js-yaml@^3.4.2:
   version "3.13.1"
   resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.13.1.tgz#aff151b30bfdfa8e49e05da22e7415e9dfa37847"
   integrity sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==
@@ -2595,6 +2764,24 @@ lines-and-columns@^1.1.6:
   resolved "https://registry.yarnpkg.com/lines-and-columns/-/lines-and-columns-1.1.6.tgz#1c00c743b433cd0a4e80758f7b64a57440d9ff00"
   integrity sha1-HADHQ7QzzQpOgHWPe2SldEDZ/wA=
 
+load-json-file@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/load-json-file/-/load-json-file-2.0.0.tgz#7947e42149af80d696cbf797bcaabcfe1fe29ca8"
+  integrity sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=
+  dependencies:
+    graceful-fs "^4.1.2"
+    parse-json "^2.2.0"
+    pify "^2.0.0"
+    strip-bom "^3.0.0"
+
+locate-path@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/locate-path/-/locate-path-2.0.0.tgz#2b568b265eec944c6d9c0de9c3dbbbca0354cd8e"
+  integrity sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=
+  dependencies:
+    p-locate "^2.0.0"
+    path-exists "^3.0.0"
+
 locate-path@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/locate-path/-/locate-path-5.0.0.tgz#1afba396afd676a6d42504d0a67a3a7eb9f62aa0"
@@ -2704,7 +2891,7 @@ mimic-fn@^2.1.0:
   resolved "https://registry.yarnpkg.com/mimic-fn/-/mimic-fn-2.1.0.tgz#7ed2c2ccccaf84d3ffcb7a69b57711fc2083401b"
   integrity sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==
 
-minimatch@^3.0.4:
+minimatch@^3.0.2, minimatch@^3.0.4:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.0.4.tgz#5166e286457f03306064be5497e8dbb0c3d32083"
   integrity sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==
@@ -2804,6 +2991,23 @@ node-notifier@^6.0.0:
     shellwords "^0.1.1"
     which "^1.3.1"
 
+node-sass-tilde-importer@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/node-sass-tilde-importer/-/node-sass-tilde-importer-1.0.2.tgz#1a15105c153f648323b4347693fdb0f331bad1ce"
+  integrity sha512-Swcmr38Y7uB78itQeBm3mThjxBy9/Ah/ykPIaURY/L6Nec9AyRoL/jJ7ECfMR+oZeCTVQNxVMu/aHU+TLRVbdg==
+  dependencies:
+    find-parent-dir "^0.3.0"
+
+normalize-package-data@^2.3.2:
+  version "2.5.0"
+  resolved "https://registry.yarnpkg.com/normalize-package-data/-/normalize-package-data-2.5.0.tgz#e66db1838b200c1dfc233225d12cb36520e234a8"
+  integrity sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==
+  dependencies:
+    hosted-git-info "^2.1.4"
+    resolve "^1.10.0"
+    semver "2 || 3 || 4 || 5"
+    validate-npm-package-license "^3.0.1"
+
 normalize-path@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/normalize-path/-/normalize-path-2.1.1.tgz#1ab28b556e198363a8c1a6f7e6fa20137fe6aed9"
@@ -2891,6 +3095,16 @@ object.pick@^1.3.0:
   dependencies:
     isobject "^3.0.1"
 
+object.values@^1.1.0:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/object.values/-/object.values-1.1.1.tgz#68a99ecde356b7e9295a3c5e0ce31dc8c953de5e"
+  integrity sha512-WTa54g2K8iu0kmS/us18jEmdv1a4Wi//BZ/DTVYEcH0XhLM5NYdpDHja3gt57VrZLcNAO2WGA+KpWsDBaHt6eA==
+  dependencies:
+    define-properties "^1.1.3"
+    es-abstract "^1.17.0-next.1"
+    function-bind "^1.1.1"
+    has "^1.0.3"
+
 once@^1.3.0, once@^1.3.1, once@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/once/-/once-1.4.0.tgz#583b1aa775961d4b113ac17d9c50baef9dd76bd1"
@@ -2937,6 +3151,13 @@ p-finally@^2.0.0:
   resolved "https://registry.yarnpkg.com/p-finally/-/p-finally-2.0.1.tgz#bd6fcaa9c559a096b680806f4d657b3f0f240561"
   integrity sha512-vpm09aKwq6H9phqRQzecoDpD8TmVyGw70qmWlyq5onxY7tqyTTFVvxMykxQSQKILBSFlbXpypIw2T1Ml7+DDtw==
 
+p-limit@^1.1.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/p-limit/-/p-limit-1.3.0.tgz#b86bd5f0c25690911c7590fcbfc2010d54b3ccb8"
+  integrity sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==
+  dependencies:
+    p-try "^1.0.0"
+
 p-limit@^2.2.0:
   version "2.2.2"
   resolved "https://registry.yarnpkg.com/p-limit/-/p-limit-2.2.2.tgz#61279b67721f5287aa1c13a9a7fbbc48c9291b1e"
@@ -2944,12 +3165,24 @@ p-limit@^2.2.0:
   dependencies:
     p-try "^2.0.0"
 
+p-locate@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/p-locate/-/p-locate-2.0.0.tgz#20a0103b222a70c8fd39cc2e580680f3dde5ec43"
+  integrity sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=
+  dependencies:
+    p-limit "^1.1.0"
+
 p-locate@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/p-locate/-/p-locate-4.1.0.tgz#a3428bb7088b3a60292f66919278b7c297ad4f07"
   integrity sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==
   dependencies:
     p-limit "^2.2.0"
+
+p-try@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/p-try/-/p-try-1.0.0.tgz#cbc79cdbaf8fd4228e13f621f2b1a237c1b207b3"
+  integrity sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=
 
 p-try@^2.0.0:
   version "2.2.0"
@@ -2967,6 +3200,21 @@ parent-module@^1.0.0:
   integrity sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==
   dependencies:
     callsites "^3.0.0"
+
+parse-json@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/parse-json/-/parse-json-2.2.0.tgz#f480f40434ef80741f8469099f8dea18f55a4dc9"
+  integrity sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=
+  dependencies:
+    error-ex "^1.2.0"
+
+parse-json@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/parse-json/-/parse-json-4.0.0.tgz#be35f5425be1f7f6c747184f98a788cb99477ee0"
+  integrity sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=
+  dependencies:
+    error-ex "^1.3.1"
+    json-parse-better-errors "^1.0.1"
 
 parse-json@^5.0.0:
   version "5.0.0"
@@ -2987,6 +3235,11 @@ pascalcase@^0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/pascalcase/-/pascalcase-0.1.1.tgz#b363e55e8006ca6fe21784d2db22bd15d7917f14"
   integrity sha1-s2PlXoAGym/iF4TS2yK9FdeRfxQ=
+
+path-exists@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/path-exists/-/path-exists-3.0.0.tgz#ce0ebeaa5f78cb18925ea7d810d7b59b010fd515"
+  integrity sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=
 
 path-exists@^4.0.0:
   version "4.0.0"
@@ -3012,6 +3265,13 @@ path-parse@^1.0.6:
   version "1.0.6"
   resolved "https://registry.yarnpkg.com/path-parse/-/path-parse-1.0.6.tgz#d62dbb5679405d72c4737ec58600e9ddcf06d24c"
   integrity sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==
+
+path-type@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/path-type/-/path-type-2.0.0.tgz#f012ccb8415b7096fc2daa1054c3d72389594c73"
+  integrity sha1-8BLMuEFbcJb8LaoQVMPXI4lZTHM=
+  dependencies:
+    pify "^2.0.0"
 
 path-type@^4.0.0:
   version "4.0.0"
@@ -3085,6 +3345,11 @@ picomatch@^2.0.4, picomatch@^2.0.5, picomatch@^2.0.7:
   resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.2.1.tgz#21bac888b6ed8601f831ce7816e335bc779f0a4a"
   integrity sha512-ISBaA8xQNmwELC7eOjqFKMESB2VIqt4PPDD0nsS95b/9dZXvVKOlz9keMSnoGGKcOHXfTvDD6WMaRoSc9UuhRA==
 
+pify@^2.0.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/pify/-/pify-2.3.0.tgz#ed141a6ac043a849ea588498e7dca8b15330e90c"
+  integrity sha1-7RQaasBDqEnqWISY59yosVMw6Qw=
+
 pirates@^4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/pirates/-/pirates-4.0.1.tgz#643a92caf894566f91b2b986d2c66950a8e2fb87"
@@ -3092,12 +3357,26 @@ pirates@^4.0.1:
   dependencies:
     node-modules-regexp "^1.0.0"
 
+pkg-dir@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/pkg-dir/-/pkg-dir-2.0.0.tgz#f6d5d1109e19d63edf428e0bd57e12777615334b"
+  integrity sha1-9tXREJ4Z1j7fQo4L1X4Sd3YVM0s=
+  dependencies:
+    find-up "^2.1.0"
+
 pkg-dir@^4.2.0:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/pkg-dir/-/pkg-dir-4.2.0.tgz#f099133df7ede422e81d1d8448270eeb3e4261f3"
   integrity sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==
   dependencies:
     find-up "^4.0.0"
+
+please-upgrade-node@^3.2.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/please-upgrade-node/-/please-upgrade-node-3.2.0.tgz#aeddd3f994c933e4ad98b99d9a556efa0e2fe942"
+  integrity sha512-gQR3WpIgNIKwBMVLkpMUeR3e1/E1y42bqDQZfql+kDeXd8COYfM8PQA4X6y7a8u9Ua9FHmsrrmirW2vHs45hWg==
+  dependencies:
+    semver-compare "^1.0.0"
 
 pn@^1.1.0:
   version "1.1.0"
@@ -3135,13 +3414,6 @@ prelude-ls@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.1.2.tgz#21932a549f5e52ffd9a827f570e04be62a97da54"
   integrity sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=
-
-prettier-linter-helpers@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/prettier-linter-helpers/-/prettier-linter-helpers-1.0.0.tgz#d23d41fe1375646de2d0104d3454a3008802cf7b"
-  integrity sha512-GbK2cP9nraSSUF9N2XwUwqfzlAFlMNYYl+ShE/V+H8a9uNl/oUqB1w2EL54Jh0OlyRSd8RfWYJ3coVS4TROP2w==
-  dependencies:
-    fast-diff "^1.1.2"
 
 prettier@^1.19.1:
   version "1.19.1"
@@ -3203,6 +3475,23 @@ react-is@^16.12.0:
   version "16.12.0"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.12.0.tgz#2cc0fe0fba742d97fd527c42a13bec4eeb06241c"
   integrity sha512-rPCkf/mWBtKc97aLL9/txD8DZdemK0vkA3JMLShjlJB3Pj3s+lpf1KaBzMfQrAmhMQB0n1cU/SUGgKKBCe837Q==
+
+read-pkg-up@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/read-pkg-up/-/read-pkg-up-2.0.0.tgz#6b72a8048984e0c41e79510fd5e9fa99b3b549be"
+  integrity sha1-a3KoBImE4MQeeVEP1en6mbO1Sb4=
+  dependencies:
+    find-up "^2.0.0"
+    read-pkg "^2.0.0"
+
+read-pkg@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/read-pkg/-/read-pkg-2.0.0.tgz#8ef1c0623c6a6db0dc6713c4bfac46332b2368f8"
+  integrity sha1-jvHAYjxqbbDcZxPEv6xGMysjaPg=
+  dependencies:
+    load-json-file "^2.0.0"
+    normalize-package-data "^2.3.2"
+    path-type "^2.0.0"
 
 readdirp@~3.3.0:
   version "3.3.0"
@@ -3308,12 +3597,22 @@ require-main-filename@^2.0.0:
   resolved "https://registry.yarnpkg.com/require-main-filename/-/require-main-filename-2.0.0.tgz#d0b329ecc7cc0f61649f62215be69af54aa8989b"
   integrity sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==
 
+require-package-name@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/require-package-name/-/require-package-name-2.0.1.tgz#c11e97276b65b8e2923f75dabf5fb2ef0c3841b9"
+  integrity sha1-wR6XJ2tluOKSP3Xav1+y7ww4Qbk=
+
 resolve-cwd@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/resolve-cwd/-/resolve-cwd-3.0.0.tgz#0f0075f1bb2544766cf73ba6a6e2adfebcb13f2d"
   integrity sha512-OrZaX2Mb+rJCpH/6CpSqt9xFVpN++x01XnN2ie9g6P5/3xelLAkXWVADpdz1IHD/KFfEXyE6V0U01OQ3UO2rEg==
   dependencies:
     resolve-from "^5.0.0"
+
+resolve-from@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/resolve-from/-/resolve-from-3.0.0.tgz#b22c7af7d9d6881bc8b6e653335eebcb0a188748"
+  integrity sha1-six699nWiBvItuZTM17rywoYh0g=
 
 resolve-from@^4.0.0:
   version "4.0.0"
@@ -3339,6 +3638,13 @@ resolve@1.x, resolve@^1.3.2, resolve@^1.8.1:
   version "1.15.0"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.15.0.tgz#1b7ca96073ebb52e741ffd799f6b39ea462c67f5"
   integrity sha512-+hTmAldEGE80U2wJJDC1lebb5jWqvTYAfm3YZ1ckk1gBr0MnCqUKlwK1e+anaFljIl+F5tR5IoZcm4ZDA1zMQw==
+  dependencies:
+    path-parse "^1.0.6"
+
+resolve@^1.10.0, resolve@^1.12.0, resolve@^1.13.1, resolve@^1.14.1:
+  version "1.15.1"
+  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.15.1.tgz#27bdcdeffeaf2d6244b95bb0f9f4b4653451f3e8"
+  integrity sha512-84oo6ZTtoTUpjgNEr5SJyzQhzL72gaRodsSfyxC/AXRvwu0Yse9H8eF9IpGo7b8YetZhlI6v7ZQ6bKBFV/6S7w==
   dependencies:
     path-parse "^1.0.6"
 
@@ -3432,15 +3738,20 @@ saxes@^3.1.9:
   dependencies:
     xmlchars "^2.1.1"
 
+semver-compare@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/semver-compare/-/semver-compare-1.0.0.tgz#0dee216a1c941ab37e9efb1788f6afc5ff5537fc"
+  integrity sha1-De4hahyUGrN+nvsXiPavxf9VN/w=
+
+"semver@2 || 3 || 4 || 5", semver@^5.4.1, semver@^5.5, semver@^5.5.0:
+  version "5.7.1"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-5.7.1.tgz#a954f931aeba508d307bbf069eff0c01c96116f7"
+  integrity sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==
+
 semver@4.3.2:
   version "4.3.2"
   resolved "https://registry.yarnpkg.com/semver/-/semver-4.3.2.tgz#c7a07158a80bedd052355b770d82d6640f803be7"
   integrity sha1-x6BxWKgL7dBSNVt3DYLWZA+AO+c=
-
-semver@^5.4.1, semver@^5.5, semver@^5.5.0:
-  version "5.7.1"
-  resolved "https://registry.yarnpkg.com/semver/-/semver-5.7.1.tgz#a954f931aeba508d307bbf069eff0c01c96116f7"
-  integrity sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==
 
 semver@^6.0.0, semver@^6.1.2, semver@^6.3.0:
   version "6.3.0"
@@ -3589,6 +3900,32 @@ source-map@^0.7.3:
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.7.3.tgz#5302f8169031735226544092e64981f751750383"
   integrity sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ==
 
+spdx-correct@^3.0.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/spdx-correct/-/spdx-correct-3.1.0.tgz#fb83e504445268f154b074e218c87c003cd31df4"
+  integrity sha512-lr2EZCctC2BNR7j7WzJ2FpDznxky1sjfxvvYEyzxNyb6lZXHODmEoJeFu4JupYlkfha1KZpJyoqiJ7pgA1qq8Q==
+  dependencies:
+    spdx-expression-parse "^3.0.0"
+    spdx-license-ids "^3.0.0"
+
+spdx-exceptions@^2.1.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/spdx-exceptions/-/spdx-exceptions-2.2.0.tgz#2ea450aee74f2a89bfb94519c07fcd6f41322977"
+  integrity sha512-2XQACfElKi9SlVb1CYadKDXvoajPgBVPn/gOQLrTvHdElaVhr7ZEbqJaRnJLVNeaI4cMEAgVCeBMKF6MWRDCRA==
+
+spdx-expression-parse@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/spdx-expression-parse/-/spdx-expression-parse-3.0.0.tgz#99e119b7a5da00e05491c9fa338b7904823b41d0"
+  integrity sha512-Yg6D3XpRD4kkOmTpdgbUiEJFKghJH03fiC1OPll5h/0sO6neh2jqRDVHOQ4o/LMea0tgCkbMgea5ip/e+MkWyg==
+  dependencies:
+    spdx-exceptions "^2.1.0"
+    spdx-license-ids "^3.0.0"
+
+spdx-license-ids@^3.0.0:
+  version "3.0.5"
+  resolved "https://registry.yarnpkg.com/spdx-license-ids/-/spdx-license-ids-3.0.5.tgz#3694b5804567a458d3c8045842a6358632f62654"
+  integrity sha512-J+FWzZoynJEXGphVIS+XEh3kFSjZX/1i9gFBaWQcB+/tmpe2qUsSBABpcxqxnAxFdiUFEgAX1bjYGQvIZmoz9Q==
+
 split-string@^3.0.1, split-string@^3.0.2:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/split-string/-/split-string-3.1.0.tgz#7cb09dda3a86585705c64b39a6466038682e8fe2"
@@ -3696,6 +4033,11 @@ strip-ansi@^6.0.0:
   integrity sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==
   dependencies:
     ansi-regex "^5.0.0"
+
+strip-bom@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/strip-bom/-/strip-bom-3.0.0.tgz#2334c18e9c759f7bdd56fdef7e9ae3d588e68ed3"
+  integrity sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=
 
 strip-bom@^4.0.0:
   version "4.0.0"
@@ -4000,6 +4342,14 @@ v8-to-istanbul@^4.0.1:
     convert-source-map "^1.6.0"
     source-map "^0.7.3"
 
+validate-npm-package-license@^3.0.1:
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz#fc91f6b9c7ba15c857f4cb2c5defeec39d4f410a"
+  integrity sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==
+  dependencies:
+    spdx-correct "^3.0.0"
+    spdx-expression-parse "^3.0.0"
+
 verror@1.10.0:
   version "1.10.0"
   resolved "https://registry.yarnpkg.com/verror/-/verror-1.10.0.tgz#3a105ca17053af55d6e270c1f8288682e18da400"
@@ -4008,6 +4358,14 @@ verror@1.10.0:
     assert-plus "^1.0.0"
     core-util-is "1.0.2"
     extsprintf "^1.2.0"
+
+vue-template-compiler@^2.6.11:
+  version "2.6.11"
+  resolved "https://registry.yarnpkg.com/vue-template-compiler/-/vue-template-compiler-2.6.11.tgz#c04704ef8f498b153130018993e56309d4698080"
+  integrity sha512-KIq15bvQDrcCjpGjrAhx4mUlyyHfdmTaoNfeoATHLAiWB+MU3cx4lOzMwrnUh9cCxy0Lt1T11hAFY6TQgroUAA==
+  dependencies:
+    de-indent "^1.0.2"
+    he "^1.1.0"
 
 w3c-hr-time@^1.0.1:
   version "1.0.1"
@@ -4024,6 +4382,11 @@ w3c-xmlserializer@^1.1.2:
     domexception "^1.0.1"
     webidl-conversions "^4.0.2"
     xml-name-validator "^3.0.0"
+
+walkdir@^0.4.1:
+  version "0.4.1"
+  resolved "https://registry.yarnpkg.com/walkdir/-/walkdir-0.4.1.tgz#dc119f83f4421df52e3061e514228a2db20afa39"
+  integrity sha512-3eBwRyEln6E1MSzcxcVpQIhRG8Q1jLvEqRmCZqS3dsfXEDR/AhOF4d+jHg1qvDCpYaVRZjENPQyrVxAkQqxPgQ==
 
 walker@^1.0.7, walker@~1.0.5:
   version "1.0.7"
@@ -4160,7 +4523,7 @@ yargs-parser@^16.1.0:
     camelcase "^5.0.0"
     decamelize "^1.2.0"
 
-yargs@^15.0.0, yargs@^15.1.0:
+yargs@^15.0.0, yargs@^15.0.2, yargs@^15.1.0:
   version "15.1.0"
   resolved "https://registry.yarnpkg.com/yargs/-/yargs-15.1.0.tgz#e111381f5830e863a89550bd4b136bb6a5f37219"
   integrity sha512-T39FNN1b6hCW4SOIk1XyTOWxtXdcen0t+XYrysQmChzSipvhBO8Bj0nK1ozAasdk24dNWuMZvr4k24nz+8HHLg==


### PR DESCRIPTION
- order imports
- lint more files
- don't run prettier inside ESLint
- use `.eslintignore` for both ESLint and Prettier