### PR TITLE
Tweak schema exist check logic

### DIFF
--- a/src/migrate.ts
+++ b/src/migrate.ts
@@ -55,12 +55,12 @@ export async function migrate(
   let latestMigration: number | null = null;
 
   const {
-    rows: [schemaExists],
-  } = await client.query({
-    text: `SELECT EXISTS(SELECT 1 FROM information_schema.schemata WHERE schema_name=$1);`,
-    values: [escapedWorkerSchema],
-  });
-  if (!schemaExists.exists) {
+    rows: [pgNamespace],
+  } = await client.query(
+    `select oid from pg_catalog.pg_namespace where nspname = $1;`,
+    [workerSchema],
+  );
+  if (!pgNamespace) {
     await installSchema(options, client);
   }
 


### PR DESCRIPTION
A small tweak to the way the schema exist checks operates. Instead of assuming the schema exists and catching when it doesn't, this change will execute a `SELECT EXISTS` statement to check existence. The current `try/catch` logic ensures that Postgres will have error output at least once causing confusion for those using this library.

Closes https://github.com/graphile/worker/issues/116