### PR TITLE
docs(README): add note about PostgreSQL schema error

### DIFF
--- a/README.md
+++ b/README.md
@@ -1020,6 +1020,15 @@ If the worker completely dies unexpectedly (e.g. `process.exit()`, segfault,
 available to be processed again automatically. You can free them up earlier than
 this by clearing the `locked_at` and `locked_by` columns on the relevant tables.
 
+If the worker schema has not yet been installed into your database, the following
+error may appear in your PostgreSQL server logs. This is completely harmless and
+should only appear once as the worker will create the schema for you.
+
+```
+ERROR: relation "graphile_worker.migrations" does not exist at character 16
+STATEMENT: select id from "graphile_worker".migrations order by id desc limit 1;
+```
+
 ## Development
 
 ```

--- a/README.md
+++ b/README.md
@@ -1020,9 +1020,10 @@ If the worker completely dies unexpectedly (e.g. `process.exit()`, segfault,
 available to be processed again automatically. You can free them up earlier than
 this by clearing the `locked_at` and `locked_by` columns on the relevant tables.
 
-If the worker schema has not yet been installed into your database, the following
-error may appear in your PostgreSQL server logs. This is completely harmless and
-should only appear once as the worker will create the schema for you.
+If the worker schema has not yet been installed into your database, the
+following error may appear in your PostgreSQL server logs. This is completely
+harmless and should only appear once as the worker will create the schema for
+you.
 
 ```
 ERROR: relation "graphile_worker.migrations" does not exist at character 16


### PR DESCRIPTION
This PR adds a quick note about the error that is output to the Postgres logs when the worker schema does not yet exist.

Discussed with @benjie here: https://github.com/graphile/worker/pull/115#issuecomment-634637412