### PR TITLE
fix(watch): don't cache external modules

### DIFF
--- a/__tests__/fixtures/blah.js
+++ b/__tests__/fixtures/blah.js
@@ -1,0 +1,1 @@
+exports.rand = () => 100 * Math.random();

--- a/__tests__/fixtures/tasks/wouldyoulike.js
+++ b/__tests__/fixtures/tasks/wouldyoulike.js
@@ -1,3 +1,5 @@
+const { rand } = require("../blah");
 module.exports = () => {
+  console.log(rand());
   return "some sausages";
 };

--- a/src/getTasks.ts
+++ b/src/getTasks.ts
@@ -44,9 +44,7 @@ async function loadFileIntoTasks(
   name: string | null = null,
   watch: boolean = false,
 ) {
-  const replacementModule = watch
-    ? await fauxRequire(filename)
-    : require(filename);
+  const replacementModule = watch ? fauxRequire(filename) : require(filename);
 
   if (!replacementModule) {
     throw new Error(`Module '${filename}' doesn't have an export`);

--- a/src/module.ts
+++ b/src/module.ts
@@ -1,6 +1,5 @@
-import { dirname } from "path";
-
 import { readFileSync } from "fs";
+import { dirname } from "path";
 import _module = require("module");
 const { Module } = _module;
 

--- a/src/module.ts
+++ b/src/module.ts
@@ -40,9 +40,13 @@ export function fauxRequire(spec: string) {
   replacementModule.paths = Module._nodeModulePaths(dirname(filename));
   const codeWithWrapper = `\
 const { resolve } = require('path');
+
+const fauxRequire = (path) => global.graphileWorker_fauxRequire(resolve(__dirname, path));
+fauxRequire.resolve = require.resolve;
+
 (function(module, exports, require) {
 ${code};
-})(module, exports, (path) => global.graphileWorker_fauxRequire(resolve(__dirname, path)));
+})(module, exports, fauxRequire);
 `;
   // @ts-ignore
   replacementModule._compile(codeWithWrapper, filename);


### PR DESCRIPTION
Previously in watch mode, if your task were to require an external module, that module would be cached in perpetuity using Node's `require()` cache, so modifications to it would not show up.

This PR changes behaviour so that it is "fauxRequire" all the way down, i.e. if you change the task then it will re-require a fresh version of all its dependencies.

**NOTE**: it does **NOT** watch other files, so you still need to modify the task itself to trigger a reload.

**NOTE**: with this enabled, other modules are **not shared**, so if taskA and taskB each `require('../shared')`, they will each get different instances of that module. This is **only true in watch mode**, so look out for inconsistencies from this.