### PR TITLE
feat(sql): allow avoiding prepared statements

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -8,6 +8,9 @@ import { RunnerOptions } from "./interfaces";
 import { runMigrations } from "./runner";
 
 const argv = yargs
+  .parserConfiguration({
+    "boolean-negation": false,
+  })
   .option("connection", {
     description:
       "Database connection string, defaults to the 'DATABASE_URL' envvar",
@@ -56,10 +59,16 @@ const argv = yargs
     default: defaults.pollInterval,
   })
   .number("poll-interval")
+  .option("no-prepared-statements", {
+    description:
+      "set this flag if you want to disable prepared statements, e.g. for compatibility with pgBouncer",
+    default: false,
+  })
+  .boolean("no-prepared-statements")
   .strict(true).argv;
 
 if (argv._.length > 0) {
-  console.error(`Unrecognised additional arguments: '${argv._.join("', '")}'`);
+  console.error(`Unrecognized additional arguments: '${argv._.join("', '")}'`);
   console.error();
   yargs.showHelp();
   process.exit(1);
@@ -102,6 +111,7 @@ async function main() {
       ? argv["poll-interval"]
       : defaults.pollInterval,
     connectionString: DATABASE_URL,
+    noPreparedStatements: !!argv["no-prepared-statements"],
   };
 
   if (SCHEMA_ONLY) {

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -254,6 +254,12 @@ export interface SharedOptions {
    * A pg.Pool instance to use instead of the `connectionString`
    */
   pgPool?: Pool;
+
+  /**
+   * Set true if you want to prevent the use of prepared statements; for
+   * example if you wish to use Graphile Worker with pgBouncer or similar.
+   */
+  noPreparedStatements?: boolean;
 }
 
 /**

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -22,6 +22,7 @@ export function makeNewWorker(
   const {
     workerId = `worker-${randomBytes(9).toString("hex")}`,
     pollInterval = defaults.pollInterval,
+    noPreparedStatements,
   } = options;
   const {
     workerSchema,
@@ -85,7 +86,7 @@ export function makeNewWorker(
             // `SELECT id, queue_name, task_identifier, payload FROM ${escapedWorkerSchema}.get_job($1, $2);`,
             `SELECT * FROM ${escapedWorkerSchema}.get_job($1, $2);`,
           values: [workerId, supportedTaskNames],
-          name: `get_job/${workerSchema}`,
+          name: noPreparedStatements ? undefined : `get_job/${workerSchema}`,
         }),
       );
 
@@ -191,7 +192,7 @@ export function makeNewWorker(
           client.query({
             text: `SELECT FROM ${escapedWorkerSchema}.fail_job($1, $2, $3);`,
             values: [workerId, job.id, message],
-            name: `fail_job/${workerSchema}`,
+            name: noPreparedStatements ? undefined : `fail_job/${workerSchema}`,
           }),
         );
       } else {
@@ -208,7 +209,9 @@ export function makeNewWorker(
           client.query({
             text: `SELECT FROM ${escapedWorkerSchema}.complete_job($1, $2);`,
             values: [workerId, job.id],
-            name: `complete_job/${workerSchema}`,
+            name: noPreparedStatements
+              ? undefined
+              : `complete_job/${workerSchema}`,
           }),
         );
       }


### PR DESCRIPTION
From pgBouncer FAQ:

> ## How to use prepared statements with transaction pooling?
> To make prepared statements work in this mode would need PgBouncer to keep track of them internally, which it does not do. So only way to keep using PgBouncer in this mode is to disable prepared statements in the client.

Passing flag `--no-prepared-statements` or option `noPreparedStatements: true` will prevent Graphile Worker using prepared statements, for compatibility with pgBouncer and other software.

Fixes #119