### PR TITLE
chore: track schema changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,4 +104,5 @@ jobs:
       - name: "Check schema hasn't changed"
         run: |
           yarn db:dump
+          git update-index -q --refresh
           git diff-index --quiet HEAD -- || (git diff && echo "^^^ The database schema has changed, please run 'yarn db:dump'" && exit 1)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,6 +94,7 @@ jobs:
         uses: actions/setup-node@v1
         with:
           node-version: 12.x
+      - run: yarn --frozen-lockfile
       - name: Install pg_dump
         run: |
           sudo bash -c "echo deb http://apt.postgresql.org/pub/repos/apt/ bionic-pgdg main >> /etc/apt/sources.list.d/pgdg.list"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,3 +70,37 @@ jobs:
       - run: yarn --frozen-lockfile
       - run: yarn lint
       - run: yarn jest -i --ci
+
+  database_updated:
+    runs-on: ubuntu-18.04
+
+    services:
+      postgres:
+        image: postgres:11
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: graphile_worker_test
+        ports:
+          - "0.0.0.0:5432:5432"
+        # needed because the postgres container does not provide a healthcheck
+        options:
+          --health-cmd pg_isready --health-interval 10s --health-timeout 5s
+          --health-retries 5
+
+    steps:
+      - uses: actions/checkout@v1
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v1
+        with:
+          node-version: 12.x
+      - name: Install pg_dump
+        run: |
+          sudo bash -c "echo deb http://apt.postgresql.org/pub/repos/apt/ bionic-pgdg main >> /etc/apt/sources.list.d/pgdg.list"
+          wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo apt-key add -
+          sudo apt-get update
+          sudo apt-get -yqq install postgresql-client-11
+      - name: "Check schema hasn't changed"
+        run: |
+          yarn db:dump
+          git diff-index --quiet HEAD -- || (git diff && echo "^^^ The database schema has changed, please run 'yarn db:dump'" && exit 1)

--- a/__tests__/schema.sql
+++ b/__tests__/schema.sql
@@ -1,0 +1,364 @@
+SET statement_timeout = 0;
+SET lock_timeout = 0;
+SET idle_in_transaction_session_timeout = 0;
+SET client_encoding = 'UTF8';
+SET standard_conforming_strings = on;
+SELECT pg_catalog.set_config('search_path', '', false);
+SET check_function_bodies = false;
+SET xmloption = content;
+SET client_min_messages = warning;
+SET row_security = off;
+CREATE SCHEMA graphile_worker;
+ALTER SCHEMA graphile_worker OWNER TO benjie;
+CREATE EXTENSION IF NOT EXISTS pgcrypto WITH SCHEMA public;
+COMMENT ON EXTENSION pgcrypto IS 'cryptographic functions';
+SET default_tablespace = '';
+SET default_with_oids = false;
+CREATE TABLE graphile_worker.jobs (
+    id bigint NOT NULL,
+    queue_name text DEFAULT (public.gen_random_uuid())::text,
+    task_identifier text NOT NULL,
+    payload json DEFAULT '{}'::json NOT NULL,
+    priority integer DEFAULT 0 NOT NULL,
+    run_at timestamp with time zone DEFAULT now() NOT NULL,
+    attempts integer DEFAULT 0 NOT NULL,
+    max_attempts integer DEFAULT 25 NOT NULL,
+    last_error text,
+    created_at timestamp with time zone DEFAULT now() NOT NULL,
+    updated_at timestamp with time zone DEFAULT now() NOT NULL,
+    key text,
+    locked_at timestamp with time zone,
+    locked_by text,
+    revision integer DEFAULT 0 NOT NULL,
+    CONSTRAINT jobs_key_check CHECK ((length(key) > 0))
+);
+ALTER TABLE graphile_worker.jobs OWNER TO benjie;
+CREATE FUNCTION graphile_worker.add_job(identifier text, payload json DEFAULT NULL::json, queue_name text DEFAULT NULL::text, run_at timestamp with time zone DEFAULT NULL::timestamp with time zone, max_attempts integer DEFAULT NULL::integer, job_key text DEFAULT NULL::text, priority integer DEFAULT NULL::integer) RETURNS graphile_worker.jobs
+    LANGUAGE plpgsql
+    AS $$
+declare
+  v_job "graphile_worker".jobs;
+begin
+  -- Apply rationality checks
+  if length(identifier) > 128 then
+    raise exception 'Task identifier is too long (max length: 128).' using errcode = 'GWBID';
+  end if;
+  if queue_name is not null and length(queue_name) > 128 then
+    raise exception 'Job queue name is too long (max length: 128).' using errcode = 'GWBQN';
+  end if;
+  if job_key is not null and length(job_key) > 512 then
+    raise exception 'Job key is too long (max length: 512).' using errcode = 'GWBJK';
+  end if;
+  if max_attempts < 1 then
+    raise exception 'Job maximum attempts must be at least 1' using errcode = 'GWBMA';
+  end if;
+  if job_key is not null then
+    -- Upsert job
+    insert into "graphile_worker".jobs (
+      task_identifier,
+      payload,
+      queue_name,
+      run_at,
+      max_attempts,
+      key,
+      priority
+    )
+      values(
+        identifier,
+        coalesce(payload, '{}'::json),
+        queue_name,
+        coalesce(run_at, now()),
+        coalesce(max_attempts, 25),
+        job_key,
+        coalesce(priority, 0)
+      )
+      on conflict (key) do update set
+        task_identifier=excluded.task_identifier,
+        payload=excluded.payload,
+        queue_name=excluded.queue_name,
+        max_attempts=excluded.max_attempts,
+        run_at=excluded.run_at,
+        priority=excluded.priority,
+        revision=jobs.revision + 1,
+        -- always reset error/retry state
+        attempts=0,
+        last_error=null
+      where jobs.locked_at is null
+      returning *
+      into v_job;
+    -- If upsert succeeded (insert or update), return early
+    if not (v_job is null) then
+      return v_job;
+    end if;
+    -- Upsert failed -> there must be an existing job that is locked. Remove
+    -- existing key to allow a new one to be inserted, and prevent any
+    -- subsequent retries by bumping attempts to the max allowed.
+    update "graphile_worker".jobs
+      set
+        key = null,
+        attempts = jobs.max_attempts
+      where key = job_key;
+  end if;
+  -- insert the new job. Assume no conflicts due to the update above
+  insert into "graphile_worker".jobs(
+    task_identifier,
+    payload,
+    queue_name,
+    run_at,
+    max_attempts,
+    key,
+    priority
+  )
+    values(
+      identifier,
+      coalesce(payload, '{}'::json),
+      queue_name,
+      coalesce(run_at, now()),
+      coalesce(max_attempts, 25),
+      job_key,
+      coalesce(priority, 0)
+    )
+    returning *
+    into v_job;
+  return v_job;
+end;
+$$;
+ALTER FUNCTION graphile_worker.add_job(identifier text, payload json, queue_name text, run_at timestamp with time zone, max_attempts integer, job_key text, priority integer) OWNER TO benjie;
+CREATE FUNCTION graphile_worker.complete_job(worker_id text, job_id bigint) RETURNS graphile_worker.jobs
+    LANGUAGE plpgsql
+    AS $$
+declare
+  v_row "graphile_worker".jobs;
+begin
+  delete from "graphile_worker".jobs
+    where id = job_id
+    returning * into v_row;
+  if v_row.queue_name is not null then
+    update "graphile_worker".job_queues
+      set locked_by = null, locked_at = null
+      where queue_name = v_row.queue_name and locked_by = worker_id;
+  end if;
+  return v_row;
+end;
+$$;
+ALTER FUNCTION graphile_worker.complete_job(worker_id text, job_id bigint) OWNER TO benjie;
+CREATE FUNCTION graphile_worker.complete_jobs(job_ids bigint[]) RETURNS SETOF graphile_worker.jobs
+    LANGUAGE sql
+    AS $$
+  delete from "graphile_worker".jobs
+    where id = any(job_ids)
+    and (
+      locked_by is null
+    or
+      locked_at < NOW() - interval '4 hours'
+    )
+    returning *;
+$$;
+ALTER FUNCTION graphile_worker.complete_jobs(job_ids bigint[]) OWNER TO benjie;
+CREATE FUNCTION graphile_worker.fail_job(worker_id text, job_id bigint, error_message text) RETURNS graphile_worker.jobs
+    LANGUAGE plpgsql STRICT
+    AS $$
+declare
+  v_row "graphile_worker".jobs;
+begin
+  update "graphile_worker".jobs
+    set
+      last_error = error_message,
+      run_at = greatest(now(), run_at) + (exp(least(attempts, 10))::text || ' seconds')::interval,
+      locked_by = null,
+      locked_at = null
+    where id = job_id and locked_by = worker_id
+    returning * into v_row;
+  if v_row.queue_name is not null then
+    update "graphile_worker".job_queues
+      set locked_by = null, locked_at = null
+      where queue_name = v_row.queue_name and locked_by = worker_id;
+  end if;
+  return v_row;
+end;
+$$;
+ALTER FUNCTION graphile_worker.fail_job(worker_id text, job_id bigint, error_message text) OWNER TO benjie;
+CREATE FUNCTION graphile_worker.get_job(worker_id text, task_identifiers text[] DEFAULT NULL::text[], job_expiry interval DEFAULT '04:00:00'::interval) RETURNS graphile_worker.jobs
+    LANGUAGE plpgsql
+    AS $$
+declare
+  v_job_id bigint;
+  v_queue_name text;
+  v_row "graphile_worker".jobs;
+  v_now timestamptz = now();
+begin
+  if worker_id is null or length(worker_id) < 10 then
+    raise exception 'invalid worker id';
+  end if;
+  select jobs.queue_name, jobs.id into v_queue_name, v_job_id
+    from "graphile_worker".jobs
+    where (jobs.locked_at is null or jobs.locked_at < (v_now - job_expiry))
+    and (
+      jobs.queue_name is null
+    or
+      exists (
+        select 1
+        from "graphile_worker".job_queues
+        where job_queues.queue_name = jobs.queue_name
+        and (job_queues.locked_at is null or job_queues.locked_at < (v_now - job_expiry))
+        for update
+        skip locked
+      )
+    )
+    and run_at <= v_now
+    and attempts < max_attempts
+    and (task_identifiers is null or task_identifier = any(task_identifiers))
+    order by priority asc, run_at asc, id asc
+    limit 1
+    for update
+    skip locked;
+  if v_job_id is null then
+    return null;
+  end if;
+  if v_queue_name is not null then
+    update "graphile_worker".job_queues
+      set
+        locked_by = worker_id,
+        locked_at = v_now
+      where job_queues.queue_name = v_queue_name;
+  end if;
+  update "graphile_worker".jobs
+    set
+      attempts = attempts + 1,
+      locked_by = worker_id,
+      locked_at = v_now
+    where id = v_job_id
+    returning * into v_row;
+  return v_row;
+end;
+$$;
+ALTER FUNCTION graphile_worker.get_job(worker_id text, task_identifiers text[], job_expiry interval) OWNER TO benjie;
+CREATE FUNCTION graphile_worker.jobs__decrease_job_queue_count() RETURNS trigger
+    LANGUAGE plpgsql
+    AS $$
+declare
+  v_new_job_count int;
+begin
+  update "graphile_worker".job_queues
+    set job_count = job_queues.job_count - 1
+    where queue_name = old.queue_name
+    returning job_count into v_new_job_count;
+  if v_new_job_count <= 0 then
+    delete from "graphile_worker".job_queues where queue_name = old.queue_name and job_count <= 0;
+  end if;
+  return old;
+end;
+$$;
+ALTER FUNCTION graphile_worker.jobs__decrease_job_queue_count() OWNER TO benjie;
+CREATE FUNCTION graphile_worker.jobs__increase_job_queue_count() RETURNS trigger
+    LANGUAGE plpgsql
+    AS $$
+begin
+  insert into "graphile_worker".job_queues(queue_name, job_count)
+    values(new.queue_name, 1)
+    on conflict (queue_name)
+    do update
+    set job_count = job_queues.job_count + 1;
+  return new;
+end;
+$$;
+ALTER FUNCTION graphile_worker.jobs__increase_job_queue_count() OWNER TO benjie;
+CREATE FUNCTION graphile_worker.permanently_fail_jobs(job_ids bigint[], error_message text DEFAULT NULL::text) RETURNS SETOF graphile_worker.jobs
+    LANGUAGE sql
+    AS $$
+  update "graphile_worker".jobs
+    set
+      last_error = coalesce(error_message, 'Manually marked as failed'),
+      attempts = max_attempts
+    where id = any(job_ids)
+    and (
+      locked_by is null
+    or
+      locked_at < NOW() - interval '4 hours'
+    )
+    returning *;
+$$;
+ALTER FUNCTION graphile_worker.permanently_fail_jobs(job_ids bigint[], error_message text) OWNER TO benjie;
+CREATE FUNCTION graphile_worker.remove_job(job_key text) RETURNS graphile_worker.jobs
+    LANGUAGE sql STRICT
+    AS $$
+  delete from "graphile_worker".jobs
+    where key = job_key
+    and locked_at is null
+  returning *;
+$$;
+ALTER FUNCTION graphile_worker.remove_job(job_key text) OWNER TO benjie;
+CREATE FUNCTION graphile_worker.reschedule_jobs(job_ids bigint[], run_at timestamp with time zone DEFAULT NULL::timestamp with time zone, priority integer DEFAULT NULL::integer, attempts integer DEFAULT NULL::integer, max_attempts integer DEFAULT NULL::integer) RETURNS SETOF graphile_worker.jobs
+    LANGUAGE sql
+    AS $$
+  update "graphile_worker".jobs
+    set
+      run_at = coalesce(reschedule_jobs.run_at, jobs.run_at),
+      priority = coalesce(reschedule_jobs.priority, jobs.priority),
+      attempts = coalesce(reschedule_jobs.attempts, jobs.attempts),
+      max_attempts = coalesce(reschedule_jobs.max_attempts, jobs.max_attempts)
+    where id = any(job_ids)
+    and (
+      locked_by is null
+    or
+      locked_at < NOW() - interval '4 hours'
+    )
+    returning *;
+$$;
+ALTER FUNCTION graphile_worker.reschedule_jobs(job_ids bigint[], run_at timestamp with time zone, priority integer, attempts integer, max_attempts integer) OWNER TO benjie;
+CREATE FUNCTION graphile_worker.tg__update_timestamp() RETURNS trigger
+    LANGUAGE plpgsql
+    AS $$
+begin
+  new.updated_at = greatest(now(), old.updated_at + interval '1 millisecond');
+  return new;
+end;
+$$;
+ALTER FUNCTION graphile_worker.tg__update_timestamp() OWNER TO benjie;
+CREATE FUNCTION graphile_worker.tg_jobs__notify_new_jobs() RETURNS trigger
+    LANGUAGE plpgsql
+    AS $$
+begin
+  perform pg_notify('jobs:insert', '');
+  return new;
+end;
+$$;
+ALTER FUNCTION graphile_worker.tg_jobs__notify_new_jobs() OWNER TO benjie;
+CREATE TABLE graphile_worker.job_queues (
+    queue_name text NOT NULL,
+    job_count integer NOT NULL,
+    locked_at timestamp with time zone,
+    locked_by text
+);
+ALTER TABLE graphile_worker.job_queues OWNER TO benjie;
+CREATE SEQUENCE graphile_worker.jobs_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+ALTER TABLE graphile_worker.jobs_id_seq OWNER TO benjie;
+ALTER SEQUENCE graphile_worker.jobs_id_seq OWNED BY graphile_worker.jobs.id;
+CREATE TABLE graphile_worker.migrations (
+    id integer NOT NULL,
+    ts timestamp with time zone DEFAULT now() NOT NULL
+);
+ALTER TABLE graphile_worker.migrations OWNER TO benjie;
+ALTER TABLE ONLY graphile_worker.jobs ALTER COLUMN id SET DEFAULT nextval('graphile_worker.jobs_id_seq'::regclass);
+ALTER TABLE ONLY graphile_worker.job_queues
+    ADD CONSTRAINT job_queues_pkey PRIMARY KEY (queue_name);
+ALTER TABLE ONLY graphile_worker.jobs
+    ADD CONSTRAINT jobs_key_key UNIQUE (key);
+ALTER TABLE ONLY graphile_worker.jobs
+    ADD CONSTRAINT jobs_pkey PRIMARY KEY (id);
+ALTER TABLE ONLY graphile_worker.migrations
+    ADD CONSTRAINT migrations_pkey PRIMARY KEY (id);
+CREATE INDEX jobs_priority_run_at_id_idx ON graphile_worker.jobs USING btree (priority, run_at, id);
+CREATE TRIGGER _100_timestamps BEFORE UPDATE ON graphile_worker.jobs FOR EACH ROW EXECUTE PROCEDURE graphile_worker.tg__update_timestamp();
+CREATE TRIGGER _500_decrease_job_queue_count AFTER DELETE ON graphile_worker.jobs FOR EACH ROW WHEN ((old.queue_name IS NOT NULL)) EXECUTE PROCEDURE graphile_worker.jobs__decrease_job_queue_count();
+CREATE TRIGGER _500_decrease_job_queue_count_update AFTER UPDATE OF queue_name ON graphile_worker.jobs FOR EACH ROW WHEN (((new.queue_name IS DISTINCT FROM old.queue_name) AND (old.queue_name IS NOT NULL))) EXECUTE PROCEDURE graphile_worker.jobs__decrease_job_queue_count();
+CREATE TRIGGER _500_increase_job_queue_count AFTER INSERT ON graphile_worker.jobs FOR EACH ROW WHEN ((new.queue_name IS NOT NULL)) EXECUTE PROCEDURE graphile_worker.jobs__increase_job_queue_count();
+CREATE TRIGGER _500_increase_job_queue_count_update AFTER UPDATE OF queue_name ON graphile_worker.jobs FOR EACH ROW WHEN (((new.queue_name IS DISTINCT FROM old.queue_name) AND (new.queue_name IS NOT NULL))) EXECUTE PROCEDURE graphile_worker.jobs__increase_job_queue_count();
+CREATE TRIGGER _900_notify_worker AFTER INSERT ON graphile_worker.jobs FOR EACH STATEMENT EXECUTE PROCEDURE graphile_worker.tg_jobs__notify_new_jobs();
+ALTER TABLE graphile_worker.job_queues ENABLE ROW LEVEL SECURITY;
+ALTER TABLE graphile_worker.jobs ENABLE ROW LEVEL SECURITY;

--- a/__tests__/schema.sql
+++ b/__tests__/schema.sql
@@ -9,7 +9,7 @@ SET xmloption = content;
 SET client_min_messages = warning;
 SET row_security = off;
 CREATE SCHEMA graphile_worker;
-ALTER SCHEMA graphile_worker OWNER TO benjie;
+ALTER SCHEMA graphile_worker OWNER TO postgres;
 CREATE EXTENSION IF NOT EXISTS pgcrypto WITH SCHEMA public;
 COMMENT ON EXTENSION pgcrypto IS 'cryptographic functions';
 SET default_tablespace = '';
@@ -32,7 +32,7 @@ CREATE TABLE graphile_worker.jobs (
     revision integer DEFAULT 0 NOT NULL,
     CONSTRAINT jobs_key_check CHECK ((length(key) > 0))
 );
-ALTER TABLE graphile_worker.jobs OWNER TO benjie;
+ALTER TABLE graphile_worker.jobs OWNER TO postgres;
 CREATE FUNCTION graphile_worker.add_job(identifier text, payload json DEFAULT NULL::json, queue_name text DEFAULT NULL::text, run_at timestamp with time zone DEFAULT NULL::timestamp with time zone, max_attempts integer DEFAULT NULL::integer, job_key text DEFAULT NULL::text, priority integer DEFAULT NULL::integer) RETURNS graphile_worker.jobs
     LANGUAGE plpgsql
     AS $$
@@ -123,7 +123,7 @@ begin
   return v_job;
 end;
 $$;
-ALTER FUNCTION graphile_worker.add_job(identifier text, payload json, queue_name text, run_at timestamp with time zone, max_attempts integer, job_key text, priority integer) OWNER TO benjie;
+ALTER FUNCTION graphile_worker.add_job(identifier text, payload json, queue_name text, run_at timestamp with time zone, max_attempts integer, job_key text, priority integer) OWNER TO postgres;
 CREATE FUNCTION graphile_worker.complete_job(worker_id text, job_id bigint) RETURNS graphile_worker.jobs
     LANGUAGE plpgsql
     AS $$
@@ -141,7 +141,7 @@ begin
   return v_row;
 end;
 $$;
-ALTER FUNCTION graphile_worker.complete_job(worker_id text, job_id bigint) OWNER TO benjie;
+ALTER FUNCTION graphile_worker.complete_job(worker_id text, job_id bigint) OWNER TO postgres;
 CREATE FUNCTION graphile_worker.complete_jobs(job_ids bigint[]) RETURNS SETOF graphile_worker.jobs
     LANGUAGE sql
     AS $$
@@ -154,7 +154,7 @@ CREATE FUNCTION graphile_worker.complete_jobs(job_ids bigint[]) RETURNS SETOF gr
     )
     returning *;
 $$;
-ALTER FUNCTION graphile_worker.complete_jobs(job_ids bigint[]) OWNER TO benjie;
+ALTER FUNCTION graphile_worker.complete_jobs(job_ids bigint[]) OWNER TO postgres;
 CREATE FUNCTION graphile_worker.fail_job(worker_id text, job_id bigint, error_message text) RETURNS graphile_worker.jobs
     LANGUAGE plpgsql STRICT
     AS $$
@@ -177,7 +177,7 @@ begin
   return v_row;
 end;
 $$;
-ALTER FUNCTION graphile_worker.fail_job(worker_id text, job_id bigint, error_message text) OWNER TO benjie;
+ALTER FUNCTION graphile_worker.fail_job(worker_id text, job_id bigint, error_message text) OWNER TO postgres;
 CREATE FUNCTION graphile_worker.get_job(worker_id text, task_identifiers text[] DEFAULT NULL::text[], job_expiry interval DEFAULT '04:00:00'::interval) RETURNS graphile_worker.jobs
     LANGUAGE plpgsql
     AS $$
@@ -232,7 +232,7 @@ begin
   return v_row;
 end;
 $$;
-ALTER FUNCTION graphile_worker.get_job(worker_id text, task_identifiers text[], job_expiry interval) OWNER TO benjie;
+ALTER FUNCTION graphile_worker.get_job(worker_id text, task_identifiers text[], job_expiry interval) OWNER TO postgres;
 CREATE FUNCTION graphile_worker.jobs__decrease_job_queue_count() RETURNS trigger
     LANGUAGE plpgsql
     AS $$
@@ -249,7 +249,7 @@ begin
   return old;
 end;
 $$;
-ALTER FUNCTION graphile_worker.jobs__decrease_job_queue_count() OWNER TO benjie;
+ALTER FUNCTION graphile_worker.jobs__decrease_job_queue_count() OWNER TO postgres;
 CREATE FUNCTION graphile_worker.jobs__increase_job_queue_count() RETURNS trigger
     LANGUAGE plpgsql
     AS $$
@@ -262,7 +262,7 @@ begin
   return new;
 end;
 $$;
-ALTER FUNCTION graphile_worker.jobs__increase_job_queue_count() OWNER TO benjie;
+ALTER FUNCTION graphile_worker.jobs__increase_job_queue_count() OWNER TO postgres;
 CREATE FUNCTION graphile_worker.permanently_fail_jobs(job_ids bigint[], error_message text DEFAULT NULL::text) RETURNS SETOF graphile_worker.jobs
     LANGUAGE sql
     AS $$
@@ -278,7 +278,7 @@ CREATE FUNCTION graphile_worker.permanently_fail_jobs(job_ids bigint[], error_me
     )
     returning *;
 $$;
-ALTER FUNCTION graphile_worker.permanently_fail_jobs(job_ids bigint[], error_message text) OWNER TO benjie;
+ALTER FUNCTION graphile_worker.permanently_fail_jobs(job_ids bigint[], error_message text) OWNER TO postgres;
 CREATE FUNCTION graphile_worker.remove_job(job_key text) RETURNS graphile_worker.jobs
     LANGUAGE sql STRICT
     AS $$
@@ -287,7 +287,7 @@ CREATE FUNCTION graphile_worker.remove_job(job_key text) RETURNS graphile_worker
     and locked_at is null
   returning *;
 $$;
-ALTER FUNCTION graphile_worker.remove_job(job_key text) OWNER TO benjie;
+ALTER FUNCTION graphile_worker.remove_job(job_key text) OWNER TO postgres;
 CREATE FUNCTION graphile_worker.reschedule_jobs(job_ids bigint[], run_at timestamp with time zone DEFAULT NULL::timestamp with time zone, priority integer DEFAULT NULL::integer, attempts integer DEFAULT NULL::integer, max_attempts integer DEFAULT NULL::integer) RETURNS SETOF graphile_worker.jobs
     LANGUAGE sql
     AS $$
@@ -305,7 +305,7 @@ CREATE FUNCTION graphile_worker.reschedule_jobs(job_ids bigint[], run_at timesta
     )
     returning *;
 $$;
-ALTER FUNCTION graphile_worker.reschedule_jobs(job_ids bigint[], run_at timestamp with time zone, priority integer, attempts integer, max_attempts integer) OWNER TO benjie;
+ALTER FUNCTION graphile_worker.reschedule_jobs(job_ids bigint[], run_at timestamp with time zone, priority integer, attempts integer, max_attempts integer) OWNER TO postgres;
 CREATE FUNCTION graphile_worker.tg__update_timestamp() RETURNS trigger
     LANGUAGE plpgsql
     AS $$
@@ -314,7 +314,7 @@ begin
   return new;
 end;
 $$;
-ALTER FUNCTION graphile_worker.tg__update_timestamp() OWNER TO benjie;
+ALTER FUNCTION graphile_worker.tg__update_timestamp() OWNER TO postgres;
 CREATE FUNCTION graphile_worker.tg_jobs__notify_new_jobs() RETURNS trigger
     LANGUAGE plpgsql
     AS $$
@@ -323,27 +323,27 @@ begin
   return new;
 end;
 $$;
-ALTER FUNCTION graphile_worker.tg_jobs__notify_new_jobs() OWNER TO benjie;
+ALTER FUNCTION graphile_worker.tg_jobs__notify_new_jobs() OWNER TO postgres;
 CREATE TABLE graphile_worker.job_queues (
     queue_name text NOT NULL,
     job_count integer NOT NULL,
     locked_at timestamp with time zone,
     locked_by text
 );
-ALTER TABLE graphile_worker.job_queues OWNER TO benjie;
+ALTER TABLE graphile_worker.job_queues OWNER TO postgres;
 CREATE SEQUENCE graphile_worker.jobs_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
     NO MAXVALUE
     CACHE 1;
-ALTER TABLE graphile_worker.jobs_id_seq OWNER TO benjie;
+ALTER TABLE graphile_worker.jobs_id_seq OWNER TO postgres;
 ALTER SEQUENCE graphile_worker.jobs_id_seq OWNED BY graphile_worker.jobs.id;
 CREATE TABLE graphile_worker.migrations (
     id integer NOT NULL,
     ts timestamp with time zone DEFAULT now() NOT NULL
 );
-ALTER TABLE graphile_worker.migrations OWNER TO benjie;
+ALTER TABLE graphile_worker.migrations OWNER TO postgres;
 ALTER TABLE ONLY graphile_worker.jobs ALTER COLUMN id SET DEFAULT nextval('graphile_worker.jobs_id_seq'::regclass);
 ALTER TABLE ONLY graphile_worker.job_queues
     ADD CONSTRAINT job_queues_pkey PRIMARY KEY (queue_name);

--- a/__tests__/schema.sql
+++ b/__tests__/schema.sql
@@ -1,19 +1,8 @@
-SET statement_timeout = 0;
-SET lock_timeout = 0;
-SET idle_in_transaction_session_timeout = 0;
-SET client_encoding = 'UTF8';
-SET standard_conforming_strings = on;
 SELECT pg_catalog.set_config('search_path', '', false);
-SET check_function_bodies = false;
-SET xmloption = content;
-SET client_min_messages = warning;
-SET row_security = off;
 CREATE SCHEMA graphile_worker;
 ALTER SCHEMA graphile_worker OWNER TO graphile_worker_role;
 CREATE EXTENSION IF NOT EXISTS pgcrypto WITH SCHEMA public;
 COMMENT ON EXTENSION pgcrypto IS 'cryptographic functions';
-SET default_tablespace = '';
-SET default_with_oids = false;
 CREATE TABLE graphile_worker.jobs (
     id bigint NOT NULL,
     queue_name text DEFAULT (public.gen_random_uuid())::text,

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "lint:fix": "eslint --ext .js,.jsx,.ts,.tsx,.graphql . --fix; prettier --ignore-path .eslintignore --write '**/*.{js,jsx,ts,tsx,graphql,md,json}'",
     "prettier:check": "prettier --ignore-path .eslintignore --check '**/*.{js,jsx,ts,tsx,graphql,md,json}'",
     "test": "yarn prepack && depcheck && createdb graphile_worker_test || true && psql -X -v GRAPHILE_WORKER_SCHEMA=\"${GRAPHILE_WORKER_SCHEMA:-graphile_worker}\" -v ON_ERROR_STOP=1 -f __tests__/reset-db.sql graphile_worker_test && jest -i",
+    "dump_db": "dropdb --if-exists graphile_worker_test && createdb graphile_worker_test && ts-node src/cli.ts -c graphile_worker_test --schema-only && pg_dump --schema-only graphile_worker_test | sed -e '/^--/d' -e '/^\\s*$/d' > __tests__/schema.sql",
     "perfTest": "cd perfTest && node ./run.js"
   },
   "bin": {

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "lint:fix": "eslint --ext .js,.jsx,.ts,.tsx,.graphql . --fix; prettier --ignore-path .eslintignore --write '**/*.{js,jsx,ts,tsx,graphql,md,json}'",
     "prettier:check": "prettier --ignore-path .eslintignore --check '**/*.{js,jsx,ts,tsx,graphql,md,json}'",
     "test": "yarn prepack && depcheck && createdb graphile_worker_test || true && psql -X -v GRAPHILE_WORKER_SCHEMA=\"${GRAPHILE_WORKER_SCHEMA:-graphile_worker}\" -v ON_ERROR_STOP=1 -f __tests__/reset-db.sql graphile_worker_test && jest -i",
-    "dump_db": "dropdb --if-exists graphile_worker_test && createdb graphile_worker_test && ts-node src/cli.ts -c graphile_worker_test --schema-only && pg_dump --schema-only graphile_worker_test | sed -e '/^--/d' -e '/^\\s*$/d' > __tests__/schema.sql",
+    "db:dump": "dropdb --if-exists graphile_worker_test && createdb graphile_worker_test && ts-node src/cli.ts -c graphile_worker_test --schema-only && pg_dump --schema-only graphile_worker_test | sed -e '/^--/d' -e '/^\\s*$/d' > __tests__/schema.sql",
     "perfTest": "cd perfTest && node ./run.js"
   },
   "bin": {

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "lint:fix": "eslint --ext .js,.jsx,.ts,.tsx,.graphql . --fix; prettier --ignore-path .eslintignore --write '**/*.{js,jsx,ts,tsx,graphql,md,json}'",
     "prettier:check": "prettier --ignore-path .eslintignore --check '**/*.{js,jsx,ts,tsx,graphql,md,json}'",
     "test": "yarn prepack && depcheck && createdb graphile_worker_test || true && psql -X -v GRAPHILE_WORKER_SCHEMA=\"${GRAPHILE_WORKER_SCHEMA:-graphile_worker}\" -v ON_ERROR_STOP=1 -f __tests__/reset-db.sql graphile_worker_test && jest -i",
-    "db:dump": "dropdb --if-exists graphile_worker_test && createdb graphile_worker_test && ts-node src/cli.ts -c graphile_worker_test --schema-only && pg_dump --schema-only graphile_worker_test | sed -e '/^--/d' -e '/^\\s*$/d' > __tests__/schema.sql",
+    "db:dump": "./scripts/dump_db",
     "perfTest": "cd perfTest && node ./run.js"
   },
   "bin": {

--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "pg-connection-string": "^2.2.0",
     "prettier": "^2.0.5",
     "ts-jest": "^25.4.0",
+    "ts-node": "^9.0.0",
     "typescript": "^3.8.3"
   },
   "files": [

--- a/scripts/dump_db
+++ b/scripts/dump_db
@@ -6,6 +6,6 @@ dropuser graphile_worker_role || true
 psql template1 -c "CREATE USER graphile_worker_role WITH SUPERUSER PASSWORD 'password';"
 createdb graphile_worker_dump -O graphile_worker_role
 PGUSER=graphile_worker_role PGPASSWORD=password PGHOST=localhost ts-node src/cli.ts -c graphile_worker_dump --schema-only
-pg_dump --schema-only graphile_worker_dump | sed -e '/^--/d' -e '/^\s*$/d' > __tests__/schema.sql
+pg_dump --schema-only graphile_worker_dump | sed -e '/^--/d' -e '/^\s*$/d' -e '/^SET /d' > __tests__/schema.sql
 dropdb graphile_worker_dump
 dropuser graphile_worker_role

--- a/scripts/dump_db
+++ b/scripts/dump_db
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+set -e
+
+dropdb --if-exists graphile_worker_dump
+dropuser graphile_worker_role || true
+psql template1 -c "CREATE USER graphile_worker_role WITH SUPERUSER PASSWORD 'password';"
+createdb graphile_worker_dump -O graphile_worker_role
+PGUSER=graphile_worker_role PGPASSWORD=password PGHOST=localhost ts-node src/cli.ts -c graphile_worker_dump --schema-only
+pg_dump --schema-only graphile_worker_dump | sed -e '/^--/d' -e '/^\s*$/d' > __tests__/schema.sql
+dropdb graphile_worker_dump
+dropuser graphile_worker_role

--- a/yarn.lock
+++ b/yarn.lock
@@ -716,6 +716,11 @@ anymatch@^3.0.3, anymatch@~3.1.1:
     normalize-path "^3.0.0"
     picomatch "^2.0.4"
 
+arg@^4.1.0:
+  version "4.1.3"
+  resolved "https://registry.yarnpkg.com/arg/-/arg-4.1.3.tgz#269fc7ad5b8e42cb63c896d5666017261c144089"
+  integrity sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==
+
 argparse@^1.0.7:
   version "1.0.10"
   resolved "https://registry.yarnpkg.com/argparse/-/argparse-1.0.10.tgz#bcd6791ea5ae09725e17e5ad988134cd40b3d911"
@@ -1365,6 +1370,11 @@ diff-sequences@^25.2.6:
   version "25.2.6"
   resolved "https://registry.yarnpkg.com/diff-sequences/-/diff-sequences-25.2.6.tgz#5f467c00edd35352b7bca46d7927d60e687a76dd"
   integrity sha512-Hq8o7+6GaZeoFjtpgvRBUknSXNeJiCx7V9Fr94ZMljNiCr9n9L8H8aJqgWOQiDDGdyn29fRNcDdRVJ5fdyihfg==
+
+diff@^4.0.1:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/diff/-/diff-4.0.2.tgz#60f3aecb89d5fae520c11aa19efc2bb982aade7d"
+  integrity sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==
 
 doctrine@1.5.0:
   version "1.5.0"
@@ -2962,7 +2972,7 @@ make-dir@^3.0.0:
   dependencies:
     semver "^6.0.0"
 
-make-error@1.x:
+make-error@1.x, make-error@^1.1.1:
   version "1.3.6"
   resolved "https://registry.yarnpkg.com/make-error/-/make-error-1.3.6.tgz#2eb2e37ea9b67c4891f684a1394799af484cf7a2"
   integrity sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==
@@ -4006,7 +4016,7 @@ source-map-resolve@^0.5.0:
     source-map-url "^0.4.0"
     urix "^0.1.0"
 
-source-map-support@^0.5.6:
+source-map-support@^0.5.17, source-map-support@^0.5.6:
   version "0.5.19"
   resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.5.19.tgz#a98b62f86dcaf4f67399648c085291ab9e8fed61"
   integrity sha512-Wonm7zOCIJzBGQdB+thsPar0kYuCIzYvxZwlBa87yi/Mdjv7Tip2cyVbLj5o0cFPN4EVkuTwb3GDDyUx2DGnGw==
@@ -4370,6 +4380,17 @@ ts-jest@^25.4.0:
     semver "6.x"
     yargs-parser "18.x"
 
+ts-node@^9.0.0:
+  version "9.0.0"
+  resolved "https://registry.yarnpkg.com/ts-node/-/ts-node-9.0.0.tgz#e7699d2a110cc8c0d3b831715e417688683460b3"
+  integrity sha512-/TqB4SnererCDR/vb4S/QvSZvzQMJN8daAslg7MeaiHvD8rDZsSfXmNeNumyZZzMned72Xoq/isQljYSt8Ynfg==
+  dependencies:
+    arg "^4.1.0"
+    diff "^4.0.1"
+    make-error "^1.1.1"
+    source-map-support "^0.5.17"
+    yn "3.1.1"
+
 tslib@^1.11.1, tslib@^1.8.1, tslib@^1.9.0:
   version "1.11.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.11.1.tgz#eb15d128827fbee2841549e171f45ed338ac7e35"
@@ -4677,3 +4698,8 @@ yargs@^15.0.2, yargs@^15.1.0, yargs@^15.3.1:
     which-module "^2.0.0"
     y18n "^4.0.0"
     yargs-parser "^18.1.1"
+
+yn@3.1.1:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/yn/-/yn-3.1.1.tgz#1e87401a09d767c1d5eab26a6e4c185182d2eb50"
+  integrity sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==


### PR DESCRIPTION
This PR adds a `yarn db:dump` command that dumps the schema to `__tests__/schema.sql`. This dumped schema differs from `pg_dump` in that it removes all lines that start `--` (i.e. pg_dumps comments) because it makes it more likely the dump will be stable across PostgreSQL versions (although we only care it's stable on CI). It also removes blank or whitespace only lines (even inside of functions) for the same reason. It's not intended to be used for anything other than as a PR review tool to make database schema differences more obvious.