### PR TITLE
feat: add support for standard PostgreSQL PG* envvars

### DIFF
--- a/README.md
+++ b/README.md
@@ -315,8 +315,7 @@ One of these must be provided (in order of priority):
 - `pgPool` pg.Pool instance
 - `connectionString` setting
 - `DATABASE_URL` envvar
-- PostgreSQL environmental variables, including at least `PGDATABASE` and
-  `PGHOST`
+- PostgreSQL environmental variables, including at least `PGDATABASE`
 
 ## Library usage: queueing jobs
 

--- a/README.md
+++ b/README.md
@@ -310,8 +310,13 @@ The following options for these methods are available.
 Exactly one of either `taskDirectory` or `taskList` must be provided (except for
 `runMigrations` which doesn't require a task list).
 
-Either `connectionString` or `pgPool` must be provided, or the `DATABASE_URL`
-envvar must be set.
+One of these must be provided (in order of priority):
+
+- `pgPool` pg.Pool instance
+- `connectionString` setting
+- `DATABASE_URL` envvar
+- PostgreSQL environmental variables, including at least `PGDATABASE` and
+  `PGHOST`
 
 ## Library usage: queueing jobs
 

--- a/README.md
+++ b/README.md
@@ -315,7 +315,8 @@ One of these must be provided (in order of priority):
 - `pgPool` pg.Pool instance
 - `connectionString` setting
 - `DATABASE_URL` envvar
-- PostgreSQL environmental variables, including at least `PGDATABASE`
+- [PostgreSQL environmental variables](https://www.postgresql.org/docs/current/libpq-envars.html),
+  including at least `PGDATABASE` (NOTE: not all envvars are supported)
 
 ## Library usage: queueing jobs
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -7,6 +7,8 @@
   feature for rate limiting (thanks @ben-pr-p)
 - Fix incorrect description of priority - numerically smaller numbers run first
   (thanks @ben-pr-p)
+- Add support for `PG*`
+  [PostgreSQL envvars](https://www.postgresql.org/docs/current/libpq-envars.html)
 
 ### v0.7.2
 

--- a/__tests__/helpers.ts
+++ b/__tests__/helpers.ts
@@ -1,4 +1,5 @@
 import * as pg from "pg";
+import { parse } from "pg-connection-string";
 
 import { Job, WorkerPoolOptions, WorkerUtils } from "../src/interfaces";
 import { migrate } from "../src/migrate";
@@ -11,6 +12,11 @@ process.env.GRAPHILE_WORKER_DEBUG = "1";
 
 export const TEST_CONNECTION_STRING =
   process.env.TEST_CONNECTION_STRING || "graphile_worker_test";
+
+const parsed = parse(TEST_CONNECTION_STRING);
+
+export const PGHOST = parsed.host || "localhost";
+export const PGDATABASE = parsed.database;
 
 export const GRAPHILE_WORKER_SCHEMA =
   process.env.GRAPHILE_WORKER_SCHEMA || "graphile_worker";

--- a/__tests__/helpers.ts
+++ b/__tests__/helpers.ts
@@ -15,8 +15,8 @@ export const TEST_CONNECTION_STRING =
 
 const parsed = parse(TEST_CONNECTION_STRING);
 
-export const PGHOST = parsed.host || "localhost";
-export const PGDATABASE = parsed.database;
+export const PGHOST = parsed.host || process.env.PGHOST;
+export const PGDATABASE = parsed.database || undefined;
 
 export const GRAPHILE_WORKER_SCHEMA =
   process.env.GRAPHILE_WORKER_SCHEMA || "graphile_worker";

--- a/__tests__/runner.runOnce.test.ts
+++ b/__tests__/runner.runOnce.test.ts
@@ -2,7 +2,12 @@ import { Pool } from "pg";
 
 import { RunnerOptions } from "../src/interfaces";
 import { runOnce } from "../src/runner";
-import { TEST_CONNECTION_STRING, withPgPool } from "./helpers";
+import {
+  PGDATABASE,
+  PGHOST,
+  TEST_CONNECTION_STRING,
+  withPgPool,
+} from "./helpers";
 
 async function runOnceErrorAssertion(options: RunnerOptions, message: string) {
   expect.assertions(1);
@@ -35,7 +40,7 @@ test("taskList and taskDirectory cannot be provided a the same time", async () =
   );
 });
 
-test("at least a connectionString, a pgPool or the DATABASE_URL env variable must be provided", async () => {
+test("at least a connectionString, a pgPool, the DATABASE_URL env variable or PGHOST/PGDATABASE envvars must be provided", async () => {
   const options: RunnerOptions = {
     taskList: { task: () => {} },
   };
@@ -65,6 +70,18 @@ test("providing just a DATABASE_URL is possible", async () => {
   expect.assertions(0);
   await runOnce(options);
   delete process.env.DATABASE_URL;
+});
+
+test("providing just PGHOST and PGDATABASE is possible", async () => {
+  process.env.PGHOST = PGHOST;
+  process.env.PGDATABASE = PGDATABASE;
+  const options: RunnerOptions = {
+    taskList: { task: () => {} },
+  };
+  expect.assertions(0);
+  await runOnce(options);
+  delete process.env.PGHOST;
+  delete process.env.PGDATABASE;
 });
 
 test("providing just a connectionString is possible", async () => {

--- a/__tests__/runner.runOnce.test.ts
+++ b/__tests__/runner.runOnce.test.ts
@@ -9,6 +9,32 @@ import {
   withPgPool,
 } from "./helpers";
 
+function setEnvvars(env: { [key: string]: string | undefined }) {
+  Object.entries(env).forEach(([key, val]) => {
+    if (val === undefined) {
+      delete process.env[key];
+    } else {
+      process.env[key] = val;
+    }
+  });
+}
+
+async function withEnv<T>(
+  envOverrides: { [key: string]: string | undefined },
+  callback: () => Promise<T>,
+): Promise<T> {
+  const old = Object.keys(envOverrides).reduce((memo, key) => {
+    memo[key] = process.env[key];
+    return memo;
+  }, {} as { [key: string]: string | undefined });
+  setEnvvars(envOverrides);
+  try {
+    return await callback();
+  } finally {
+    setEnvvars(old);
+  }
+}
+
 async function runOnceErrorAssertion(options: RunnerOptions, message: string) {
   expect.assertions(1);
   try {
@@ -40,13 +66,13 @@ test("taskList and taskDirectory cannot be provided a the same time", async () =
   );
 });
 
-test("at least a connectionString, a pgPool, the DATABASE_URL env variable or PGHOST/PGDATABASE envvars must be provided", async () => {
+test("at least a connectionString, a pgPool, the DATABASE_URL or PGDATABASE envvars must be provided", async () => {
   const options: RunnerOptions = {
     taskList: { task: () => {} },
   };
   await runOnceErrorAssertion(
     options,
-    "You must either specify `pgPool` or `connectionString`, or you must make the `DATABASE_URL` environmental variable available.",
+    "You must either specify `pgPool` or `connectionString`, or you must make the `DATABASE_URL` or `PG*` environmental variables available.",
   );
 });
 
@@ -63,25 +89,23 @@ test("connectionString and a pgPool cannot provided a the same time", async () =
 });
 
 test("providing just a DATABASE_URL is possible", async () => {
-  process.env.DATABASE_URL = TEST_CONNECTION_STRING;
-  const options: RunnerOptions = {
-    taskList: { task: () => {} },
-  };
-  expect.assertions(0);
-  await runOnce(options);
-  delete process.env.DATABASE_URL;
+  return withEnv({ DATABASE_URL: TEST_CONNECTION_STRING }, async () => {
+    const options: RunnerOptions = {
+      taskList: { task: () => {} },
+    };
+    expect.assertions(0);
+    await runOnce(options);
+  });
 });
 
 test("providing just PGHOST and PGDATABASE is possible", async () => {
-  process.env.PGHOST = PGHOST;
-  process.env.PGDATABASE = PGDATABASE;
-  const options: RunnerOptions = {
-    taskList: { task: () => {} },
-  };
-  expect.assertions(0);
-  await runOnce(options);
-  delete process.env.PGHOST;
-  delete process.env.PGDATABASE;
+  return withEnv({ PGHOST, PGDATABASE }, async () => {
+    const options: RunnerOptions = {
+      taskList: { task: () => {} },
+    };
+    expect.assertions(0);
+    await runOnce(options);
+  });
 });
 
 test("providing just a connectionString is possible", async () => {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -5,6 +5,7 @@ import { defaults } from "./config";
 import getTasks from "./getTasks";
 import { run, runOnce } from "./index";
 import { RunnerOptions } from "./interfaces";
+import { connectionStringFromEnvvars } from "./lib";
 import { runMigrations } from "./runner";
 
 const argv = yargs
@@ -79,7 +80,7 @@ const isInteger = (n: number): boolean => {
 };
 
 async function main() {
-  const DATABASE_URL = argv.connection || process.env.DATABASE_URL || undefined;
+  const DATABASE_URL = argv.connection || connectionStringFromEnvvars();
   const SCHEMA = argv.schema || undefined;
   const ONCE = argv.once;
   const SCHEMA_ONLY = argv["schema-only"];
@@ -97,7 +98,7 @@ async function main() {
 
   if (!DATABASE_URL) {
     throw new Error(
-      "Please use `--connection` flag or set `DATABASE_URL` envvar to indicate the PostgreSQL connection string.",
+      "Please use `--connection` flag, set `DATABASE_URL` envvar, or set `PGHOST` and `PGDATABASE` envvars to indicate the PostgreSQL connection string.",
     );
   }
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -5,7 +5,6 @@ import { defaults } from "./config";
 import getTasks from "./getTasks";
 import { run, runOnce } from "./index";
 import { RunnerOptions } from "./interfaces";
-import { connectionStringFromEnvvars } from "./lib";
 import { runMigrations } from "./runner";
 
 const argv = yargs
@@ -80,7 +79,7 @@ const isInteger = (n: number): boolean => {
 };
 
 async function main() {
-  const DATABASE_URL = argv.connection || connectionStringFromEnvvars();
+  const DATABASE_URL = argv.connection || process.env.DATABASE_URL || undefined;
   const SCHEMA = argv.schema || undefined;
   const ONCE = argv.once;
   const SCHEMA_ONLY = argv["schema-only"];
@@ -96,9 +95,9 @@ async function main() {
     throw new Error("Cannot specify both --watch and --once");
   }
 
-  if (!DATABASE_URL) {
+  if (!DATABASE_URL && !process.env.PGDATABASE) {
     throw new Error(
-      "Please use `--connection` flag, set `DATABASE_URL` envvar, or set `PGHOST` and `PGDATABASE` envvars to indicate the PostgreSQL connection string.",
+      "Please use `--connection` flag, set `DATABASE_URL` or `PGDATABASE` envvars to indicate the PostgreSQL connection to use.",
     );
   }
 

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -53,93 +53,6 @@ export function processSharedOptions(
   }
 }
 
-/**
- * Builds a connection string from the `PG*` or `DATABASE_URL` envvars.
- *
- * @remarks
- * In future we should rely on the `pg` module to correctly interperet these
- * envvars; but since our internals rely on manipulation of the connection
- * string (and this is also required for passing the connection string down to
- * child processes, e.g. from the hooks) for now we'll do best efforts
- * connection string construction from the envvars.
- */
-export function connectionStringFromEnvvars() {
-  if (process.env.DATABASE_URL) {
-    return process.env.DATABASE_URL;
-  } else if (process.env.PGHOST && process.env.PGDATABASE) {
-    const {
-      PGHOST,
-      PGPORT,
-      PGDATABASE,
-      PGUSER,
-      PGPASSWORD,
-      PGAPPNAME,
-      PGCLIENTENCODING,
-      PGSSLMODE,
-      PGREQUIRESSL,
-      PGSSLCERT,
-      PGSSLKEY,
-      PGSSLROOTCERT,
-    } = process.env;
-    let str = "postgres://";
-    if (PGUSER) {
-      str += encodeURIComponent(PGUSER);
-    }
-    if (PGPASSWORD) {
-      str += ":" + encodeURIComponent(PGPASSWORD);
-    }
-    if (PGUSER || PGPASSWORD) {
-      str += "@";
-    }
-    if (PGHOST && !PGHOST.startsWith("/")) {
-      str += PGHOST;
-    }
-    if (PGPORT) {
-      str += ":" + PGPORT;
-    }
-    str += "/";
-    str += PGDATABASE;
-    let sep = "?";
-    const q = (
-      key: string,
-      val: string | null | undefined | boolean,
-    ): string => {
-      if (val != null) {
-        const str =
-          sep +
-          encodeURIComponent(key) +
-          "=" +
-          encodeURIComponent(
-            val === true ? "true" : val === false ? "false" : val,
-          );
-        if (sep === "?") {
-          sep = "&";
-        }
-        return str;
-      }
-      return "";
-    };
-    if (PGHOST && PGHOST.startsWith("/")) {
-      str += q("host", PGHOST);
-    }
-    str += q(
-      "ssl",
-      ["1", "true"].includes(PGREQUIRESSL || "") ||
-        ["allow", "prefer", "require", "verify-ca", "verify-full"].includes(
-          PGSSLMODE || "",
-        ),
-    );
-    str += q("client_encoding", PGCLIENTENCODING);
-    str += q("application_name", PGAPPNAME);
-    str += q("sslcert", PGSSLCERT);
-    str += q("sslkey", PGSSLKEY);
-    str += q("sslrootcert", PGSSLROOTCERT);
-    return str;
-  } else {
-    return undefined;
-  }
-}
-
 export type Releasers = Array<() => void | Promise<void>>;
 
 export async function assertPool(
@@ -152,13 +65,18 @@ export async function assertPool(
     "Both `pgPool` and `connectionString` are set, at most one of these options should be provided",
   );
   let pgPool: Pool;
-  const connectionString =
-    options.connectionString || connectionStringFromEnvvars();
+  const connectionString = options.connectionString || process.env.DATABASE_URL;
   if (options.pgPool) {
     pgPool = options.pgPool;
   } else if (connectionString) {
     pgPool = new Pool({
       connectionString,
+      max: options.maxPoolSize,
+    });
+    releasers.push(() => pgPool.end());
+  } else if (process.env.PGDATABASE) {
+    pgPool = new Pool({
+      /* Pool automatically pulls settings from envvars */
       max: options.maxPoolSize,
     });
     releasers.push(() => pgPool.end());

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -109,7 +109,9 @@ export function connectionStringFromEnvvars() {
           sep +
           encodeURIComponent(key) +
           "=" +
-          encodeURIComponent(val === true ? "1" : val === false ? "0" : val);
+          encodeURIComponent(
+            val === true ? "true" : val === false ? "false" : val,
+          );
         if (sep === "?") {
           sep = "&";
         }

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -91,7 +91,7 @@ export function connectionStringFromEnvvars() {
     if (PGUSER || PGPASSWORD) {
       str += "@";
     }
-    if (PGHOST) {
+    if (PGHOST && !PGHOST.startsWith("/")) {
       str += PGHOST;
     }
     if (PGPORT) {
@@ -117,6 +117,9 @@ export function connectionStringFromEnvvars() {
       }
       return "";
     };
+    if (PGHOST && PGHOST.startsWith("/")) {
+      str += q("host", PGHOST);
+    }
     str += q(
       "ssl",
       ["1", "true"].includes(PGREQUIRESSL || "") ||


### PR DESCRIPTION
Fixes #50

We defer to Pool to process the envvars; we just check that there's at least a `PGDATABASE` envvar because we don't want to overwrite the default database by accident.