### PR TITLE
Add generics for typed payloads

### DIFF
--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -139,8 +139,8 @@ export interface WorkerUtils extends Helpers {
   ) => Promise<Job[]>;
 }
 
-export type Task = (
-  payload: unknown,
+export type Task<T = unknown> = (
+  payload: T,
   helpers: JobHelpers,
 ) => void | Promise<void>;
 
@@ -160,11 +160,11 @@ export interface WatchedTaskList {
   release: () => void;
 }
 
-export interface Job {
+export interface Job<T = unknown> {
   id: string;
   queue_name: string | null;
   task_identifier: string;
-  payload: unknown;
+  payload: T;
   priority: number;
   run_at: Date;
   attempts: number;


### PR DESCRIPTION
Payloads for jobs are untyped and require unnecessary/unsafe casting, e.g

```ts
type MyType = {
  Val: string;
}
const task: Task = async (payload) => {
  const { Val } = payload as MyType;
  // etc
}
```

This PR enables us to utilize TS generics:

```ts
type MyType = {
  Val: string;
}
const task: Task<MyType> = async ({ Val }) => {
  // etc
}
```

Note: this update is backward compatible i.e. does not require changes to existing code since the generic is optional.