### PR TITLE
fix(watch): solve bug with cyclic requires

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -74,12 +74,12 @@ ${code};
   // Since the code is evaluated synchronously, we set this immediately before
   // compiling and clear after.
   global["graphileWorker_fauxRequireCache"] = cache;
+  cache[filename] = replacementModule;
   // @ts-ignore
   replacementModule._compile(codeWithWrapper, filename);
   global["graphileWorker_fauxRequireCache"] = null;
 
   replacementModule.loaded = true;
-  cache[filename] = replacementModule;
 
   return replacementModule.exports;
 }


### PR DESCRIPTION
Fixes #145; the module cache was being written to at too late a stage, causing cyclic requires to trigger an infinite loop. This PR fixes this by caching the module _before_ we execute the module, meaning the cache is in place before the module can require other modules which might in turn require this module again.

(We fixed this on stream.)