### PR TITLE
feat(types): allow configuring task payloads

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -3,6 +3,7 @@
 ### Pending
 
 - Add your changes here
+- TypeScript: make the `Task` type generic, to allow specifying payloads
 
 ### v0.8.1
 

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -139,8 +139,8 @@ export interface WorkerUtils extends Helpers {
   ) => Promise<Job[]>;
 }
 
-export type Task = (
-  payload: unknown,
+export type Task<Payload extends unknown = unknown> = (
+  payload: Payload,
   helpers: JobHelpers,
 ) => void | Promise<void>;
 


### PR DESCRIPTION
## Description

This PR makes the `Task` type generic, thereby allowing users to configure the exact shape of payloads.

## Performance impact

N/A

## Security impact

N/A

## Checklist

<!-- If this PR is work in progress, please open it as a "Draft PR". -->
<!-- To tick a checkbox, change it from `[ ]` to `[x]` -->

- [x] My code matches the project's code style and `yarn lint:fix` passes.
- [x] ~~I've added tests for the new feature, and `yarn test` passes~~
- [x] I have detailed the new feature in the relevant documentation.
- [x] I have added this feature to 'Pending' in the `RELEASE_NOTES.md` file (if one exists).
- [x] ~~If this is a breaking change I've explained why.~~

<!-- For some Graphile projects the documentation is the README.md file, for
      others please see https://github.com/graphile/graphile.github.io -->
