### PR TITLE
feat(events): add events system

### DIFF
--- a/README.md
+++ b/README.md
@@ -409,6 +409,16 @@ export type WorkerEvents = TypedEventEmitter<{
   "worker:create": { worker: Worker; tasks: TaskList };
 
   /**
+   * When a worker release is requested
+   */
+  "worker:release": { worker: Worker };
+
+  /**
+   * When a worker stops (normally after a release)
+   */
+  "worker:stop": { worker: Worker; error?: any };
+
+  /**
    * When a worker calls get_job but there are no available jobs
    */
   "worker:getJob:error": { worker: Worker; error: any };

--- a/README.md
+++ b/README.md
@@ -301,6 +301,9 @@ The following options for these methods are available.
 - `schema` can be used to change the default `graphile_worker` schema to
   something else (equivalent to `--schema` on the CLI)
 - `forbiddenFlags` see [Forbidden flags](#forbidden-flags) below
+- `events`: pass your own `new EventEmitter()` if you want to customize the
+  options, get earlier events (before the runner object resolves), or want to
+  get events from alternative Graphile Worker entrypoints.
 
 Exactly one of either `taskDirectory` or `taskList` must be provided (except for
 `runMigrations` which doesn't require a task list).

--- a/README.md
+++ b/README.md
@@ -345,7 +345,7 @@ await runner.addJob("testTask", {
 See [`WorkerEvents`](#workerevents) for more details.
 
 ```js
-runner.events.on("job.success", ({ worker, job }) => {
+runner.events.on("job:success", ({ worker, job }) => {
   console.log(`Hooray! Worker ${worker.workerId} completed job ${job.id}`);
 });
 ```

--- a/__tests__/events.test.ts
+++ b/__tests__/events.test.ts
@@ -1,0 +1,126 @@
+import { EventEmitter } from "events";
+import { Pool } from "pg";
+
+import { run } from "../src";
+import deferred, { Deferred } from "../src/deferred";
+import { Task, TaskList, WorkerSharedOptions } from "../src/interfaces";
+import {
+  ESCAPED_GRAPHILE_WORKER_SCHEMA,
+  jobCount,
+  reset,
+  sleep,
+  sleepUntil,
+  withPgPool,
+} from "./helpers";
+
+const EVENTS = [
+  "pool:create",
+  "pool:listen:connecting",
+  "pool:listen:success",
+  "pool:listen:error",
+  "pool:release",
+  "pool:gracefulShutdown",
+  "pool:gracefulShutdown:error",
+  "worker:create",
+  "worker:getJob:error",
+  "worker:getJob:empty",
+  "worker:fatalError",
+  "job:start",
+  "job:success",
+  "job:error",
+  "job:failed",
+  "gracefulShutdown",
+  "stop",
+];
+
+const addJob = (pgPool: Pool, id?: string | number) =>
+  pgPool.query(
+    `select ${ESCAPED_GRAPHILE_WORKER_SCHEMA}.add_job('job1', json_build_object('id', $1::text), 'serial')`,
+    [String(id != null ? id : Math.random())],
+  );
+
+const options: WorkerSharedOptions = {};
+
+test("emits the expected events", () =>
+  withPgPool(async (pgPool) => {
+    await reset(pgPool, options);
+
+    // Build the tasks
+    const jobPromises: {
+      [id: string]: Deferred;
+    } = {};
+    const job1: Task = jest.fn(({ id }: { id: string }) => {
+      const jobPromise = deferred();
+      if (jobPromises[id]) {
+        throw new Error("Job with this id already registered");
+      }
+      jobPromises[id] = jobPromise;
+      return jobPromise;
+    });
+    const tasks: TaskList = {
+      job1,
+    };
+
+    // Run the worker
+    const events = new EventEmitter();
+
+    const emittedEvents: Array<{ event: string; payload: any }> = [];
+    function createListener(event: string) {
+      return (payload: any) => {
+        emittedEvents.push({ event, payload });
+      };
+    }
+
+    EVENTS.forEach((event) => {
+      events.on(event, createListener(event));
+    });
+
+    const CONCURRENCY = 3;
+    const runner = await run({
+      concurrency: CONCURRENCY,
+      pgPool,
+      taskList: tasks,
+      events,
+    });
+
+    expect(runner.events).toEqual(events);
+
+    const eventCount = (name: string) =>
+      emittedEvents.map((obj) => obj.event).filter((n) => n === name).length;
+
+    // NOTE: these are the events that get emitted _before_ `run` resolves; so
+    // you can only receive these if you pass an EventEmitter to run manually.
+    expect(eventCount("pool:create")).toEqual(1);
+    expect(eventCount("pool:listen:connecting")).toEqual(1);
+    expect(eventCount("worker:create")).toEqual(CONCURRENCY);
+
+    let finished = false;
+    runner.promise.then(() => {
+      finished = true;
+    });
+
+    for (let i = 0; i < 5; i++) {
+      await addJob(pgPool, i);
+    }
+
+    for (let i = 0; i < 5; i++) {
+      await sleepUntil(() => !!jobPromises[i]);
+      expect(eventCount("job:start")).toEqual(i + 1);
+      expect(eventCount("job:success")).toEqual(i);
+      jobPromises[i].resolve();
+      await sleepUntil(() => eventCount("job:success") === i + 1);
+    }
+
+    await sleep(1);
+    expect(finished).toBeFalsy();
+    expect(eventCount("stop")).toEqual(0);
+    expect(eventCount("pool:release")).toEqual(0);
+    await runner.stop();
+    expect(eventCount("stop")).toEqual(1);
+    expect(job1).toHaveBeenCalledTimes(5);
+    await sleep(1);
+    expect(finished).toBeTruthy();
+    await runner.promise;
+    expect(eventCount("pool:release")).toEqual(1);
+    expect(await jobCount(pgPool)).toEqual(0);
+  }));

--- a/__tests__/events.test.ts
+++ b/__tests__/events.test.ts
@@ -22,6 +22,8 @@ const EVENTS = [
   "pool:gracefulShutdown",
   "pool:gracefulShutdown:error",
   "worker:create",
+  "worker:release",
+  "worker:stop",
   "worker:getJob:error",
   "worker:getJob:empty",
   "worker:fatalError",
@@ -114,6 +116,7 @@ test("emits the expected events", () =>
     await sleep(1);
     expect(finished).toBeFalsy();
     expect(eventCount("stop")).toEqual(0);
+    expect(eventCount("worker:release")).toEqual(0);
     expect(eventCount("pool:release")).toEqual(0);
     await runner.stop();
     expect(eventCount("stop")).toEqual(1);
@@ -121,6 +124,8 @@ test("emits the expected events", () =>
     await sleep(1);
     expect(finished).toBeTruthy();
     await runner.promise;
+    expect(eventCount("worker:release")).toEqual(CONCURRENCY);
+    expect(eventCount("worker:stop")).toEqual(CONCURRENCY);
     expect(eventCount("pool:release")).toEqual(1);
     expect(await jobCount(pgPool)).toEqual(0);
   }));

--- a/examples/readme/README.md
+++ b/examples/readme/README.md
@@ -1,0 +1,10 @@
+Examples from the README, mostly for testing.
+
+- `events.js` is a combination of the
+  [Quickstart: library](https://github.com/graphile/worker/blob/main/README.md#quickstart-library)
+  example with the
+  [Example: listening to an event with `runner.events`](https://github.com/graphile/worker/blob/main/README.md#example-listening-to-an-event-with-runnerevents)
+  example; it's designed to be run standalone
+- `tasks/task_2.js` to be used with `await addJob("task_2", { foo: "bar" });`;
+  to run this you can run `graphile-worker -c your_database_here` in this folder
+  and it should pick up the task automatically.

--- a/examples/readme/events.js
+++ b/examples/readme/events.js
@@ -1,0 +1,42 @@
+const { run, quickAddJob } = require(/* "graphile-worker" */ "../..");
+
+async function main() {
+  // Run a worker to execute jobs:
+  const runner = await run({
+    connectionString: "postgres:///my_db",
+    concurrency: 5,
+    // Install signal handlers for graceful shutdown on SIGINT, SIGTERM, etc
+    noHandleSignals: false,
+    pollInterval: 1000,
+    // you can set the taskList or taskDirectory but not both
+    taskList: {
+      hello: async (payload, helpers) => {
+        const { name } = payload;
+        helpers.logger.info(`Hello, ${name}`);
+      },
+    },
+    // or:
+    //   taskDirectory: `${__dirname}/tasks`,
+  });
+
+  runner.events.on("job:success", ({ worker, job }) => {
+    console.log(`Hooray! Worker ${worker.workerId} completed job ${job.id}`);
+  });
+
+  // Or add a job to be executed:
+  await quickAddJob(
+    // makeWorkerUtils options
+    { connectionString: "postgres:///my_db" },
+
+    // Task identifier
+    "hello",
+
+    // Payload
+    { name: "Bobby Tables" },
+  );
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/examples/readme/tasks/task_2.js
+++ b/examples/readme/tasks/task_2.js
@@ -1,0 +1,4 @@
+module.exports = async (payload, helpers) => {
+  // async is optional, but best practice
+  helpers.logger.debug(`Received ${JSON.stringify(payload)}`);
+};

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -427,6 +427,16 @@ export type WorkerEvents = TypedEventEmitter<{
   "worker:create": { worker: Worker; tasks: TaskList };
 
   /**
+   * When a worker release is requested
+   */
+  "worker:release": { worker: Worker };
+
+  /**
+   * When a worker stops (normally after a release)
+   */
+  "worker:stop": { worker: Worker; error?: any };
+
+  /**
    * When a worker calls get_job but there are no available jobs
    */
   "worker:getJob:error": { worker: Worker; error: any };

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -1,4 +1,5 @@
 import * as assert from "assert";
+import { EventEmitter } from "events";
 import { Client, Pool } from "pg";
 
 import { defaults } from "./config";
@@ -8,11 +9,13 @@ import {
   RunnerOptions,
   SharedOptions,
   WithPgClient,
+  WorkerEvents,
 } from "./interfaces";
 import { defaultLogger, Logger, LogScope } from "./logger";
 import { migrate } from "./migrate";
 
 interface CompiledSharedOptions {
+  events: WorkerEvents;
   logger: Logger;
   workerSchema: string;
   escapedWorkerSchema: string;
@@ -33,9 +36,11 @@ export function processSharedOptions(
     const {
       logger = defaultLogger,
       schema: workerSchema = defaults.schema,
+      events = new EventEmitter(),
     } = options;
     const escapedWorkerSchema = Client.prototype.escapeIdentifier(workerSchema);
     compiled = {
+      events,
       logger,
       workerSchema,
       escapedWorkerSchema,

--- a/src/main.ts
+++ b/src/main.ts
@@ -263,11 +263,6 @@ export const runTaskListOnce = (
   options: WorkerOptions,
   tasks: TaskList,
   client: PoolClient,
-) => {
-  return makeNewWorker(
-    options,
-    tasks,
-    makeWithPgClientFromClient(client),
-    false,
-  ).promise;
-};
+) =>
+  makeNewWorker(options, tasks, makeWithPgClientFromClient(client), false)
+    .promise;

--- a/src/main.ts
+++ b/src/main.ts
@@ -102,11 +102,7 @@ export function runTaskList(
 ): WorkerPool {
   const { logger, escapedWorkerSchema, events } = processSharedOptions(options);
   logger.debug(`Worker pool options are ${inspect(options)}`, { options });
-  const {
-    concurrency = defaults.concurrentJobs,
-    noHandleSignals,
-    ...workerOptions
-  } = options;
+  const { concurrency = defaults.concurrentJobs, noHandleSignals } = options;
 
   if (!noHandleSignals) {
     // Clean up when certain signals occur
@@ -251,7 +247,7 @@ export function runTaskList(
   // Spawn our workers; they can share clients from the pool.
   const withPgClient = makeWithPgClientFromPool(pgPool);
   for (let i = 0; i < concurrency; i++) {
-    workers.push(makeNewWorker(workerOptions, tasks, withPgClient));
+    workers.push(makeNewWorker(options, tasks, withPgClient));
   }
 
   // TODO: handle when a worker shuts down (spawn a new one)

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,3 +1,4 @@
+import { EventEmitter } from "events";
 import { Pool, PoolClient } from "pg";
 import { inspect } from "util";
 
@@ -11,6 +12,7 @@ import {
   Job,
   TaskList,
   Worker,
+  WorkerEvents,
   WorkerOptions,
   WorkerPool,
   WorkerPoolOptions,
@@ -25,14 +27,38 @@ const allWorkerPools: Array<WorkerPool> = [];
 // Exported for testing only
 export { allWorkerPools as _allWorkerPools };
 
+/**
+ * All pools share the same signal handlers, so we need to broadcast
+ * gracefulShutdown to all the pools' events; we use this event emitter to
+ * aggregate these requests.
+ */
+let _signalHandlersEventEmitter: WorkerEvents = new EventEmitter();
+
+/**
+ * Only register the signal handlers once _globally_.
+ */
 let _registeredSignalHandlers = false;
+
+/**
+ * Only trigger graceful shutdown once.
+ */
 let _shuttingDown = false;
-function registerSignalHandlers(logger: Logger) {
+
+/**
+ * This will register the signal handlers to make sure the worker shuts down
+ * gracefully if it can. It will only register signal handlers once; even if
+ * you call it multiple times it will always use the first logger it is passed,
+ * future calls will register the events but take no further actions.
+ */
+function registerSignalHandlers(logger: Logger, events: WorkerEvents) {
   if (_shuttingDown) {
     throw new Error(
       "System has already gone into shutdown, should not be spawning new workers now!",
     );
   }
+  _signalHandlersEventEmitter.on("gracefulShutdown", (o) =>
+    events.emit("gracefulShutdown", o),
+  );
   if (_registeredSignalHandlers) {
     return;
   }
@@ -54,6 +80,7 @@ function registerSignalHandlers(logger: Logger) {
         return;
       }
       _shuttingDown = true;
+      _signalHandlersEventEmitter.emit("gracefulShutdown", { signal });
       Promise.all(
         allWorkerPools.map((pool) =>
           pool.gracefulShutdown(`Forced worker shutdown due to ${signal}`),
@@ -73,7 +100,7 @@ export function runTaskList(
   tasks: TaskList,
   pgPool: Pool,
 ): WorkerPool {
-  const { logger, escapedWorkerSchema } = processSharedOptions(options);
+  const { logger, escapedWorkerSchema, events } = processSharedOptions(options);
   logger.debug(`Worker pool options are ${inspect(options)}`, { options });
   const {
     concurrency = defaults.concurrentJobs,
@@ -83,7 +110,7 @@ export function runTaskList(
 
   if (!noHandleSignals) {
     // Clean up when certain signals occur
-    registerSignalHandlers(logger);
+    registerSignalHandlers(logger, events);
   }
 
   const promise = deferred();
@@ -105,64 +132,10 @@ export function runTaskList(
     }
   };
 
-  const listenForChanges = (
-    err: Error | undefined,
-    client: PoolClient,
-    release: () => void,
-  ) => {
-    if (err) {
-      logger.error(
-        `Error connecting with notify listener (trying again in 5 seconds): ${err.message}`,
-        { error: err },
-      );
-      // Try again in 5 seconds
-      setTimeout(() => {
-        pgPool.connect(listenForChanges);
-      }, 5000);
-      return;
-    }
-    listenForChangesClient = client;
-    client.on("notification", () => {
-      if (listenForChangesClient === client) {
-        // Find a worker that's available
-        workers.some((worker) => worker.nudge());
-      }
-    });
-
-    // Subscribe to jobs:insert message
-    client.query('LISTEN "jobs:insert"');
-
-    // On error, release this client and try again
-    client.on("error", (e: Error) => {
-      logger.error(`Error with database notify listener: ${e.message}`, {
-        error: e,
-      });
-      listenForChangesClient = null;
-      try {
-        release();
-      } catch (e) {
-        logger.error(`Error occurred releasing client: ${e.stack}`, {
-          error: e,
-        });
-      }
-      pgPool.connect(listenForChanges);
-    });
-
-    const supportedTaskNames = Object.keys(tasks);
-
-    logger.info(
-      `Worker connected and looking for jobs... (task names: '${supportedTaskNames.join(
-        "', '",
-      )}')`,
-    );
-  };
-
-  // Create a client dedicated to listening for new jobs.
-  pgPool.connect(listenForChanges);
-
   // This is a representation of us that can be interacted with externally
-  const workerPool = {
+  const workerPool: WorkerPool = {
     release: async () => {
+      events.emit("pool:release", { pool: this });
       unlistenForChanges();
       promise.resolve();
       await Promise.all(workers.map((worker) => worker.release()));
@@ -172,6 +145,7 @@ export function runTaskList(
 
     // Make sure we clean up after ourselves even if a signal is caught
     async gracefulShutdown(message: string) {
+      events.emit("pool:gracefulShutdown", { pool: this, message });
       try {
         logger.debug(`Attempting graceful shutdown`);
         // Release all our workers' jobs
@@ -198,6 +172,7 @@ export function runTaskList(
         });
         logger.debug("Jobs released");
       } catch (e) {
+        events.emit("pool:gracefulShutdown:error", { pool: this, error: e });
         logger.error(`Error occurred during graceful shutdown: ${e.message}`, {
           error: e,
         });
@@ -211,6 +186,67 @@ export function runTaskList(
 
   // Ensure that during a forced shutdown we get cleaned up too
   allWorkerPools.push(workerPool);
+  events.emit("pool:create", { workerPool });
+
+  const listenForChanges = (
+    err: Error | undefined,
+    client: PoolClient,
+    release: () => void,
+  ) => {
+    if (err) {
+      events.emit("pool:listen:error", { workerPool, client, error: err });
+      logger.error(
+        `Error connecting with notify listener (trying again in 5 seconds): ${err.message}`,
+        { error: err },
+      );
+      // Try again in 5 seconds
+      setTimeout(() => {
+        pgPool.connect(listenForChanges);
+      }, 5000);
+      return;
+    }
+    events.emit("pool:listen:success", { workerPool, client });
+    listenForChangesClient = client;
+    client.on("notification", () => {
+      if (listenForChangesClient === client) {
+        // Find a worker that's available
+        workers.some((worker) => worker.nudge());
+      }
+    });
+
+    // On error, release this client and try again
+    client.on("error", (e: Error) => {
+      events.emit("pool:listen:error", { workerPool, client, error: e });
+      logger.error(`Error with database notify listener: ${e.message}`, {
+        error: e,
+      });
+      listenForChangesClient = null;
+      try {
+        release();
+      } catch (e) {
+        logger.error(`Error occurred releasing client: ${e.stack}`, {
+          error: e,
+        });
+      }
+      events.emit("pool:listen:connecting", { workerPool });
+      pgPool.connect(listenForChanges);
+    });
+
+    // Subscribe to jobs:insert message
+    client.query('LISTEN "jobs:insert"');
+
+    const supportedTaskNames = Object.keys(tasks);
+
+    logger.info(
+      `Worker connected and looking for jobs... (task names: '${supportedTaskNames.join(
+        "', '",
+      )}')`,
+    );
+  };
+
+  // Create a client dedicated to listening for new jobs.
+  events.emit("pool:listen:connecting", { workerPool });
+  pgPool.connect(listenForChanges);
 
   // Spawn our workers; they can share clients from the pool.
   const withPgClient = makeWithPgClientFromPool(pgPool);
@@ -227,6 +263,11 @@ export const runTaskListOnce = (
   options: WorkerOptions,
   tasks: TaskList,
   client: PoolClient,
-) =>
-  makeNewWorker(options, tasks, makeWithPgClientFromClient(client), false)
-    .promise;
+) => {
+  return makeNewWorker(
+    options,
+    tasks,
+    makeWithPgClientFromClient(client),
+    false,
+  ).promise;
+};

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -75,6 +75,7 @@ export const run = async (
     release,
     releasers,
     addJob,
+    events,
   } = await getUtilsAndReleasersFromOptions(options);
 
   try {
@@ -89,6 +90,7 @@ export const run = async (
       async stop() {
         if (running) {
           running = false;
+          events.emit("stop", {});
           await release();
         } else {
           throw new Error("Runner is already stopped");
@@ -96,6 +98,7 @@ export const run = async (
       },
       addJob,
       promise: workerPool.promise,
+      events,
     };
   } catch (e) {
     await release();

--- a/src/signals.ts
+++ b/src/signals.ts
@@ -1,3 +1,11 @@
+export type Signal =
+  | "SIGUSR2"
+  | "SIGINT"
+  | "SIGTERM"
+  | "SIGPIPE"
+  | "SIGHUP"
+  | "SIGABRT";
+
 export default [
   "SIGUSR2",
   "SIGINT",
@@ -5,4 +13,4 @@ export default [
   "SIGPIPE",
   "SIGHUP",
   "SIGABRT",
-] as Array<"SIGUSR2" | "SIGINT" | "SIGTERM" | "SIGPIPE" | "SIGHUP" | "SIGABRT">;
+] as Array<Signal>;

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -38,6 +38,14 @@ export function makeNewWorker(
     },
   });
   const promise = deferred();
+  promise.then(
+    () => {
+      events.emit("worker:stop", { worker });
+    },
+    (error) => {
+      events.emit("worker:stop", { worker, error });
+    },
+  );
   let activeJob: Job | null = null;
 
   let doNextTimer: NodeJS.Timer | null = null;
@@ -56,6 +64,7 @@ export function makeNewWorker(
       return;
     }
     active = false;
+    events.emit("worker:release", { worker });
     if (cancelDoNext()) {
       // Nothing in progress; resolve the promise
       promise.resolve();


### PR DESCRIPTION
## Description

There's lots of events that happen inside of Graphile Worker that library consumers might be interested in; this PR raises these events with an event system.

**IMPORTANT**: people registering event handlers **MUST** make sure that these handlers do **NOT** throw errors. We've wrapped the `emit` with a try/catch that swallows the error in the two most dangerous places, but consumers must be certain that errors are not thrown as this may cause unexpected states of the work queue to take place.

Events added so far:

- `pool:create` - When a worker pool is created
- `pool:listen:connecting` - When a worker pool attempts to connect to PG ready to issue a LISTEN statement
- `pool:listen:success` - When a worker pool starts listening for jobs via PG LISTEN
- `pool:listen:error` - When a worker pool faces an error on their PG LISTEN client
- `pool:release` - When a worker pool is released
- `pool:gracefulShutdown` - When a worker pool starts a graceful shutdown
- `pool:gracefulShutdown:error` - When a worker pool graceful shutdown throws an error
- `worker:create` - When a worker is created
- `worker:release` - When release of a worker is requested
- `worker:stop` - When a worker stops (normally after a release)
- `worker:getJob:error` - When a worker calls get_job but there are no available jobs
- `worker:getJob:empty` - When a worker calls get_job but there are no available jobs
- `worker:fatalError` - When a worker is created
- `job:start` - When a job is retrieved by get_job
- `job:success` - When a job completes successfully
- `job:error` - When a job throws an error
- `job:failed` - When a job fails permanently (emitted after job:error when appropriate)
- `gracefulShutdown` - When the runner is terminated by a signal
- `stop` - When the runner is stopped

Fixes #28 

## Performance impact

There must be an impact, but it seems too small to show up in benchmarks.

## Security impact

None known.
