### PR TITLE
chore(ci): separate linting into its own action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,8 +39,19 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
       - run: yarn --frozen-lockfile
-      - run: yarn lint
       - run: yarn jest -i --ci
+
+  lint:
+    runs-on: ubuntu-18.04
+
+    steps:
+      - uses: actions/checkout@v1
+      - name: Use Node.js 14.x
+        uses: actions/setup-node@v1
+        with:
+          node-version: 14.x
+      - run: yarn --frozen-lockfile
+      - run: yarn lint
 
   altschema:
     runs-on: ubuntu-18.04


### PR DESCRIPTION
Doesn't make sense to run the linting in all the different environments.