### PR TITLE
docs(README): note about awaiting runner.promise

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,10 @@ async function main() {
     // Payload
     { name: "Bobby Tables" },
   );
+
+  // If the worker exits (whether through fatal error or otherwise), this
+  // promise will resolve/reject:
+  await runner.promise;
 }
 
 main().catch((err) => {

--- a/examples/readme/events.js
+++ b/examples/readme/events.js
@@ -34,6 +34,10 @@ async function main() {
     // Payload
     { name: "Bobby Tables" },
   );
+
+  // If the worker exits (whether through fatal error or otherwise), this
+  // promise will resolve/reject:
+  await runner.promise;
 }
 
 main().catch((err) => {


### PR DESCRIPTION
If you use the worker in library mode and you have an issue whereby a job cannot be released (marked as success or failure) then the entire worker will exit with a fatal error. You should await `runner.promise` so that you know about this; and on error you can take the appropriate action (logging the error, restarting the worker, exiting the process, whatever makes sense for you).