### PR TITLE
chore(ci): don't lint altschema

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,7 +79,7 @@ jobs:
         with:
           node-version: 12.x
       - run: yarn --frozen-lockfile
-      - run: yarn lint
+      # - run: yarn lint # No need to lint altschema
       - run: yarn jest -i --ci
 
   database_updated:


### PR DESCRIPTION
No need, and on lint error it makes it seem altschema has issues too (misleading).