### PR TITLE
chore(perfTest): solve confusion via logging++

### DIFF
--- a/perfTest/b.js
+++ b/perfTest/b.js
@@ -1,3 +1,3 @@
 const a = require("./n").a;
-console.log(`a is ${a}`);
-exports.b = a + 2;
+console.log(`perfTest/b.js cyclic check: a is ${a} (expect 3)`);
+exports.b = a + 2; /* 5 */

--- a/perfTest/n.js
+++ b/perfTest/n.js
@@ -1,6 +1,6 @@
 const a = 3;
 exports.a = a;
 const b = require("./b").b;
-const n = a + b;
+const n = a + b; /* 3 + 5 */
 exports.n = n;
-console.log(`n is ${n}`);
+console.log(`perfTest/n.js cyclic check: n is ${n} (expect 8)`);


### PR DESCRIPTION
Just seeing `a is 3`, `n is 8` logged is kinda useless. This improves those logging messages.