### PR TITLE
feat(cli): --crontab option to give alternative crontab path

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,24 +238,31 @@ The following CLI options are available:
 
 ```
 Options:
-  --help               Show help                                       [boolean]
-  --version            Show version number                             [boolean]
-  --connection, -c     Database connection string, defaults to the
-                       'DATABASE_URL' envvar                            [string]
-  --schema, -s         The database schema in which Graphile Worker is (to be)
-                       located             [string] [default: "graphile_worker"]
-  --schema-only        Just install (or update) the database schema, then exit
-                                                      [boolean] [default: false]
-  --once               Run until there are no runnable jobs left, then exit
-                                                      [boolean] [default: false]
-  --watch, -w          [EXPERIMENTAL] Watch task files for changes,
-                       automatically reloading the task code without restarting
-                       worker                         [boolean] [default: false]
-  --jobs, -j           number of jobs to run concurrently  [number] [default: 1]
-  --max-pool-size, -m  maximum size of the PostgreSQL pool[number] [default: 10]
-  --poll-interval      how long to wait between polling for jobs in milliseconds
-                       (for jobs scheduled in the future/retries)
-                                                        [number] [default: 2000]
+      --help                    Show help                              [boolean]
+      --version                 Show version number                    [boolean]
+  -c, --connection              Database connection string, defaults to the
+                                'DATABASE_URL' envvar                   [string]
+  -s, --schema                  The database schema in which Graphile Worker is
+                                (to be) located
+                                           [string] [default: "graphile_worker"]
+      --schema-only             Just install (or update) the database schema,
+                                then exit             [boolean] [default: false]
+      --once                    Run until there are no runnable jobs left, then
+                                exit                  [boolean] [default: false]
+  -w, --watch                   [EXPERIMENTAL] Watch task files for changes,
+                                automatically reloading the task code without
+                                restarting worker     [boolean] [default: false]
+      --crontab                 override path to crontab file           [string]
+  -j, --jobs                    number of jobs to run concurrently
+                                                           [number] [default: 1]
+  -m, --max-pool-size           maximum size of the PostgreSQL pool
+                                                          [number] [default: 10]
+      --poll-interval           how long to wait between polling for jobs in
+                                milliseconds (for jobs scheduled in the
+                                future/retries)         [number] [default: 2000]
+      --no-prepared-statements  set this flag if you want to disable prepared
+                                statements, e.g. for compatibility with
+                                pgBouncer             [boolean] [default: false]
 ```
 
 ## Library usage: running jobs

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -42,6 +42,10 @@ const argv = yargs
     default: false,
   })
   .boolean("watch")
+  .option("crontab", {
+    description: "override path to crontab file",
+  })
+  .string("crontab")
   .option("jobs", {
     description: "number of jobs to run concurrently",
     alias: "j",
@@ -124,7 +128,7 @@ async function main() {
   const watchedTasks = await getTasks(options, `${process.cwd()}/tasks`, WATCH);
   const watchedCronItems = await getCronItems(
     options,
-    `${process.cwd()}/crontab`,
+    argv.crontab || `${process.cwd()}/crontab`,
     WATCH,
   );
 


### PR DESCRIPTION
## Description

Graphile Starter uses `dist/tasks/*.js` for tasks, because the original tasks are written in TypeScript and worker doesn't (currently) support loading tasks in anything but native JS. Putting the crontab file in `dist` feels very wrong; putting it in `src` and copying it seems like a pain, and using a symlink is not cross-platform enough (and further may not support watch mode well). I decided the best way to deal with this would be to let you override the path to the crontab.

## Performance impact

Negligible.

## Security impact

None known.