### PR TITLE
feat: switch out custom logger with @graphile/logger

### DIFF
--- a/README.md
+++ b/README.md
@@ -712,14 +712,17 @@ export interface TaskSpec {
 
 ## Logger
 
-By default we log to the `console`, and debug-level messages are not output
-unless you have the environmental variable `GRAPHILE_WORKER_DEBUG=1`.
+We use [`@graphile/logger`](https://github.com/graphile/logger) as a log
+abstraction so that you can log to whatever logging facilities you like. By
+default this will log to `console`, and debug-level messages are not output
+unless you have the environmental variable `GRAPHILE_LOGGER_DEBUG=1`. You can
+override this by passing a custom `logger`.
 
 It's recommended that your tasks always use the methods on `helpers.logger` for
 logging so that you can later route your messages to a different log store if
-you want to. There are 4 methods, one for each level of severity (error, warn,
-info, debug), and each accept a string as the first argument and optionally an
-arbitrary object as the second argument:
+you want to. There are 4 methods, one for each level of severity (`error`,
+`warn`, `info`, `debug`), and each accept a string as the first argument and
+optionally an arbitrary object as the second argument:
 
 - `helpers.logger.error(message: string, meta?: LogMeta)`
 - `helpers.logger.warn(message: string, meta?: LogMeta)`
@@ -768,8 +771,8 @@ The return result of the logger function is currently ignored; but we strongly
 recommend that for future compatibility you do not return anything from your
 logger function.
 
-See `consoleLogFactory` in [src/logger.ts](src/logger.ts) for an example
-logFactory.
+See the [`@graphile/logger`](https://github.com/graphile/logger) documentation
+for more information.
 
 **NOTE**: you do not need to (and should not) customise, inherit or extend the
 `Logger` class at all.
@@ -839,8 +842,9 @@ Each task function is passed two arguments:
 
 So that you may redirect logs to your preferred logging provider, we have
 enabled you to supply your own logging provider. Overriding this is currently
-only available in library mode. We then wrap this logging provider with a helper
-class to ease debugging; the helper class has the following methods:
+only available in library mode (see [Logger](#logger)). We then wrap this
+logging provider with a helper class to ease debugging; the helper class has the
+following methods:
 
 - `error(message, meta?)`: for logging errors, similar to `console.error`
 - `warn(message, meta?)`: for logging warnings, similar to `console.warn`

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,10 @@
 # Release notes
 
+### Pending
+
+- Replace `Logger` with new
+  [`@graphile/logger`](https://github.com/graphile/logger) module
+
 ### v0.10.0
 
 - No longer exit on SIGPIPE (Node will swallow this error code)

--- a/__tests__/helpers.ts
+++ b/__tests__/helpers.ts
@@ -28,7 +28,7 @@ export {
 // extends the default timeout just in case.
 jest.setTimeout(15000);
 
-// process.env.GRAPHILE_WORKER_DEBUG = "1";
+// process.env.GRAPHILE_LOGGER_DEBUG = "1";
 
 export const TEST_CONNECTION_STRING =
   process.env.TEST_CONNECTION_STRING || "graphile_worker_test";

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
   },
   "homepage": "https://github.com/graphile/worker#readme",
   "dependencies": {
+    "@graphile/logger": "^0.2.0",
     "@types/debug": "^4.1.2",
     "@types/pg": "^7.14.3",
     "chokidar": "^3.4.0",

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -1,10 +1,13 @@
+// For backwards compatibility
+if (process.env.GRAPHILE_WORKER_DEBUG) {
+  process.env.GRAPHILE_LOGGER_DEBUG = process.env.GRAPHILE_WORKER_DEBUG;
+}
+
 import {
   LogFunctionFactory as GraphileLogFunctionFactory,
   Logger as GraphileLogger,
   makeConsoleLogFactory,
 } from "@graphile/logger";
-
-export { consoleLogFactory } from "@graphile/logger";
 
 export interface LogScope {
   label?: string;
@@ -16,6 +19,7 @@ export interface LogScope {
 // For backwards compatibility
 export type Logger = GraphileLogger<LogScope>;
 export type LogFunctionFactory = GraphileLogFunctionFactory<LogScope>;
+export const consoleLogFactory = makeConsoleLogFactory<LogScope>();
 
 export const defaultLogger = new GraphileLogger<LogScope>(
   makeConsoleLogFactory({

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -1,3 +1,11 @@
+import {
+  LogFunctionFactory as GraphileLogFunctionFactory,
+  Logger as GraphileLogger,
+  makeConsoleLogFactory,
+} from "@graphile/logger";
+
+export { consoleLogFactory } from "@graphile/logger";
+
 export interface LogScope {
   label?: string;
   workerId?: string;
@@ -5,88 +13,22 @@ export interface LogScope {
   jobId?: string;
 }
 
-export interface LogMeta {
-  [key: string]: unknown;
-}
+// For backwards compatibility
+export type Logger = GraphileLogger<LogScope>;
+export type LogFunctionFactory = GraphileLogFunctionFactory<LogScope>;
 
-// Inspired by the 'winston' levels: https://github.com/winstonjs/winston#logging-levels
-export enum LogLevel {
-  ERROR = "error",
-  WARNING = "warning",
-  INFO = "info",
-  DEBUG = "debug",
-}
-
-export interface LogFunction {
-  (level: LogLevel, message: string, meta?: LogMeta): void;
-}
-
-export interface LogFunctionFactory {
-  (scope: LogScope): LogFunction;
-}
-
-export class Logger {
-  private _scope: LogScope;
-  private _logFactory: LogFunctionFactory;
-
-  private log: LogFunction;
-
-  constructor(logFactory: LogFunctionFactory, scope: LogScope = {}) {
-    this._scope = scope;
-    this._logFactory = logFactory;
-
-    this.log = logFactory(scope);
-  }
-
-  scope(additionalScope: LogScope) {
-    return new Logger(this._logFactory, { ...this._scope, ...additionalScope });
-  }
-
-  error(message: string, meta?: LogMeta): void {
-    return this.log(LogLevel.ERROR, message, meta);
-  }
-  warn(message: string, meta?: LogMeta): void {
-    return this.log(LogLevel.WARNING, message, meta);
-  }
-  info(message: string, meta?: LogMeta): void {
-    return this.log(LogLevel.INFO, message, meta);
-  }
-  debug(message: string, meta?: LogMeta): void {
-    return this.log(LogLevel.DEBUG, message, meta);
-  }
-}
-
-// The default console logger does not output metadata
-export const consoleLogFactory = (scope: LogScope) => (
-  level: LogLevel,
-  message: string,
-) => {
-  if (level === LogLevel.DEBUG && !process.env.GRAPHILE_WORKER_DEBUG) {
-    return;
-  }
-  let method: "error" | "warn" | "info" | "log" = (() => {
-    switch (level) {
-      case LogLevel.ERROR:
-        return "error";
-      case LogLevel.WARNING:
-        return "warn";
-      case LogLevel.INFO:
-        return "info";
-      default:
-        return "log";
-    }
-  })();
-  console[method](
-    `[%s%s] %s: %s`,
-    scope.label || "core",
-    scope.workerId
-      ? `(${scope.workerId}${
-          scope.taskIdentifier ? `: ${scope.taskIdentifier}` : ""
-        }${scope.jobId ? `{${scope.jobId}}` : ""})`
-      : "",
-    level.toUpperCase(),
-    message,
-  );
-};
-
-export const defaultLogger = new Logger(consoleLogFactory);
+export const defaultLogger = new GraphileLogger<LogScope>(
+  makeConsoleLogFactory({
+    format: `[%s%s] %s: %s`,
+    formatParameters(level, message, scope) {
+      const taskText = scope.taskIdentifier ? `: ${scope.taskIdentifier}` : "";
+      const jobIdText = scope.jobId ? `{${scope.jobId}}` : "";
+      return [
+        scope.label || "core",
+        scope.workerId ? `(${scope.workerId}${taskText}${jobIdText})` : "",
+        level.toUpperCase(),
+        message,
+      ];
+    },
+  }),
+);

--- a/yarn.lock
+++ b/yarn.lock
@@ -294,6 +294,11 @@
     minimatch "^3.0.4"
     strip-json-comments "^3.1.1"
 
+"@graphile/logger@^0.2.0":
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/@graphile/logger/-/logger-0.2.0.tgz#e484ec420162157c6e6f0cfb080fa29ef3a714ba"
+  integrity sha512-jjcWBokl9eb1gVJ85QmoaQ73CQ52xAaOCF29ukRbYNl6lY+ts0ErTaDYOBlejcbUs2OpaiqYLO5uDhyLFzWw4w==
+
 "@istanbuljs/load-nyc-config@^1.0.0":
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/@istanbuljs/load-nyc-config/-/load-nyc-config-1.1.0.tgz#fd3db1d59ecf7cf121e80650bb86712f9b55eced"


### PR DESCRIPTION
## Description

Trying to standardize on one logging framework across the stack; so I've extracted out the worker logger into a new library which I've enhanced and documented better:

https://github.com/graphile/logger

This PR ports this new library back into worker :grin: 

## Performance impact

Negligible.

## Security impact

None known.

## Checklist

- [x] My code matches the project's code style and `yarn lint:fix` passes.
- [x] I've added tests for the new feature, and `yarn test` passes.
- [x] I have detailed the new feature in the relevant documentation.
- [x] I have added this feature to 'Pending' in the `RELEASE_NOTES.md` file (if one exists).
- [x] If this is a breaking change I've explained why.

<!-- For some Graphile projects the documentation is the README.md file, for
      others please see https://github.com/graphile/graphile.github.io -->
