### PR TITLE
fix(errors): more thorough error handling

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,9 @@
 # Release notes
 
+### v0.11.1
+
+- Handles unexpected errors whilst PostgreSQL client is idle
+
 ### v0.11.0
 
 - Export `getCronItems` so library-mode users can watch the crontab file


### PR DESCRIPTION
## Description

If an error occurred on a client that was checked out from the pool when the client wasn't being actively used (e.g. the server terminated the client, the network timed out, etc) then the client would emit the `error` event. For long running clients we register an error handler to catch this, but it seems that short running clients can also be vulnerable to it under the right conditions.

Fixes #178.

## Performance impact

Negligible.

## Security impact

Fixes a potential unexpected server exit.

## Checklist

<!-- If this PR is work in progress, please open it as a "Draft PR". -->
<!-- To tick a checkbox, change it from `[ ]` to `[x]` -->

- [x] My code matches the project's code style and `yarn lint:fix` passes.
- [ ] I've added tests for the new feature, and `yarn test` passes.
- [ ] I have detailed the new feature in the relevant documentation.
- [x] I have added this feature to 'Pending' in the `RELEASE_NOTES.md` file (if one exists).
- [x] If this is a breaking change I've explained why.

<!-- For some Graphile projects the documentation is the README.md file, for
      others please see https://github.com/graphile/graphile.github.io -->
