### PR TITLE
docs(README): use @graphile/logger in logger example

### DIFF
--- a/README.md
+++ b/README.md
@@ -733,7 +733,8 @@ You may customise where log messages from `graphile-worker` (and your tasks) go
 by supplying a custom `Logger` instance using your own `logFactory`.
 
 ```js
-const { Logger, run } = require("graphile-worker");
+const { Logger } = require('@graphile/logger');
+const { run } = require("graphile-worker");
 
 /* Replace this function with your own implementation */
 function logFactory(scope) {


### PR DESCRIPTION
## Description

<!-- If this PR adds a feature, what does it add and what was the motivation for it? -->
First things first: thanks @benjie for your great work on the graphile project 🙏 

After upgrading from `graphile-worker@0.9.0` to  `0.11.2` my custom logger setup failed with this message:
```
graphile_worker_1.Logger is not a constructor
TypeError: graphile_worker_1.Logger is not a constructor
```
I still imported Logger from `graphile-worker` as stated in the README, but as TS told me `'Logger' only refers to a type, but is being used as a value here.`

Installing `@graphile/logger` and importing the `Logger` from it fixed the issue for me. So I thought it might be helpful to update the docs.


## Checklist
n/a