### PR TITLE
fix: restore Logger export

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,9 @@
 # Release notes
 
+### v0.11.3
+
+- Restores `Logger` export accidentally removed in v0.11.0
+
 ### v0.11.2
 
 - Added support for wider range of `@types/pg` dependency

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -17,11 +17,11 @@ export interface LogScope {
 }
 
 // For backwards compatibility
-export type Logger = GraphileLogger<LogScope>;
+export class Logger extends GraphileLogger<LogScope> {}
 export type LogFunctionFactory = GraphileLogFunctionFactory<LogScope>;
 export const consoleLogFactory = makeConsoleLogFactory<LogScope>();
 
-export const defaultLogger = new GraphileLogger<LogScope>(
+export const defaultLogger = new Logger(
   makeConsoleLogFactory({
     format: `[%s%s] %s: %s`,
     formatParameters(level, message, scope) {


### PR DESCRIPTION
## Description

We accidentally turned the `Logger` export into a type-only export. This fixes that regression.

Fixes #192 

## Performance impact

None.

## Security impact

None.

## Checklist

- [x] My code matches the project's code style and `yarn lint:fix` passes.
- [ ] ~~I've added tests for the new feature, and `yarn test` passes.~~
- [ ] ~~I have detailed the new feature in the relevant documentation.~~
- [x] I have added this feature to 'Pending' in the `RELEASE_NOTES.md` file (if one exists).
- [ ] ~~If this is a breaking change I've explained why.~~

<!-- For some Graphile projects the documentation is the README.md file, for
      others please see https://github.com/graphile/graphile.github.io -->
