### PR TITLE
fix(docs): "nohandleSignals" => "noHandleSignals"

### DIFF
--- a/README.md
+++ b/README.md
@@ -295,7 +295,7 @@ The following options for these methods are available.
 
 - `concurrency`: The equivalent of the CLI `--jobs` option with the same default
   value.
-- `nohandleSignals`: If set true, we won't install signal handlers and it'll be
+- `noHandleSignals`: If set true, we won't install signal handlers and it'll be
   up to you to handle graceful shutdown of the worker if the process receives a
   signal.
 - `pollInterval`: The equivalent of the CLI `--poll-interval` option with the


### PR DESCRIPTION
## Description

Fix doc typo in readme. "nohandleSignals" should be "noHandleSignals".

## Performance impact

N/A

## Security impact

N/A

## Checklist

<!-- If this PR is work in progress, please open it as a "Draft PR". -->
<!-- To tick a checkbox, change it from `[ ]` to `[x]` -->

- [ ] My code matches the project's code style and `yarn lint:fix` passes.
- [ ] I've added tests for the new feature, and `yarn test` passes.
- [ ] I have detailed the new feature in the relevant documentation.
- [ ] I have added this feature to 'Pending' in the `RELEASE_NOTES.md` file (if one exists).
- [ ] If this is a breaking change I've explained why.

<!-- For some Graphile projects the documentation is the README.md file, for
      others please see https://github.com/graphile/graphile.github.io -->
