### PR TITLE
allow custom job lock interval

### DIFF
--- a/sql/000009.sql
+++ b/sql/000009.sql
@@ -1,0 +1,235 @@
+alter table :GRAPHILE_WORKER_SCHEMA.jobs add locked_duration interval;
+
+drop function :GRAPHILE_WORKER_SCHEMA.add_job(text, json, text, timestamptz, int, text, int, text[], text);
+create function :GRAPHILE_WORKER_SCHEMA.add_job(
+  identifier text,
+  payload json = null,
+  queue_name text = null,
+  run_at timestamptz = null,
+  max_attempts integer = null,
+  job_key text = null,
+  priority integer = null,
+  flags text[] = null,
+  job_key_mode text = 'replace',
+  locked_duration interval = null
+) returns :GRAPHILE_WORKER_SCHEMA.jobs as $$
+declare
+  v_job :GRAPHILE_WORKER_SCHEMA.jobs;
+  v_now timestamptz = now();
+begin
+  -- Apply rationality checks
+  if length(identifier) > 128 then
+    raise exception 'Task identifier is too long (max length: 128).' using errcode = 'GWBID';
+  end if;
+  if queue_name is not null and length(queue_name) > 128 then
+    raise exception 'Job queue name is too long (max length: 128).' using errcode = 'GWBQN';
+  end if;
+  if job_key is not null and length(job_key) > 512 then
+    raise exception 'Job key is too long (max length: 512).' using errcode = 'GWBJK';
+  end if;
+  if max_attempts < 1 then
+    raise exception 'Job maximum attempts must be at least 1.' using errcode = 'GWBMA';
+  end if;
+  if job_key is not null and (job_key_mode is null or job_key_mode in ('replace', 'preserve_run_at')) then
+    -- Upsert job if existing job isn't locked, but in the case of locked
+    -- existing job create a new job instead as it must have already started
+    -- executing (i.e. it's world state is out of date, and the fact add_job
+    -- has been called again implies there's new information that needs to be
+    -- acted upon).
+    insert into :GRAPHILE_WORKER_SCHEMA.jobs (
+      task_identifier,
+      payload,
+      queue_name,
+      run_at,
+      max_attempts,
+      key,
+      priority,
+      flags,
+      locked_duration
+    )
+      values(
+        identifier,
+        coalesce(payload, '{}'::json),
+        queue_name,
+        coalesce(run_at, now()),
+        coalesce(max_attempts, 25),
+        job_key,
+        coalesce(priority, 0),
+        (
+          select jsonb_object_agg(flag, true)
+          from unnest(flags) as item(flag)
+        ),
+        coalesce(locked_duration, '4 hours'::interval)
+      )
+      on conflict (key) do update set
+        task_identifier=excluded.task_identifier,
+        payload=excluded.payload,
+        queue_name=excluded.queue_name,
+        max_attempts=excluded.max_attempts,
+        run_at=(case
+          when job_key_mode = 'preserve_run_at' and jobs.attempts = 0 then jobs.run_at
+          else excluded.run_at
+        end),
+        priority=excluded.priority,
+        revision=jobs.revision + 1,
+        flags=excluded.flags,
+        locked_duration=jobs.locked_duration,
+        -- always reset error/retry state
+        attempts=0,
+        last_error=null
+        -- replace job is it isn't locked or locked duration has been elapsed
+      where jobs.locked_at is null or jobs.locked_at < (v_now - jobs.locked_duration)
+      returning *
+      into v_job;
+    -- If upsert succeeded (insert or update), return early
+    if not (v_job is null) then
+      return v_job;
+    end if;
+    -- Upsert failed -> there must be an existing job that is locked. Remove
+    -- existing key to allow a new one to be inserted, and prevent any
+    -- subsequent retries of existing job by bumping attempts to the max
+    -- allowed.
+    update :GRAPHILE_WORKER_SCHEMA.jobs
+      set
+        key = null,
+        attempts = jobs.max_attempts
+      where key = job_key;
+  elsif job_key is not null and job_key_mode = 'unsafe_dedupe' then
+    -- Insert job, but if one already exists then do nothing, even if the
+    -- existing job has already started (and thus represents an out-of-date
+    -- world state). This is dangerous because it means that whatever state
+    -- change triggered this add_job may not be acted upon (since it happened
+    -- after the existing job started executing, but no further job is being
+    -- scheduled), but it is useful in very rare circumstances for
+    -- de-duplication. If in doubt, DO NOT USE THIS.
+    insert into :GRAPHILE_WORKER_SCHEMA.jobs (
+      task_identifier,
+      payload,
+      queue_name,
+      run_at,
+      max_attempts,
+      key,
+      priority,
+      flags,
+      locked_duration
+    )
+      values(
+        identifier,
+        coalesce(payload, '{}'::json),
+        queue_name,
+        coalesce(run_at, now()),
+        coalesce(max_attempts, 25),
+        job_key,
+        coalesce(priority, 0),
+        (
+          select jsonb_object_agg(flag, true)
+          from unnest(flags) as item(flag)
+        ),
+        coalesce(locked_duration, '4 hours'::interval)
+      )
+      on conflict (key)
+      -- Bump the revision so that there's something to return
+      do update set revision = jobs.revision + 1
+      returning *
+      into v_job;
+    return v_job;
+  elsif job_key is not null then
+    raise exception 'Invalid job_key_mode value, expected ''replace'', ''preserve_run_at'' or ''unsafe_dedupe''.' using errcode = 'GWBKM';
+  end if;
+  -- insert the new job. Assume no conflicts due to the update above
+  insert into :GRAPHILE_WORKER_SCHEMA.jobs(
+    task_identifier,
+    payload,
+    queue_name,
+    run_at,
+    max_attempts,
+    key,
+    priority,
+    flags,
+    locked_duration
+  )
+    values(
+      identifier,
+      coalesce(payload, '{}'::json),
+      queue_name,
+      coalesce(run_at, now()),
+      coalesce(max_attempts, 25),
+      job_key,
+      coalesce(priority, 0),
+      (
+        select jsonb_object_agg(flag, true)
+        from unnest(flags) as item(flag)
+      ),
+      coalesce(locked_duration, '4 hours'::interval)
+    )
+    returning *
+    into v_job;
+  return v_job;
+end;
+
+$$ language plpgsql volatile;
+
+drop function :GRAPHILE_WORKER_SCHEMA.get_job(text, text[], interval, text[]);
+create function :GRAPHILE_WORKER_SCHEMA.get_job(
+  worker_id text,
+  task_identifiers text[] = null,
+  forbidden_flags text[] = null
+) returns :GRAPHILE_WORKER_SCHEMA.jobs as $$
+declare
+  v_job_id bigint;
+  v_queue_name text;
+  v_row :GRAPHILE_WORKER_SCHEMA.jobs;
+  v_now timestamptz = now();
+begin
+  if worker_id is null or length(worker_id) < 10 then
+    raise exception 'invalid worker id';
+  end if;
+
+  select jobs.queue_name, jobs.id into v_queue_name, v_job_id
+    from :GRAPHILE_WORKER_SCHEMA.jobs
+    where (jobs.locked_at is null or jobs.locked_at < (v_now - jobs.locked_duration))
+    and (
+      jobs.queue_name is null
+    or
+      exists (
+        select 1
+        from :GRAPHILE_WORKER_SCHEMA.job_queues
+        where job_queues.queue_name = jobs.queue_name
+        and (job_queues.locked_at is null or job_queues.locked_at < (v_now - jobs.locked_duration))
+        for update
+        skip locked
+      )
+    )
+    and run_at <= v_now
+    and attempts < max_attempts
+    and (task_identifiers is null or task_identifier = any(task_identifiers))
+    and (forbidden_flags is null or (flags ?| forbidden_flags) is not true)
+    order by priority asc, run_at asc, id asc
+    limit 1
+    for update
+    skip locked;
+
+  if v_job_id is null then
+    return null;
+  end if;
+
+  if v_queue_name is not null then
+    update :GRAPHILE_WORKER_SCHEMA.job_queues
+      set
+        locked_by = worker_id,
+        locked_at = v_now
+      where job_queues.queue_name = v_queue_name;
+  end if;
+
+  update :GRAPHILE_WORKER_SCHEMA.jobs
+    set
+      attempts = attempts + 1,
+      locked_by = worker_id,
+      locked_at = v_now
+    where id = v_job_id
+    returning * into v_row;
+
+  return v_row;
+end;
+
+$$ language plpgsql strict;

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -29,7 +29,8 @@ export function makeAddJob(
           job_key => $6::text,
           priority => $7::int,
           flags => $8::text[],
-          job_key_mode => $9::text
+          job_key_mode => $9::text,
+          locked_duration => $10::interval
         );
         `,
         [
@@ -42,6 +43,7 @@ export function makeAddJob(
           spec.priority || null,
           spec.flags || null,
           spec.jobKeyMode || null,
+          spec.jobExpiryDuration || null,
         ],
       );
       const job: Job = rows[0];

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -349,6 +349,13 @@ export interface TaskSpec {
    * cannot run at runtime. (Default: null)
    */
   flags?: string[];
+
+  /**
+   * Interval before which the job unlocks and is picked up by a worker again.
+   * Should be of INTERVAL type
+   * Default: "4 hours"
+   */
+  jobExpiryDuration?: string;
 }
 
 export type ForbiddenFlagsFn = () => null | string[] | Promise<null | string[]>;


### PR DESCRIPTION
## Description

<!-- If this PR adds a feature, what does it add and what was the motivation for it? -->
Currently, each job has a default lock period of 4 hours. Some jobs may last longer than 4 hours and some may last only for a few minutes. With this feature, I aim to give the developer the power to control locked duration. This will allow graphile to execute jobs which last at most locked_duration, which is fixed to 4 now.

It is a highly risky thing to configure a task's lock period to be shorter than its execution time.

<!-- If this PR fixes an issue, what is the issue? -->
Related to issue #198 
<!-- Please link to the relevant GitHub issues/Discord discussion/etc as appropriate -->

## Performance impact

<!-- Detail any impact on performance of this PR, or put 'unknown' if not known -->
Unknown

## Security impact

<!-- Detail any impact on security of this PR, or put 'unknown' if not known -->
Unknown

## Checklist

<!-- If this PR is work in progress, please open it as a "Draft PR". -->
<!-- To tick a checkbox, change it from `[ ]` to `[x]` -->

- [x] My code matches the project's code style and `yarn lint:fix` passes.
- [ ] I've added tests for the new feature, and `yarn test` passes.
- [ ] I have detailed the new feature in the relevant documentation.
- [ ] I have added this feature to 'Pending' in the `RELEASE_NOTES.md` file (if one exists).
- [ ] If this is a breaking change I've explained why.

<!-- For some Graphile projects the documentation is the README.md file, for
      others please see https://github.com/graphile/graphile.github.io -->
