### PR TITLE
feat: expose parseCronItem function

### DIFF
--- a/src/crontab.ts
+++ b/src/crontab.ts
@@ -417,39 +417,45 @@ export const parseCrontab = (crontab: string): Array<ParsedCronItem> => {
  * (including those that cannot be encoded in TypeScript).
  */
 export const parseCronItems = (items: CronItem[]): ParsedCronItem[] => {
-  return items.map(
-    (
-      {
-        pattern,
-        task,
-        options = {} as CronItemOptions,
-        payload = {},
-        identifier = task,
-      },
-      idx,
-    ) => {
-      const matches = CRONTAB_TIME_PARTS.exec(pattern);
-      if (!matches) {
-        throw new Error(
-          `Invalid cron pattern '${pattern}' in item ${idx} of parseCronItems call`,
-        );
-      }
-      const { minutes, hours, dates, months, dows } = parseCrontabRanges(
-        matches,
-        `item ${idx} of parseCronItems call`,
-      );
-      const item: ParsedCronItem = {
-        minutes,
-        hours,
-        dates,
-        months,
-        dows,
-        task,
-        options,
-        payload,
-        identifier,
-      };
-      return item;
-    },
+  return items.map((item, idx) =>
+    parseCronItem(item, `item ${idx} of parseCronItems call`),
   );
+};
+
+/**
+ * Parses an individual `CronItem` into a `ParsedCronItem`, ensuring the
+ * results comply with all the expectations of the `ParsedCronItem` type
+ * (including those that cannot be encoded in TypeScript).
+ */
+export const parseCronItem = (
+  cronItem: CronItem,
+  source: string = "parseCronItem call",
+) => {
+  const {
+    pattern,
+    task,
+    options = {} as CronItemOptions,
+    payload = {},
+    identifier = task,
+  } = cronItem;
+  const matches = CRONTAB_TIME_PARTS.exec(pattern);
+  if (!matches) {
+    throw new Error(`Invalid cron pattern '${pattern}' in ${source}`);
+  }
+  const { minutes, hours, dates, months, dows } = parseCrontabRanges(
+    matches,
+    source,
+  );
+  const item: ParsedCronItem = {
+    minutes,
+    hours,
+    dates,
+    months,
+    dows,
+    task,
+    options,
+    payload,
+    identifier,
+  };
+  return item;
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
 import getCronItems from "./getCronItems";
 import getTasks from "./getTasks";
-export { parseCronItems, parseCrontab } from "./crontab";
+export { parseCronItem, parseCronItems, parseCrontab } from "./crontab";
 export * from "./interfaces";
 export { consoleLogFactory, LogFunctionFactory, Logger } from "./logger";
 export { runTaskList, runTaskListOnce } from "./main";


### PR DESCRIPTION
## Description

Exposes separate `parseCronItem` helper for parsing an individual cron item.

Separates refactoring work out of #213.

## Performance impact

Negligible additional startup cost.

## Security impact

None known.

## Checklist

- [x] My code matches the project's code style and `yarn lint:fix` passes.
- [ ] I've added tests for the new feature, and `yarn test` passes.
- [ ] I have detailed the new feature in the relevant documentation.
- [ ] I have added this feature to 'Pending' in the `RELEASE_NOTES.md` file (if one exists).
- [x] ~~If this is a breaking change I've explained why.~~
