### PR TITLE
Add last execution time to _cron payload

### DIFF
--- a/README.md
+++ b/README.md
@@ -1284,7 +1284,9 @@ the value being an object with the following entries:
 
 - `ts` - ISO8601 timestamp representing when this job was due to execute
 - `backfilled` - true if the task was "backfilled" (i.e. it wasn't scheduled on
-  time), false otherwise
+- `knownSince` - the ISO-8601 string representation of the date this job was
+  first registered
+- `lastExecution` - the ISO-8601 string representation of last execution date
 
 ### Distributed crontab
 

--- a/__tests__/cron.test.ts
+++ b/__tests__/cron.test.ts
@@ -98,7 +98,11 @@ test("backfills if identifier already registered (25h)", () =>
     await reset(pgPool, options);
     const now = Date.now();
     const expectedTime = now - (now % FOUR_HOURS);
-    await pgPool.query(
+    const {
+      rows: {
+        0: { last_execution: lastOnTimeExecution, known_since: knownSince },
+      },
+    } = await pgPool.query(
       `
         insert into ${ESCAPED_GRAPHILE_WORKER_SCHEMA}.known_crontabs (
           identifier,
@@ -110,6 +114,7 @@ test("backfills if identifier already registered (25h)", () =>
           NOW() - interval '14 days',
           NOW() - interval '25 hours'
         )
+        returning last_execution, known_since
       `,
     );
     const eventMonitor = new EventMonitor();
@@ -143,6 +148,20 @@ test("backfills if identifier already registered (25h)", () =>
       expect(jobs.length).toBeGreaterThanOrEqual(6);
       expect(jobs.length).toBeLessThanOrEqual(7);
       expect(jobs.every((j) => j.task_identifier === "do_it")).toBe(true);
+      expect(
+        jobs.every(
+          (j) =>
+            (j.payload as any)["_cron"]["knownSince"] ==
+            knownSince.toISOString(),
+        ),
+      ).toBe(true);
+      expect(
+        jobs.every(
+          (j) =>
+            (j.payload as any)["_cron"]["lastOnTimeExecution"] ==
+            lastOnTimeExecution.toISOString(),
+        ),
+      ).toBe(true);
     }
   }));
 

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -476,11 +476,9 @@ export interface RunnerOptions extends WorkerPoolOptions {
 export interface CronJob {
   task: string;
   payload: {
-    _cron: { ts: string; backfilled?: boolean };
     [key: string]: unknown;
   };
   queueName?: string;
-  runAt: string;
   maxAttempts?: number;
   priority?: number;
 }


### PR DESCRIPTION
## Description

Fixes #177 (although doesn't add the info to the event)

This PR adds the last execution and known since dates to the `_cron` payload. I have cron jobs that run every minute need to run back to back. So even if the server is down for some reason I still want to find the last execution date so that I properly report everything that happened since then.

Not all tests pass because I struggled to make `lastOnTimeExecution` contain the correct values. I wasn't aware that the CTE is more like a view rather than a table so when backfilling, last_exeuction gets changed as the query executes.

Any help would be appreciated here

## Performance impact

unknown

It adds a bit of complexity to the SQL query but also removes a bit of complexity from the JS code.

## Security impact

unknown

## Checklist

- [x] My code matches the project's code style and `yarn lint:fix` passes.
- [x] I've added tests for the new feature, and `yarn test` passes.
- [x] I have detailed the new feature in the relevant documentation.
- [ ] I have added this feature to 'Pending' in the `RELEASE_NOTES.md` file (if one exists).
- [ ] If this is a breaking change I've explained why.