### PR TITLE
Add support for arbitrary functions in place of the cron pattern

### DIFF
--- a/__tests__/cron.test.ts
+++ b/__tests__/cron.test.ts
@@ -1,5 +1,4 @@
-import { parseCronItem, run, TimestampDigest } from "../src";
-import { cronItemMatches } from "../src/cronMatcher";
+import { run } from "../src";
 import {
   ESCAPED_GRAPHILE_WORKER_SCHEMA,
   EventMonitor,
@@ -145,51 +144,3 @@ test("backfills if identifier already registered (25h)", () =>
       expect(jobs.every((j) => j.task_identifier === "do_it")).toBe(true);
     }
   }));
-
-describe("matches datetime", () => {
-  const makeMatcher = (pattern: string) => (digest: TimestampDigest) => {
-    return cronItemMatches(
-      parseCronItem({ pattern, task: "" }, "test"),
-      digest,
-    );
-  };
-
-  const _0_0_1_1_0 = { min: 0, hour: 0, date: 1, month: 1, dow: 0 };
-  const _0_0_1_1_5 = { ..._0_0_1_1_0, dow: 5 };
-  const _0_0_1_1_4 = { ..._0_0_1_1_0, dow: 4 };
-  const _0_15_1_7_0 = { ..._0_0_1_1_0, hour: 15, month: 7 };
-  const _0_15_4_7_2 = { ..._0_0_1_1_0, hour: 15, date: 4, month: 7, dow: 2 };
-  const _0_15_4_7_5 = { ..._0_0_1_1_0, hour: 15, date: 4, month: 7, dow: 5 };
-  const _6_15_4_7_5 = { min: 6, hour: 15, date: 4, month: 7, dow: 5 };
-
-  test("every minute", () => {
-    const match = makeMatcher("* * * * *");
-    expect(match(_0_0_1_1_0)).toBeTruthy();
-    expect(match(_0_0_1_1_5)).toBeTruthy();
-    expect(match(_0_0_1_1_4)).toBeTruthy();
-    expect(match(_0_15_1_7_0)).toBeTruthy();
-    expect(match(_0_15_4_7_2)).toBeTruthy();
-    expect(match(_0_15_4_7_5)).toBeTruthy();
-    expect(match(_6_15_4_7_5)).toBeTruthy();
-  });
-  test("dow range", () => {
-    const match = makeMatcher("* * * * 5-6");
-    expect(match(_0_0_1_1_0)).toBeFalsy();
-    expect(match(_0_0_1_1_5)).toBeTruthy();
-    expect(match(_0_0_1_1_4)).toBeFalsy();
-    expect(match(_0_15_1_7_0)).toBeFalsy();
-    expect(match(_0_15_4_7_2)).toBeFalsy();
-    expect(match(_0_15_4_7_5)).toBeTruthy();
-    expect(match(_6_15_4_7_5)).toBeTruthy();
-  });
-  test("dow and date range", () => {
-    const match = makeMatcher("0-5 15 3-4 7 0-2");
-    expect(match(_0_0_1_1_0)).toBeFalsy();
-    expect(match(_0_0_1_1_5)).toBeFalsy();
-    expect(match(_0_0_1_1_4)).toBeFalsy();
-    expect(match(_0_15_1_7_0)).toBeTruthy();
-    expect(match(_0_15_4_7_2)).toBeTruthy();
-    expect(match(_0_15_4_7_5)).toBeTruthy();
-    expect(match(_6_15_4_7_5)).toBeFalsy();
-  });
-});

--- a/__tests__/cronMatcher.test.ts
+++ b/__tests__/cronMatcher.test.ts
@@ -1,0 +1,47 @@
+import { cronItemMatches, parseCronString } from "../src/cronMatcher";
+import { TimestampDigest } from "../src/interfaces";
+
+describe("matches datetime", () => {
+  const makeMatcher = (pattern: string) => (digest: TimestampDigest) => {
+    return cronItemMatches(parseCronString(pattern, "test"), digest);
+  };
+
+  const _0_0_1_1_0 = { min: 0, hour: 0, date: 1, month: 1, dow: 0 };
+  const _0_0_1_1_5 = { ..._0_0_1_1_0, dow: 5 };
+  const _0_0_1_1_4 = { ..._0_0_1_1_0, dow: 4 };
+  const _0_15_1_7_0 = { ..._0_0_1_1_0, hour: 15, month: 7 };
+  const _0_15_4_7_2 = { ..._0_0_1_1_0, hour: 15, date: 4, month: 7, dow: 2 };
+  const _0_15_4_7_5 = { ..._0_0_1_1_0, hour: 15, date: 4, month: 7, dow: 5 };
+  const _6_15_4_7_5 = { min: 6, hour: 15, date: 4, month: 7, dow: 5 };
+
+  test("every minute", () => {
+    const match = makeMatcher("* * * * *");
+    expect(match(_0_0_1_1_0)).toBeTruthy();
+    expect(match(_0_0_1_1_5)).toBeTruthy();
+    expect(match(_0_0_1_1_4)).toBeTruthy();
+    expect(match(_0_15_1_7_0)).toBeTruthy();
+    expect(match(_0_15_4_7_2)).toBeTruthy();
+    expect(match(_0_15_4_7_5)).toBeTruthy();
+    expect(match(_6_15_4_7_5)).toBeTruthy();
+  });
+  test("dow range", () => {
+    const match = makeMatcher("* * * * 5-6");
+    expect(match(_0_0_1_1_0)).toBeFalsy();
+    expect(match(_0_0_1_1_5)).toBeTruthy();
+    expect(match(_0_0_1_1_4)).toBeFalsy();
+    expect(match(_0_15_1_7_0)).toBeFalsy();
+    expect(match(_0_15_4_7_2)).toBeFalsy();
+    expect(match(_0_15_4_7_5)).toBeTruthy();
+    expect(match(_6_15_4_7_5)).toBeTruthy();
+  });
+  test("dow and date range", () => {
+    const match = makeMatcher("0-5 15 3-4 7 0-2");
+    expect(match(_0_0_1_1_0)).toBeFalsy();
+    expect(match(_0_0_1_1_5)).toBeFalsy();
+    expect(match(_0_0_1_1_4)).toBeFalsy();
+    expect(match(_0_15_1_7_0)).toBeTruthy();
+    expect(match(_0_15_4_7_2)).toBeTruthy();
+    expect(match(_0_15_4_7_5)).toBeTruthy();
+    expect(match(_6_15_4_7_5)).toBeFalsy();
+  });
+});

--- a/__tests__/cronMatcher.test.ts
+++ b/__tests__/cronMatcher.test.ts
@@ -1,9 +1,8 @@
-import { cronItemMatches, parseCronString } from "../src/cronMatcher";
-import { TimestampDigest } from "../src/interfaces";
+import { createCronMatcher } from "../src/cronMatcher";
 
 describe("matches datetime", () => {
-  const makeMatcher = (pattern: string) => (digest: TimestampDigest) => {
-    return cronItemMatches(parseCronString(pattern, "test"), digest);
+  const makeMatcher = (pattern: string) => {
+    return createCronMatcher(pattern, "test");
   };
 
   const _0_0_1_1_0 = { min: 0, hour: 0, date: 1, month: 1, dow: 0 };

--- a/src/cron.ts
+++ b/src/cron.ts
@@ -1,7 +1,6 @@
 import * as assert from "assert";
 import { Pool } from "pg";
 
-import { cronItemMatches } from "./cronMatcher";
 import { parseCrontab } from "./crontab";
 import defer from "./deferred";
 import getCronItems from "./getCronItems";
@@ -229,7 +228,7 @@ async function registerAndBackfillItems(
         if (
           item.options.backfillPeriod >= timeAgo &&
           unsafeTs >= notBefore &&
-          cronItemMatches(item, digest)
+          item.match(digest)
         ) {
           itemsToBackfill.push({
             identifier: item.identifier,
@@ -420,7 +419,7 @@ export const runCron = (
 
         // Gather the relevant jobs
         for (const item of parsedCronItems) {
-          if (cronItemMatches(item, digest)) {
+          if (item.match(digest)) {
             jobsAndIdentifiers.push({
               identifier: item.identifier,
               job: makeJobForItem(item, ts),
@@ -528,21 +527,6 @@ export async function getParsedCronItemsFromOptions(
       Array.isArray(parsedCronItems),
       "Expected `parsedCronItems` to be an array; you must use a helper e.g. `parseCrontab()` or `parseCronItems()` to produce this value.",
     );
-    const firstItem = parsedCronItems[0];
-    if (firstItem) {
-      if (
-        !Array.isArray(firstItem.minutes) ||
-        !Array.isArray(firstItem.hours) ||
-        !Array.isArray(firstItem.dates) ||
-        !Array.isArray(firstItem.months) ||
-        !Array.isArray(firstItem.dows)
-      ) {
-        throw new Error(
-          "Invalid `parsedCronItems`; you must use a helper e.g. `parseCrontab()` or `parseCronItems()` to produce this value.",
-        );
-      }
-    }
-
     return parsedCronItems;
   }
 }

--- a/src/cronMatcher.ts
+++ b/src/cronMatcher.ts
@@ -1,16 +1,26 @@
 import {
   CRONTAB_NUMBER,
   CRONTAB_RANGE,
+  CRONTAB_TIME_PARTS,
   CRONTAB_WILDCARD,
 } from "./cronConstants";
-import { ParsedCronItem, TimestampDigest } from "./interfaces";
+import { TimestampDigest } from "./interfaces";
+
+// Crontab ranges from the minute, hour, day of month, month and day of week parts of the crontab line
+interface CrontabRanges {
+  minutes: number[];
+  hours: number[];
+  dates: number[];
+  months: number[];
+  dows: number[];
+}
 
 /**
  * Returns true if the cronItem should fire for the given timestamp digest,
  * false otherwise.
  */
 export function cronItemMatches(
-  cronItem: ParsedCronItem,
+  cronItem: CrontabRanges,
   digest: TimestampDigest,
 ): boolean {
   const { min, hour, date, month, dow } = digest;
@@ -170,3 +180,11 @@ export function parseCrontabRanges(matches: string[], source: string) {
   );
   return { minutes, hours, dates, months, dows };
 }
+
+export const parseCronString = (pattern: string, source: string = "") => {
+  const matches = CRONTAB_TIME_PARTS.exec(pattern);
+  if (!matches) {
+    throw new Error(`Invalid cron pattern '${pattern}' in ${source}`);
+  }
+  return parseCrontabRanges(matches, source);
+};

--- a/src/cronMatcher.ts
+++ b/src/cronMatcher.ts
@@ -188,3 +188,26 @@ export const parseCronString = (pattern: string, source: string = "") => {
   }
   return parseCrontabRanges(matches, source);
 };
+
+/**
+ * Creates a CronSchedule based on a cron expression
+ */
+export const createCronMatcherFromRanges = (
+  matches: string[],
+  source: string = "",
+) => {
+  const cronItem = parseCrontabRanges(matches, source);
+
+  return (digest: TimestampDigest) => {
+    return cronItemMatches(cronItem, digest);
+  };
+};
+
+export const createCronMatcher = (pattern: string, source: string = "") => {
+  const matches = CRONTAB_TIME_PARTS.exec(pattern);
+  if (!matches) {
+    throw new Error(`Invalid cron pattern '${pattern}' in ${source}`);
+  }
+
+  return createCronMatcherFromRanges(matches, source);
+};

--- a/src/crontab.ts
+++ b/src/crontab.ts
@@ -9,11 +9,10 @@ import {
   CRONTAB_OPTIONS_MAX,
   CRONTAB_OPTIONS_PRIORITY,
   CRONTAB_OPTIONS_QUEUE,
-  CRONTAB_TIME_PARTS,
   PERIOD_DURATIONS,
   TIMEPHRASE_PART,
 } from "./cronConstants";
-import { parseCrontabRanges } from "./cronMatcher";
+import { parseCronString, parseCrontabRanges } from "./cronMatcher";
 import { CronItem, CronItemOptions, ParsedCronItem } from "./interfaces";
 
 /**
@@ -267,12 +266,8 @@ export const parseCronItem = (
     payload = {},
     identifier = task,
   } = cronItem;
-  const matches = CRONTAB_TIME_PARTS.exec(pattern);
-  if (!matches) {
-    throw new Error(`Invalid cron pattern '${pattern}' in ${source}`);
-  }
-  const { minutes, hours, dates, months, dows } = parseCrontabRanges(
-    matches,
+  const { minutes, hours, dates, months, dows } = parseCronString(
+    pattern,
     source,
   );
   const item: ParsedCronItem = {

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -185,6 +185,11 @@ export interface CronItemOptions {
 }
 
 /**
+ * Returns true if a cron job should run given a TimestampDigest
+ */
+export type CronSchedule = (digest: TimestampDigest) => boolean;
+
+/**
  * A recurring task schedule; this may represent a line in the `crontab` file,
  * or may be the result of calling `parseCronItems` on a list of `CronItem`s
  * the user has specified.
@@ -205,16 +210,8 @@ export interface CronItemOptions {
  * Worker helpers to construct this type.
  */
 export interface ParsedCronItem {
-  /** Minutes (0-59) on which to run the item; must contain unique numbers from the allowed range, ordered ascending. */
-  minutes: number[];
-  /** Hours (0-23) on which to run the item; must contain unique numbers from the allowed range, ordered ascending. */
-  hours: number[];
-  /** Dates (1-31) on which to run the item; must contain unique numbers from the allowed range, ordered ascending. */
-  dates: number[];
-  /** Months (1-12) on which to run the item; must contain unique numbers from the allowed range, ordered ascending. */
-  months: number[];
-  /** Days of the week (0-6) on which to run the item; must contain unique numbers from the allowed range, ordered ascending. */
-  dows: number[];
+  /** Returns true if a task should be executed on a given time */
+  match: CronSchedule;
 
   /** The identifier of the task to execute */
   task: string;
@@ -240,8 +237,13 @@ export interface CronItem {
   /** The identifier of the task to execute */
   task: string;
 
-  /** Cron pattern (e.g. `* * * * *`) to detail when the task should be executed */
-  pattern: string;
+  /**
+   * @deprecated
+   * Cron pattern (e.g. `* * * * *`) to detail when the task should be executed */
+  pattern?: string;
+
+  /** Cron pattern (e.g. `* * * * *`) or a function to detail when the task should be executed */
+  match?: string | CronSchedule;
 
   /** Options influencing backfilling and properties of the scheduled job */
   options?: CronItemOptions;


### PR DESCRIPTION
## Description

Fixes #218

Please keep in mind that this PR includes some changes. Cron expressions are not any different from any other function you can pass as the "schedule matcher". 

## Checklist

- [x] My code matches the project's code style and `yarn lint:fix` passes.
- [x] I've added tests for the new feature, and `yarn test` passes.
- [ ] I have detailed the new feature in the relevant documentation.
- [ ] I have added this feature to 'Pending' in the `RELEASE_NOTES.md` file (if one exists).
- [ ] If this is a breaking change I've explained why.

I haven't updated the documentation yet because I'm not sure if the implementation is satisfying.