### PR TITLE
chore(refactor): split some cron code into new files to ease maintenance

### DIFF
--- a/__tests__/cron.test.ts
+++ b/__tests__/cron.test.ts
@@ -1,5 +1,5 @@
 import { parseCronItem, run, TimestampDigest } from "../src";
-import { cronItemMatches } from "../src/cron";
+import { cronItemMatches } from "../src/cronMatcher";
 import {
   ESCAPED_GRAPHILE_WORKER_SCHEMA,
   EventMonitor,

--- a/__tests__/cron.test.ts
+++ b/__tests__/cron.test.ts
@@ -1,5 +1,5 @@
-import { parseCronItem, run } from "../src";
-import { cronItemMatches, TimestampDigest } from "../src/cron";
+import { parseCronItem, run, TimestampDigest } from "../src";
+import { cronItemMatches } from "../src/cron";
 import {
   ESCAPED_GRAPHILE_WORKER_SCHEMA,
   EventMonitor,

--- a/src/cron.ts
+++ b/src/cron.ts
@@ -11,6 +11,7 @@ import {
   KnownCrontab,
   ParsedCronItem,
   RunnerOptions,
+  TimestampDigest,
   WorkerEvents,
 } from "./interfaces";
 import { processSharedOptions, Releasers } from "./lib";
@@ -543,17 +544,6 @@ export async function getParsedCronItemsFromOptions(
 
     return parsedCronItems;
   }
-}
-
-/**
- * The digest of a timestamp into the component parts that a cron schedule cares about.
- */
-export interface TimestampDigest {
-  min: number;
-  hour: number;
-  date: number;
-  month: number;
-  dow: number;
 }
 
 /**

--- a/src/cron.ts
+++ b/src/cron.ts
@@ -1,6 +1,7 @@
 import * as assert from "assert";
 import { Pool } from "pg";
 
+import { cronItemMatches } from "./cronMatcher";
 import { parseCrontab } from "./crontab";
 import defer from "./deferred";
 import getCronItems from "./getCronItems";
@@ -561,37 +562,4 @@ function digestTimestamp(ts: Date): TimestampDigest {
   const month = ts.getUTCMonth() + 1;
   const dow = ts.getUTCDay();
   return { min, hour, date, month, dow };
-}
-
-/**
- * Returns true if the cronItem should fire for the given timestamp digest,
- * false otherwise.
- */
-export function cronItemMatches(
-  cronItem: ParsedCronItem,
-  digest: TimestampDigest,
-): boolean {
-  const { min, hour, date, month, dow } = digest;
-
-  if (
-    // If minute, hour and month match
-    cronItem.minutes.includes(min) &&
-    cronItem.hours.includes(hour) &&
-    cronItem.months.includes(month)
-  ) {
-    const dateIsExclusionary = cronItem.dates.length !== 31;
-    const dowIsExclusionary = cronItem.dows.length !== 7;
-    if (dateIsExclusionary && dowIsExclusionary) {
-      // Cron has a special behaviour: if both date and day of week are
-      // exclusionary (i.e. not "*") then a match for *either* passes.
-      return cronItem.dates.includes(date) || cronItem.dows.includes(dow);
-    } else if (dateIsExclusionary) {
-      return cronItem.dates.includes(date);
-    } else if (dowIsExclusionary) {
-      return cronItem.dows.includes(dow);
-    } else {
-      return true;
-    }
-  }
-  return false;
 }

--- a/src/cronConstants.ts
+++ b/src/cronConstants.ts
@@ -1,0 +1,50 @@
+/** One second in milliseconds */
+export const SECOND = 1000;
+/** One minute in milliseconds */
+export const MINUTE = 60 * SECOND;
+/** One hour in milliseconds */
+export const HOUR = 60 * MINUTE;
+/** One day in milliseconds */
+export const DAY = 24 * HOUR;
+/** One week in milliseconds */
+export const WEEK = 7 * DAY;
+
+// A (non-comment, non-empty) line in the crontab file
+/** Separates crontab line into the minute, hour, day of month, month, day of week and command parts. */
+export const CRONTAB_LINE_PARTS = /^([0-9*/,-]+)\s+([0-9*/,-]+)\s+([0-9*/,-]+)\s+([0-9*/,-]+)\s+([0-9*/,-]+)\s+(.*)$/;
+/** Just the time expression from CRONTAB_LINE_PARTS */
+export const CRONTAB_TIME_PARTS = /^([0-9*/,-]+)\s+([0-9*/,-]+)\s+([0-9*/,-]+)\s+([0-9*/,-]+)\s+([0-9*/,-]+)$/;
+
+// Crontab ranges from the minute, hour, day of month, month and day of week parts of the crontab line
+/** Matches an explicit numeric value */
+export const CRONTAB_NUMBER = /^([0-9]+)$/;
+/** Matches a range of numeric values */
+export const CRONTAB_RANGE = /^([0-9]+)-([0-9]+)$/;
+/** Matches a numeric wildcard, optionally with a divisor */
+export const CRONTAB_WILDCARD = /^\*(?:\/([0-9]+))?$/;
+
+// The command from the crontab line
+/** Splits the command from the crontab line into the task, options and payload. */
+export const CRONTAB_COMMAND = /^([_a-zA-Z][_a-zA-Z0-9:_-]*)(?:\s+\?([^\s]+))?(?:\s+(\{.*\}))?$/;
+
+// Crontab command options
+/** Matches the id=UID option, capturing the unique identifier */
+export const CRONTAB_OPTIONS_ID = /^([_a-zA-Z][-_a-zA-Z0-9]*)$/;
+/** Matches the fill=t option, capturing the time phrase  */
+export const CRONTAB_OPTIONS_BACKFILL = /^((?:[0-9]+[smhdw])+)$/;
+/** Matches the max=n option, capturing the max executions number */
+export const CRONTAB_OPTIONS_MAX = /^([0-9]+)$/;
+/** Matches the queue=name option, capturing the queue name */
+export const CRONTAB_OPTIONS_QUEUE = /^([-a-zA-Z0-9_:]+)$/;
+/** Matches the priority=n option, capturing the priority value */
+export const CRONTAB_OPTIONS_PRIORITY = /^(-?[0-9]+)$/;
+
+/** Matches the quantity and period string at the beginning of a timephrase */
+export const TIMEPHRASE_PART = /^([0-9]+)([smhdw])/;
+export const PERIOD_DURATIONS = {
+  s: SECOND,
+  m: MINUTE,
+  h: HOUR,
+  d: DAY,
+  w: WEEK,
+};

--- a/src/cronMatcher.ts
+++ b/src/cronMatcher.ts
@@ -1,0 +1,34 @@
+import { ParsedCronItem, TimestampDigest } from "./interfaces";
+
+/**
+ * Returns true if the cronItem should fire for the given timestamp digest,
+ * false otherwise.
+ */
+export function cronItemMatches(
+  cronItem: ParsedCronItem,
+  digest: TimestampDigest,
+): boolean {
+  const { min, hour, date, month, dow } = digest;
+
+  if (
+    // If minute, hour and month match
+    cronItem.minutes.includes(min) &&
+    cronItem.hours.includes(hour) &&
+    cronItem.months.includes(month)
+  ) {
+    const dateIsExclusionary = cronItem.dates.length !== 31;
+    const dowIsExclusionary = cronItem.dows.length !== 7;
+    if (dateIsExclusionary && dowIsExclusionary) {
+      // Cron has a special behaviour: if both date and day of week are
+      // exclusionary (i.e. not "*") then a match for *either* passes.
+      return cronItem.dates.includes(date) || cronItem.dows.includes(dow);
+    } else if (dateIsExclusionary) {
+      return cronItem.dates.includes(date);
+    } else if (dowIsExclusionary) {
+      return cronItem.dows.includes(dow);
+    } else {
+      return true;
+    }
+  }
+  return false;
+}

--- a/src/cronMatcher.ts
+++ b/src/cronMatcher.ts
@@ -1,3 +1,8 @@
+import {
+  CRONTAB_NUMBER,
+  CRONTAB_RANGE,
+  CRONTAB_WILDCARD,
+} from "./cronConstants";
 import { ParsedCronItem, TimestampDigest } from "./interfaces";
 
 /**
@@ -31,4 +36,137 @@ export function cronItemMatches(
     }
   }
   return false;
+}
+
+/**
+ * Parses a range from a crontab line; a comma separated list of:
+ *
+ * - exact number
+ * - wildcard `*` optionally with `/n` divisor
+ * - range `a-b`
+ *
+ * Returns an ordered list of unique numbers in the range `min` to `max` that match the given range.
+ *
+ * If `wrap` is true, then the number `max + 1` will be replaced by the number
+ * `min`; this is specifically to handle the value `7` being used to represent
+ * Sunday (as opposed to `0` which is correct).
+ */
+const parseCrontabRange = (
+  locationForError: string,
+  range: string,
+  min: number,
+  max: number,
+  wrap = false,
+): number[] => {
+  const parts = range.split(",");
+  const numbers: number[] = [];
+
+  /**
+   * Adds a number to our numbers array after wrapping it (if necessary) and
+   * checking it's in the valid range.
+   */
+  function add(number: number) {
+    const wrappedNumber = wrap && number === max + 1 ? min : number;
+    if (wrappedNumber > max) {
+      throw new Error(
+        `Too large value '${number}' in ${locationForError}: expected values in the range ${min}-${max}.`,
+      );
+    } else if (wrappedNumber < min) {
+      throw new Error(
+        `Too small value '${number}' in ${locationForError}: expected values in the range ${min}-${max}.`,
+      );
+    } else {
+      numbers.push(wrappedNumber);
+    }
+  }
+
+  for (const part of parts) {
+    {
+      const matches = CRONTAB_NUMBER.exec(part);
+      if (matches) {
+        add(parseInt(matches[1], 10));
+        continue;
+      }
+    }
+    {
+      const matches = CRONTAB_RANGE.exec(part);
+      if (matches) {
+        const a = parseInt(matches[1], 10);
+        const b = parseInt(matches[2], 10);
+        if (b <= a) {
+          throw new Error(
+            `Invalid range '${part}' in ${locationForError}: destination is not larger than source`,
+          );
+        }
+        for (let i = a; i <= b; i++) {
+          add(i);
+        }
+        continue;
+      }
+    }
+    {
+      const matches = CRONTAB_WILDCARD.exec(part);
+      if (matches) {
+        const divisor = matches[1] ? parseInt(matches[1], 10) : 1;
+        if (divisor >= 1) {
+          for (let i = min; i <= max; i += divisor) {
+            // We know this is fine, so no need to call `add`
+            numbers.push(i);
+          }
+        } else {
+          throw new Error(
+            `Invalid wildcard expression '${part}' in ${locationForError}: divisor '${matches[1]}' expected to be greater than zero`,
+          );
+        }
+        continue;
+      }
+    }
+    throw new Error(
+      `Unsupported syntax '${part}' in ${locationForError}: this doesn't appear to be a number, range or wildcard`,
+    );
+  }
+
+  numbers.sort((a, b) => a - b);
+
+  // Filter out numbers that are identical to the previous number
+  const uniqueNumbers = numbers.filter(
+    (currentNumber, idx) => idx === 0 || numbers[idx - 1] !== currentNumber,
+  );
+
+  return uniqueNumbers;
+};
+
+export function parseCrontabRanges(matches: string[], source: string) {
+  const minutes = parseCrontabRange(
+    `minutes range in ${source}`,
+    matches[1],
+    0,
+    59,
+  );
+  const hours = parseCrontabRange(
+    `hours range in ${source}`,
+    matches[2],
+    0,
+    23,
+  );
+  const dates = parseCrontabRange(
+    `dates range in ${source}`,
+    matches[3],
+    1,
+    31,
+  );
+  const months = parseCrontabRange(
+    `months range in ${source}`,
+    matches[4],
+    1,
+    12,
+  );
+  const dows = parseCrontabRange(
+    `days of week range in ${source}`,
+    matches[5],
+    0,
+    6,
+    true,
+  );
+  return { minutes, hours, dates, months, dows };
 }

--- a/src/crontab.ts
+++ b/src/crontab.ts
@@ -1,48 +1,22 @@
 import * as JSON5 from "json5";
 import { parse } from "querystring";
 
+import {
+  CRONTAB_COMMAND,
+  CRONTAB_LINE_PARTS,
+  CRONTAB_NUMBER,
+  CRONTAB_OPTIONS_BACKFILL,
+  CRONTAB_OPTIONS_ID,
+  CRONTAB_OPTIONS_MAX,
+  CRONTAB_OPTIONS_PRIORITY,
+  CRONTAB_OPTIONS_QUEUE,
+  CRONTAB_RANGE,
+  CRONTAB_TIME_PARTS,
+  CRONTAB_WILDCARD,
+  PERIOD_DURATIONS,
+  TIMEPHRASE_PART,
+} from "./cronConstants";
 import { CronItem, CronItemOptions, ParsedCronItem } from "./interfaces";
-
-/** One second in milliseconds */
-const SECOND = 1000;
-/** One minute in milliseconds */
-const MINUTE = 60 * SECOND;
-/** One hour in milliseconds */
-const HOUR = 60 * MINUTE;
-/** One day in milliseconds */
-const DAY = 24 * HOUR;
-/** One week in milliseconds */
-const WEEK = 7 * DAY;
-
-// A (non-comment, non-empty) line in the crontab file
-/** Separates crontab line into the minute, hour, day of month, month, day of week and command parts. */
-const CRONTAB_LINE_PARTS = /^([0-9*/,-]+)\s+([0-9*/,-]+)\s+([0-9*/,-]+)\s+([0-9*/,-]+)\s+([0-9*/,-]+)\s+(.*)$/;
-/** Just the time expression from CRONTAB_LINE_PARTS */
-const CRONTAB_TIME_PARTS = /^([0-9*/,-]+)\s+([0-9*/,-]+)\s+([0-9*/,-]+)\s+([0-9*/,-]+)\s+([0-9*/,-]+)$/;
-
-// Crontab ranges from the minute, hour, day of month, month and day of week parts of the crontab line
-/** Matches an explicit numeric value */
-const CRONTAB_NUMBER = /^([0-9]+)$/;
-/** Matches a range of numeric values */
-const CRONTAB_RANGE = /^([0-9]+)-([0-9]+)$/;
-/** Matches a numeric wildcard, optionally with a divisor */
-const CRONTAB_WILDCARD = /^\*(?:\/([0-9]+))?$/;
-
-// The command from the crontab line
-/** Splits the command from the crontab line into the task, options and payload. */
-const CRONTAB_COMMAND = /^([_a-zA-Z][_a-zA-Z0-9:_-]*)(?:\s+\?([^\s]+))?(?:\s+(\{.*\}))?$/;
-
-// Crontab command options
-/** Matches the id=UID option, capturing the unique identifier */
-const CRONTAB_OPTIONS_ID = /^([_a-zA-Z][-_a-zA-Z0-9]*)$/;
-/** Matches the fill=t option, capturing the time phrase  */
-const CRONTAB_OPTIONS_BACKFILL = /^((?:[0-9]+[smhdw])+)$/;
-/** Matches the max=n option, capturing the max executions number */
-const CRONTAB_OPTIONS_MAX = /^([0-9]+)$/;
-/** Matches the queue=name option, capturing the queue name */
-const CRONTAB_OPTIONS_QUEUE = /^([-a-zA-Z0-9_:]+)$/;
-/** Matches the priority=n option, capturing the priority value */
-const CRONTAB_OPTIONS_PRIORITY = /^(-?[0-9]+)$/;
 
 /**
  * Parses a range from a crontab line; a comma separated list of:
@@ -140,16 +114,6 @@ const parseCrontabRange = (
   );
 
   return uniqueNumbers;
-};
-
-/** Matches the quantity and period string at the beginning of a timephrase */
-const TIMEPHRASE_PART = /^([0-9]+)([smhdw])/;
-const PERIOD_DURATIONS = {
-  s: SECOND,
-  m: MINUTE,
-  h: HOUR,
-  d: DAY,
-  w: WEEK,
 };
 
 /**

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -708,3 +708,14 @@ export type WorkerEventMap = {
 };
 
 export type WorkerEvents = TypedEventEmitter<WorkerEventMap>;
+
+/**
+ * The digest of a timestamp into the component parts that a cron schedule cares about.
+ */
+export interface TimestampDigest {
+  min: number;
+  hour: number;
+  date: number;
+  month: number;
+  dow: number;
+}


### PR DESCRIPTION
## Description

This PR is made of 4 separate commits:

1. **Move TimestampDigest into interfaces**
   This should always have been in the interfaces file.
   *Change:* this results in TimestampDigest being export; previously it was not. *No other changes to exported interface or functionality.*
2. **Move regexps and constants out of crontab into a common file**
   It's important that the cron regexps remain together so that they will not diverge over time, however it's desirable to be able to use them in different files in future (e.g. #219) so I've moved them to a common file that can be imported from the files that need it.
   *No change in exported interface or functionality.*
3. **Extract `cronItemMatches` to new file**
   In the future (e.g. #219) it's likely that parsing/matching a cron expression (`* * * * *`) will be useful beyond just the crontab.ts file. So I've moved it out into a new file.
   *No change in exported interface or functionality.*
4. **Move parseCrontabRange and parseCrontabRanges to cronMatcher**
   These functions only relate to parsing a cron expression (`* * * * *`) and not the other components of a crontab line. As such it makes sense to extract them so they can be used independently.
   *No change in exported interface or functionality.*

In total the only change this refactor causes is that `TimestampDigest` is now an exported interface.

## Performance impact

None.

## Security impact

None.

## Checklist

- [x] My code matches the project's code style and `yarn lint:fix` passes.
- [x] ~~I've added tests for the new feature, and~~ `yarn test` passes.
- [x] ~~I have detailed the new feature in the relevant documentation.~~
- [x] ~~I have added this feature to 'Pending' in the `RELEASE_NOTES.md` file (if one exists).~~
- [x] ~~If this is a breaking change I've explained why.~~