### PR TITLE
Release worker & cron before release PG pool/connections when stopping runner

### DIFF
--- a/src/runner.ts
+++ b/src/runner.ts
@@ -87,10 +87,8 @@ export const run = async (
       (await getParsedCronItemsFromOptions(options, releasers));
 
     const cron = runCron(options, parsedCronItems, { pgPool, events });
-    releasers.push(() => cron.release());
 
     const workerPool = runTaskList(options, taskList, pgPool);
-    releasers.push(() => workerPool.release());
 
     let running = true;
     return {
@@ -98,6 +96,7 @@ export const run = async (
         if (running) {
           running = false;
           events.emit("stop", {});
+          await Promise.all([cron.release(), workerPool.release()])
           await release();
         } else {
           throw new Error("Runner is already stopped");


### PR DESCRIPTION
## Description

<!-- If this PR adds a feature, what does it add and what was the motivation for it? -->
<!-- If this PR fixes an issue, what is the issue? -->
<!-- Please link to the relevant GitHub issues/Discord discussion/etc as appropriate -->
Currently, when stopping a runner, the releases of worker pool, cron, pg pool happens at the same time. I think it is executed [here](https://github.com/graphile/worker/blob/main/src/lib.ts#L147-L149).

However, during my test, it turns out if there is an active job in the worker pool when `stop` is called. The release of the worker pool will wait for that active job to be processed. And at the end of job processing, it writes job status back to PG. If successful, it removes the job record, if failed, it updates the error message. But pg pool is ended at that moment.

Here is a code snippet I use:

```javascript
const { run, Logger, makeWorkerUtils, quickAddJob } = require("graphile-worker");
const EventEmitter = require('events')

const pgURL = "postgres://postgres:my_password@dell.home:5432/dev"
const maxAttempts = 3

async function main() {

  const workerUtils = await makeWorkerUtils({
    connectionString: pgURL,
  })
  await workerUtils.migrate()

  const events = new EventEmitter()
  events.on('job:start', ({worker, job})=>{
    console.log('start', worker.workerId, job.payload.name, Date.now() - job.created_at)
  })
  events.on('job:failed', async ({job}) => {
    console.log('permanently failed')
    // remove permanently failed job record in case the number of records keeps growing which will slow down worker performance on retrieving jobs
    await workerUtils.completeJobs([job.id])
  })

  const runner = await run({
    connectionString: pgURL,
    concurrency: 5,
    logger: new Logger((scope)=> (level, message , meta)=>{
      // console.log(scope, level, message, meta)
    }),
    noHandleSignals: true,
    pollInterval: 1000,
    events,
    taskList: {
      hello: async (payload, {job}) => {
        try {
          await new Promise((resolve, reject)=>{
            console.log('processing', job.id)
            setTimeout(()=>{
              if (payload.name === 'success' || (job.attempts === job.max_attempts && payload.name !== 'hey1')) {
                return resolve()
              }
              reject(new Error('timeout'))
            }, 10000)
          })
          await new Promise(resolve => {
            setTimeout(()=>{
              // just mocking
              console.log('saved success jobs to DB')
              resolve()
            }, 100)
          })
        } catch(e) {
          if (job.attempts === job.max_attempts) {
            await new Promise(resolve => {
              setTimeout(()=>{
                // just mocking
                console.log('saved permanent job failures to DB')
                resolve()
              }, 100)
            })
          }
          throw e
        }
      },
    },
  });

  const add = n => quickAddJob({
      connectionString: pgURL,
    }, 'hello',
    {
      name: `hey${n}`
    },
    {
      queueName: '1',
      maxAttempts
    }
  )

  process.on('SIGTERM', async () => {
    try {
      await runner.stop()
    } catch (e) {
      console.log('stop failed', e)
    }
    await runner.promise
    process.exit(0)
  })

  await runner.addJob('hello', {
    name: 'success'
  }, {
    queueName: '1',
    maxAttempts,
  })

  await add(1)
  await add(2)
  await add(3)
}

console.log(process.pid)
main().catch((err) => {
  console.error(err);
  process.exit(1);
});
```

Here is the screenshot of running this code snippet

![Screen Shot 2021-09-24 at 11 24 12 PM](https://user-images.githubusercontent.com/1751150/134757061-7497d0cf-ff27-4fe3-9921-96922dfda41a.png)

Here are job entries in DB

![Screen Shot 2021-09-24 at 11 59 01 PM](https://user-images.githubusercontent.com/1751150/134757123-e63c7445-4dad-4b66-a900-637befb90420.png)

You can see that due to the pg pool being closed, the worker cannot update the job record, it remains locked.

## Performance impact

<!-- Detail any impact on performance of this PR, or put 'unknown' if not known -->

## Security impact

<!-- Detail any impact on security of this PR, or put 'unknown' if not known -->

## Checklist

<!-- If this PR is work in progress, please open it as a "Draft PR". -->
<!-- To tick a checkbox, change it from `[ ]` to `[x]` -->

- [ ] My code matches the project's code style and `yarn lint:fix` passes.
- [ ] I've added tests for the new feature, and `yarn test` passes.
- [ ] I have detailed the new feature in the relevant documentation.
- [ ] I have added this feature to 'Pending' in the `RELEASE_NOTES.md` file (if one exists).
- [ ] If this is a breaking change I've explained why.

<!-- For some Graphile projects the documentation is the README.md file, for
      others please see https://github.com/graphile/graphile.github.io -->
