### PR TITLE
Add full support for ES modules

### DIFF
--- a/src/getTasks.ts
+++ b/src/getTasks.ts
@@ -10,7 +10,7 @@ import {
 } from "./interfaces";
 import { processSharedOptions } from "./lib";
 import { Logger } from "./logger";
-import { fauxRequire } from "./module";
+import { fauxImport, fauxRequire } from "./module";
 
 function validTasks(
   logger: Logger,
@@ -44,7 +44,14 @@ async function loadFileIntoTasks(
   name: string | null = null,
   watch: boolean = false,
 ) {
-  const replacementModule = watch ? fauxRequire(filename) : require(filename);
+  const isNode12OrAbove = Number(process.versions.node.split(".")[0]) >= 12;
+  const replacementModule = isNode12OrAbove
+    ? watch
+      ? await fauxImport(filename)
+      : await import(filename)
+    : watch
+    ? fauxRequire(filename)
+    : require(filename);
 
   if (!replacementModule) {
     throw new Error(`Module '${filename}' doesn't have an export`);

--- a/src/module.ts
+++ b/src/module.ts
@@ -10,6 +10,11 @@ function stripBOM(str: string) {
   return str;
 }
 
+export function fauxImport(spec: string) {
+  // Add a timestamp parameter to bust cache
+  return import(`${spec}?ts=${Date.now()}`);
+}
+
 /**
  * This function emulates the behavior of `require()`, enabling us to call it
  * multiple times without worrying about having to clear out the cache (useful


### PR DESCRIPTION
Hey @benjie,

Here is some equivalent of what I did to Graphile Migrate but for Graphile Worker this time.

Again it's just a start / suggestion, because of the accelerating trend of moving from CommonJS to ESM. I guess there will be issues with Typescript e.g. https://github.com/microsoft/TypeScript/issues/43329 but I'm not fluent in Typescript...

Cheers !