### PR TITLE
docs: describe noPreparedStatements within RunnerOptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -316,8 +316,10 @@ The following options for these methods are available.
 - `events`: pass your own `new EventEmitter()` if you want to customize the
   options, get earlier events (before the runner object resolves), or want to
   get events from alternative Graphile Worker entrypoints.
-- `noPreparedStatements`: Set true if you want to prevent the use of prepared statements. 
-  For example if you wish to use Graphile Worker with pgBouncer or similar.
+- `noPreparedStatements`: Set true if you want to prevent the use of prepared
+  statements, for example if you wish to use Graphile Worker with an external
+  PostgreSQL connection pool. Enabling this setting may have a small performance
+  impact.
 
 Exactly one of either `taskDirectory` or `taskList` must be provided (except for
 `runMigrations` which doesn't require a task list).


### PR DESCRIPTION
## Description

Add noPreparedStatements to runner config in the README.md

## Performance impact

NO

## Security impact

NO

## Checklist

<!-- If this PR is work in progress, please open it as a "Draft PR". -->
<!-- To tick a checkbox, change it from `[ ]` to `[x]` -->

- [x] My code matches the project's code style and `yarn lint:fix` passes.
- [x] I've added tests for the new feature, and `yarn test` passes.
- [x] I have detailed the new feature in the relevant documentation.
- [ ] I have added this feature to 'Pending' in the `RELEASE_NOTES.md` file (if one exists).
- [ ] If this is a breaking change I've explained why.

<!-- For some Graphile projects the documentation is the README.md file, for
      others please see https://github.com/graphile/graphile.github.io -->
