### PR TITLE
fix(shutdown): properly release jobs with no queue assigned

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -166,10 +166,9 @@ export function runTaskList(
         });
         const { rows: cancelledJobs } = await pgPool.query(
           `
-          SELECT ${escapedWorkerSchema}.fail_job(job_queues.locked_by, jobs.id, $2)
+          SELECT ${escapedWorkerSchema}.fail_job(jobs.locked_by, jobs.id, $2)
           FROM ${escapedWorkerSchema}.jobs
-          INNER JOIN ${escapedWorkerSchema}.job_queues ON (job_queues.queue_name = jobs.queue_name)
-          WHERE job_queues.locked_by = ANY($1::text[]) AND jobs.id = ANY($3::int[]);
+          WHERE jobs.locked_by = ANY($1::text[]) AND jobs.id = ANY($3::int[]);
         `,
           [workerIds, message, jobsInProgress.map((job) => job.id)],
         );


### PR DESCRIPTION
## Description

Graceful shutdown does not unlock jobs with no `queue` assigned.

## Performance impact

NA

## Security impact

NA

## Checklist

- [x] My code matches the project's code style and `yarn lint:fix` passes.
- [ ] I've added tests for the new feature, and `yarn test` passes.
- [ ] I have detailed the new feature in the relevant documentation.
- [ ] I have added this feature to 'Pending' in the `RELEASE_NOTES.md` file (if one exists).
- [ ] If this is a breaking change I've explained why.
