### PR TITLE
fix: handle errors when releasing worker

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -197,7 +197,7 @@ export function runTaskList(
   const listenForChanges = (
     err: Error | undefined,
     client: PoolClient,
-    releaseClient: () => void,
+    releaseClient: () => void = () => {},
   ) => {
     if (!active) {
       // We were released, release this new client and abort

--- a/src/main.ts
+++ b/src/main.ts
@@ -197,11 +197,11 @@ export function runTaskList(
   const listenForChanges = (
     err: Error | undefined,
     client: PoolClient,
-    releaseClient: () => void = () => {},
+    releaseClient: () => void,
   ) => {
     if (!active) {
       // We were released, release this new client and abort
-      releaseClient();
+      releaseClient?.();
       return;
     }
 


### PR DESCRIPTION
## Description

First of all, thank you for your library. I discovered a bug today.

![Screen Shot 2021-12-07 at 6 05 04 PM](https://user-images.githubusercontent.com/1751150/145120052-0a12c9c1-5272-4610-b3d0-e189c2e7130d.png)

The callback passed to `pool.connect(callback)` [in this case](https://github.com/brianc/node-postgres/blob/master/packages/pg-pool/index.js#L166) will only be called with an error. Therefore, `releaseClient` can be undefined.


## Performance impact

n/a

## Security impact

n/a

## Checklist

<!-- If this PR is work in progress, please open it as a "Draft PR". -->
<!-- To tick a checkbox, change it from `[ ]` to `[x]` -->

- [x] My code matches the project's code style and `yarn lint:fix` passes.
- [ ] I've added tests for the new feature, and `yarn test` passes.
- [ ] I have detailed the new feature in the relevant documentation.
- [ ] I have added this feature to 'Pending' in the `RELEASE_NOTES.md` file (if one exists).
- [ ] If this is a breaking change I've explained why.

<!-- For some Graphile projects the documentation is the README.md file, for
      others please see https://github.com/graphile/graphile.github.io -->
