### PR TITLE
chore: replace deprecated String.prototype.substr()

### DIFF
--- a/src/crontab.ts
+++ b/src/crontab.ts
@@ -44,7 +44,7 @@ const parseTimePhrase = (timePhrase: string): number => {
     const [wholeMatch, quantity, period] = matches;
     const periodDuration = PERIOD_DURATIONS[period] || 0;
     milliseconds += parseInt(quantity, 10) * periodDuration;
-    remaining = remaining.substr(wholeMatch.length);
+    remaining = remaining.slice(wholeMatch.length);
   }
   return milliseconds;
 };

--- a/src/getTasks.ts
+++ b/src/getTasks.ts
@@ -157,7 +157,7 @@ export default async function getTasks(
     const files = await readdir(taskPath);
     for (const file of files) {
       if (file.endsWith(".js")) {
-        const taskName = file.substr(0, file.length - 3);
+        const taskName = file.slice(0, -3);
         try {
           await loadFileIntoTasks(
             logger,

--- a/src/migrate.ts
+++ b/src/migrate.ts
@@ -73,7 +73,7 @@ export async function migrate(
     .filter((f) => f.match(/^[0-9]{6}\.sql$/))
     .sort();
   for (const migrationFile of migrationFiles) {
-    const migrationNumber = parseInt(migrationFile.substr(0, 6), 10);
+    const migrationNumber = parseInt(migrationFile.slice(0, 6), 10);
     if (latestMigration == null || migrationNumber > latestMigration) {
       await runMigration(options, client, migrationFile, migrationNumber);
     }


### PR DESCRIPTION
## Description

[String.prototype.substr()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr) is deprecated so we replace it with [String.prototype.slice()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice) which works similarily but isn't deprecated.
.substr() probably isn't going away anytime soon but the change is trivial so it doesn't hurt to do it.

## Performance impact

From past experience there is no performance impact due to switching to slice()

## Security impact

None as the returned values are still the same

## Checklist

- [x] My code matches the project's code style and `yarn lint:fix` passes.
- [ ] I've added tests for the new feature, and `yarn test` passes.
- [ ] I have detailed the new feature in the relevant documentation.
- [ ] I have added this feature to 'Pending' in the `RELEASE_NOTES.md` file (if one exists).
- [ ] If this is a breaking change I've explained why.

