### PR TITLE
fix(cron): avoid unhandled rejection

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ Instead of running `graphile-worker` via the CLI, you may use it directly in
 your Node.js code. The following is equivalent to the CLI example above:
 
 ```js
-const { run, quickAddJob } = require("graphile-worker");
+const { run } = require("graphile-worker");
 
 async function main() {
   // Run a worker to execute jobs:
@@ -119,21 +119,13 @@ async function main() {
     //   taskDirectory: `${__dirname}/tasks`,
   });
 
-  // Or add a job to be executed:
-  await quickAddJob(
-    // makeWorkerUtils options
-    { connectionString: "postgres:///my_db" },
-
-    // Task identifier
-    "hello",
-
-    // Payload
-    { name: "Bobby Tables" },
-  );
-
-  // If the worker exits (whether through fatal error or otherwise), this
-  // promise will resolve/reject:
+  // Immediately await (or otherwise handled) the resulting promise, to avoid
+  // "unhandled rejection" errors causing a process crash in the event of
+  // something going wrong.
   await runner.promise;
+
+  // If the worker exits (whether through fatal error or otherwise), the above
+  // promise will resolve/reject.
 }
 
 main().catch((err) => {
@@ -142,7 +134,27 @@ main().catch((err) => {
 });
 ```
 
-Running this example should output something like:
+You can also use the library to quickly add a job:
+
+```js
+const { quickAddJob } = require("graphile-worker");
+
+quickAddJob(
+  // makeWorkerUtils options
+  { connectionString: "postgres:///my_db" },
+
+  // Task identifier
+  "hello",
+
+  // Payload
+  { name: "Bobby Tables" },
+).catch((err) => {
+  console.error(err);
+  process.exit(1);
+});
+```
+
+Running these two examples should output something like:
 
 ```
 [core] INFO: Worker connected and looking for jobs... (task names: 'hello')

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,9 @@
 # Release notes
 
+### Pending
+
+- Fix error handling of cron issues in 'run' method.
+
 ### v0.13.0
 
 - Remove dependency on `pgcrypto` database extension (thanks @noinkling)

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -86,6 +86,9 @@ export const run = async (
       overrideParsedCronItems ||
       (await getParsedCronItemsFromOptions(options, releasers));
 
+    // NO AWAIT AFTER THIS POINT! The promise from cron and workerPool must be
+    // returned synchronously.
+
     const cron = runCron(options, parsedCronItems, { pgPool, events });
     releasers.push(() => cron.release());
 
@@ -113,9 +116,6 @@ export const run = async (
         return Promise.reject(e);
       },
     );
-
-    // On error, don't kill node process.
-    promise.then(null, () => {});
 
     return {
       stop,

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -108,17 +108,13 @@ export const run = async (
  *
  * @internal
  */
-function buildRunner({
-  options,
-  compiledOptions,
-  taskList,
-  parsedCronItems,
-}: {
+function buildRunner(input: {
   options: RunnerOptions;
   compiledOptions: CompiledOptions;
   taskList: TaskList;
   parsedCronItems: ParsedCronItem[];
 }): Runner {
+  const { options, compiledOptions, taskList, parsedCronItems } = input;
   const { events, pgPool, releasers, release, addJob } = compiledOptions;
 
   const cron = runCron(options, parsedCronItems, { pgPool, events });

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -1,15 +1,8 @@
 import * as assert from "assert";
-import { Pool } from "pg";
 
 import { getParsedCronItemsFromOptions, runCron } from "./cron";
 import getTasks from "./getTasks";
-import {
-  ParsedCronItem,
-  Runner,
-  RunnerOptions,
-  TaskList,
-  WorkerEvents,
-} from "./interfaces";
+import { ParsedCronItem, Runner, RunnerOptions, TaskList } from "./interfaces";
 import {
   CompiledOptions,
   getUtilsAndReleasersFromOptions,


### PR DESCRIPTION
## Description

Fixes #262.

There's a bug in `runner` where it does not expose the promise returned from `cron` to the user; as such the user has no way to handle errors that happen in cron (or even to know if an error did happen) - instead the worker would just continue on regardless, but with cron not running. In Node v16+ this behavior changes, and instead the unhandled rejection will crash the entire process. Neither of these solutions are ideal...

This PR changes the error handling, making it so that errors raised from cron are also returned via the `promise` property. Further, it refactors to make the synchronous nature of the error handling more obvious. And further still, it makes it so that an error in cron will shut down the worker and vice versa.

## Performance impact

Negligible.

## Security impact

More resilient to backend issues ─ minor improvement.

## Checklist

- [x] My code matches the project's code style and `yarn lint:fix` passes.
- [ ] ~~I've added tests for the new feature, and `yarn test` passes.~~
- [x] I have detailed the new feature in the relevant documentation.
- [x] I have added this feature to 'Pending' in the `RELEASE_NOTES.md` file (if one exists).
- [x] If this is a breaking change I've explained why.
