### PR TITLE
feat: batch jobs

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -38,6 +38,7 @@ earlier workers against this releases database schema or Bad Things will happen.
 
 #### Features
 
+- New "batch jobs" feature for merging payloads with a `job_key` (see README)
 - Significantly improved 'large jobs table' performance (e.g. when a large queue
   is locked, or there's a lot of jobs queued for task identifiers your worker
   instance doesn't support, or a lot of failed jobs). Around 20x improvement in

--- a/__tests__/migrate.test.ts
+++ b/__tests__/migrate.test.ts
@@ -34,7 +34,7 @@ test("migration installs schema; second migration does no harm", async () => {
     const { rows: migrationRows } = await pgClient.query(
       `select * from ${ESCAPED_GRAPHILE_WORKER_SCHEMA}.migrations`,
     );
-    expect(migrationRows).toHaveLength(11);
+    expect(migrationRows).toHaveLength(12);
     const migration = migrationRows[0];
     expect(migration.id).toEqual(1);
 

--- a/sql/000012.sql
+++ b/sql/000012.sql
@@ -1,0 +1,91 @@
+create or replace function :GRAPHILE_WORKER_SCHEMA.add_jobs(
+  specs :GRAPHILE_WORKER_SCHEMA.job_spec[],
+  job_key_preserve_run_at boolean default false
+)
+returns setof :GRAPHILE_WORKER_SCHEMA.jobs
+as $$
+begin
+  -- Ensure all the tasks exist
+  insert into :GRAPHILE_WORKER_SCHEMA.tasks (identifier)
+  select distinct spec.identifier
+  from unnest(specs) spec
+  on conflict do nothing;
+
+  -- Ensure all the queues exist
+  insert into :GRAPHILE_WORKER_SCHEMA.job_queues (queue_name)
+  select distinct spec.queue_name
+  from unnest(specs) spec
+  where spec.queue_name is not null
+  on conflict do nothing;
+
+  -- Ensure any locked jobs have their key cleared - in the case of locked
+  -- existing job create a new job instead as it must have already started
+  -- executing (i.e. it's world state is out of date, and the fact add_job
+  -- has been called again implies there's new information that needs to be
+  -- acted upon).
+  update :GRAPHILE_WORKER_SCHEMA.jobs
+  set
+    key = null,
+    attempts = jobs.max_attempts,
+    updated_at = now()
+  from unnest(specs) spec
+  where spec.job_key is not null
+  and jobs.key = spec.job_key
+  and is_available is not true;
+
+  -- TODO: is there a risk that a conflict could occur depending on the
+  -- isolation level?
+
+  return query insert into :GRAPHILE_WORKER_SCHEMA.jobs (
+    job_queue_id,
+    task_id,
+    payload,
+    run_at,
+    max_attempts,
+    key,
+    priority,
+    flags
+  )
+    select
+      job_queues.id,
+      tasks.id,
+      coalesce(spec.payload, '{}'::json),
+      coalesce(spec.run_at, now()),
+      coalesce(spec.max_attempts, 25),
+      spec.job_key,
+      coalesce(spec.priority, 0),
+      (
+        select jsonb_object_agg(flag, true)
+        from unnest(spec.flags) as item(flag)
+      )
+    from unnest(specs) spec
+    inner join :GRAPHILE_WORKER_SCHEMA.tasks
+    on tasks.identifier = spec.identifier
+    left join :GRAPHILE_WORKER_SCHEMA.job_queues
+    on job_queues.queue_name = spec.queue_name
+  on conflict (key) do update set
+    job_queue_id = excluded.job_queue_id,
+    task_id = excluded.task_id,
+    payload =
+      case
+      when json_typeof(jobs.payload) = 'array' and json_typeof(excluded.payload) = 'array' then
+        (jobs.payload::jsonb || excluded.payload::jsonb)::json
+      else
+        excluded.payload
+      end,
+    max_attempts = excluded.max_attempts,
+    run_at = (case
+      when job_key_preserve_run_at is true and jobs.attempts = 0 then jobs.run_at
+      else excluded.run_at
+    end),
+    priority = excluded.priority,
+    revision = jobs.revision + 1,
+    flags = excluded.flags,
+    -- always reset error/retry state
+    attempts = 0,
+    last_error = null,
+    updated_at = now()
+  where jobs.locked_at is null
+  returning *;
+end;
+$$ language plpgsql;

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -146,7 +146,7 @@ export type PromiseOrDirect<T> = Promise<T> | T;
 export type Task = (
   payload: unknown,
   helpers: JobHelpers,
-) => PromiseOrDirect<void | PromiseOrDirect<undefined>[]>;
+) => PromiseOrDirect<void | PromiseOrDirect<unknown>[]>;
 
 export function isValidTask(fn: unknown): fn is Task {
   if (typeof fn === "function") {

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -141,10 +141,12 @@ export interface WorkerUtils extends Helpers {
   ) => Promise<DbJob[]>;
 }
 
+export type PromiseOrDirect<T> = Promise<T> | T;
+
 export type Task = (
   payload: unknown,
   helpers: JobHelpers,
-) => void | Promise<void>;
+) => PromiseOrDirect<void | PromiseOrDirect<undefined>[]>;
 
 export function isValidTask(fn: unknown): fn is Task {
   if (typeof fn === "function") {
@@ -692,12 +694,17 @@ export type WorkerEventMap = {
   /**
    * When a job throws an error
    */
-  "job:error": { worker: Worker; job: Job; error: any };
+  "job:error": { worker: Worker; job: Job; error: any; batchJobErrors?: any[] };
 
   /**
    * When a job fails permanently (emitted after job:error when appropriate)
    */
-  "job:failed": { worker: Worker; job: Job; error: any };
+  "job:failed": {
+    worker: Worker;
+    job: Job;
+    error: any;
+    batchJobErrors?: any[];
+  };
 
   /**
    * When a job has finished executing and the result (success or failure) has

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -6,6 +6,7 @@ import deferred from "./deferred";
 import { makeJobHelpers } from "./helpers";
 import {
   Job,
+  PromiseOrDirect,
   TaskList,
   WithPgClient,
   Worker,
@@ -204,20 +205,61 @@ export function makeNewWorker(
        * **MUST** release the job once we've attempted it (success or error).
        */
       const startTimestamp = process.hrtime();
+      let result: void | PromiseOrDirect<undefined>[];
       try {
         logger.debug(`Found task ${job.id} (${job.task_identifier})`);
         const task = tasks[job.task_identifier];
         assert(task, `Unsupported task '${job.task_identifier}'`);
         const helpers = makeJobHelpers(options, job, { withPgClient, logger });
-        await task(job.payload, helpers);
+        result = await task(job.payload, helpers);
       } catch (error) {
         err = error;
       }
       const durationRaw = process.hrtime(startTimestamp);
       const duration = durationRaw[0] * 1e3 + durationRaw[1] * 1e-6;
+
+      const batchJobFailedPayloads = [];
+      const batchJobErrors = [];
+
+      if (!err) {
+        if (Array.isArray(job.payload) && Array.isArray(result)) {
+          if (job.payload.length !== result.length) {
+            console.warn(
+              `Task '${job.task_identifier}' has invalid return value - should return an array with the same length as the incoming payload to indicate success or otherwise. We're going to treat this as full success, but this is a bug in your code.`,
+            );
+          }
+
+          const results = await Promise.allSettled(result);
+          for (let i = 0; i < job.payload.length; i++) {
+            const entryResult = results[i];
+            if (entryResult.status === "rejected") {
+              const entry = job.payload[i];
+              batchJobFailedPayloads.push(entry);
+              batchJobErrors.push(entryResult.reason);
+            } else {
+              // success!
+            }
+          }
+        }
+
+        if (batchJobFailedPayloads.length > 0) {
+          err = new Error(
+            `Batch failures:\n${batchJobErrors
+              .map((e) => e.message ?? String(e))
+              .join("\n")}`,
+          );
+        }
+      }
+
       if (err) {
         try {
-          events.emit("job:error", { worker, job, error: err });
+          events.emit("job:error", {
+            worker,
+            job,
+            error: err,
+            batchJobErrors:
+              batchJobErrors.length > 0 ? batchJobErrors : undefined,
+          });
         } catch (e) {
           logger.error(
             "Error occurred in event emitter for 'job:error'; this is an issue in your application code and you should fix it",
@@ -226,7 +268,13 @@ export function makeNewWorker(
         if (job.attempts >= job.max_attempts) {
           try {
             // Failed forever
-            events.emit("job:failed", { worker, job, error: err });
+            events.emit("job:failed", {
+              worker,
+              job,
+              error: err,
+              batchJobErrors:
+                batchJobErrors.length > 0 ? batchJobErrors : undefined,
+            });
           } catch (e) {
             logger.error(
               "Error occurred in event emitter for 'job:failed'; this is an issue in your application code and you should fix it",
@@ -258,6 +306,9 @@ export function makeNewWorker(
           workerId,
           job,
           message,
+          batchJobFailedPayloads.length > 0
+            ? batchJobFailedPayloads
+            : undefined,
         );
       } else {
         try {

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -205,7 +205,7 @@ export function makeNewWorker(
        * **MUST** release the job once we've attempted it (success or error).
        */
       const startTimestamp = process.hrtime();
-      let result: void | PromiseOrDirect<undefined>[];
+      let result: void | PromiseOrDirect<unknown>[];
       try {
         logger.debug(`Found task ${job.id} (${job.task_identifier})`);
         const task = tasks[job.task_identifier];


### PR DESCRIPTION
## Description

Sometimes you want to append data to a scheduled job, but currently we only allow replacing the payload via `job_key`. Sometimes you want to process data in a batch, but we currently only allow creating or replacing jobs, and we only run them one at a time.

This PR solves both of these issues with on solution: "batch jobs." The concept is pretty simple (as is the code thanks to the previous work in #274) - we allow a job payload to be an array, and if it is indeed an array then when you use a `job_key` instead of replacing the payload, we'll merge it (the new items will be appended to the previous list).

When it comes time to execute the task, it'll work as it did previously, _except_ you can optionally return a list of promises from your task if it's processing a batch job. If you do so (and the list has the same length as the batch job's payload list length) then Worker will check for rejections in the list. If there are none then the job succeeds as normal, but if there are some rejections then the job will be "failed" as currently _except_ the payload will only retain entries that correlate with the rejections - successful payload entries will be deleted.

## Performance impact

Incredibly slight increased cost when queueing jobs (200ms -> 204ms?) but any other impact wasn't significant enough to show up above noise when benchmarking.

## Security impact

None known.

## Checklist


- [x] My code matches the project's code style and `yarn lint:fix` passes.
- [x] I've added tests for the new feature, and `yarn test` passes.
- [x] I have detailed the new feature in the relevant documentation.
- [x] I have added this feature to 'Pending' in the `RELEASE_NOTES.md` file (if one exists).
- [x] ~~If this is a breaking change I've explained why.~~
