### PR TITLE
fix: don't log worker options even in debug mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -829,6 +829,13 @@ for more information.
 **NOTE**: you do not need to (and should not) customise, inherit or extend the
 `Logger` class at all.
 
+**NOTE**: some log messages are gated behind the
+`GRAPHILE_ENABLE_DANGEROUS_LOGS=1` environmental variable - to see them you will
+need to enable that envvar AND enable debug logging (e.g. with
+`GRAPHILE_LOGGER_DEBUG=1` as mentioned above) - do not do this in production as
+these logs may include incredibly sensitive details such as your full database
+connection string including password.
+
 ## Creating task executors
 
 A task executor is a simple async JS function which receives as input the job

--- a/src/main.ts
+++ b/src/main.ts
@@ -23,6 +23,9 @@ import SIGNALS from "./signals";
 import { resetLockedAt } from "./sql/resetLockedAt";
 import { makeNewWorker } from "./worker";
 
+const ENABLE_DANGEROUS_LOGS =
+  process.env.GRAPHILE_ENABLE_DANGEROUS_LOGS === "1";
+
 // Wait at most 60 seconds between connection attempts for LISTEN.
 const MAX_DELAY = 60 * 1000;
 
@@ -105,7 +108,9 @@ export function runTaskList(
   pgPool: Pool,
 ): WorkerPool {
   const { logger, escapedWorkerSchema, events } = processSharedOptions(options);
-  logger.debug(`Worker pool options are ${inspect(options)}`, { options });
+  if (ENABLE_DANGEROUS_LOGS) {
+    logger.debug(`Worker pool options are ${inspect(options)}`, { options });
+  }
   const { concurrency = defaults.concurrentJobs, noHandleSignals } = options;
 
   if (!noHandleSignals) {


### PR DESCRIPTION
## Description

A Graphile Worker user was using a custom logger in `debug` mode in production and was surprised to find their database credentials in the logs. By default Graphile Worker does not log `debug` mode messages - you have to enable `GRAPHILE_LOGGER_DEBUG=1` to see them - but custom loggers can make their own decisions in this regard. To help others not make this mistake we now _also_ require that you set `GRAPHILE_ENABLE_DANGEROUS_LOGS=1` in order to see this particular log message even if you're using a custom logger.

## Performance impact

Negligible.

## Security impact

Addresses the above mentioned issue.

## Checklist

- [x] My code matches the project's code style and `yarn lint:fix` passes.
- [ ] ~~I've added tests for the new feature, and `yarn test` passes.~~
- [ ] ~~I have detailed the new feature in the relevant documentation.~~
- [ ] ~~I have added this feature to 'Pending' in the `RELEASE_NOTES.md` file (if one exists).~~
- [ ] ~~If this is a breaking change I've explained why.~~
