### PR TITLE
fix: factor useNodeTime into prepared statement name

### DIFF
--- a/src/sql/resetLockedAt.ts
+++ b/src/sql/resetLockedAt.ts
@@ -28,7 +28,7 @@ where locked_at < ${now} - interval '4 hours'`,
       values: useNodeTime ? [new Date().toISOString()] : [],
       name: noPreparedStatements
         ? undefined
-        : `clear_stale_locks/${workerSchema}`,
+        : `clear_stale_locks${useNodeTime ? "N" : ""}/${workerSchema}`,
     }),
   );
 }


### PR DESCRIPTION
Unlikely to affect anyone, but this ensures if you're using a mixture of node-time and not-node-time (why would you do that?) that no conflicts occur