### PR TITLE
fix: unlocked jobs should have run_at bumped to now()

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -52,6 +52,10 @@ referencing the jobs table in a database function you may have a bad time.
 - Added new (experimental) much faster `add_jobs` batch API.
 - Fix error handling of cron issues in 'run' method.
 - CronItem.match can now accept either a pattern string or a matcher function
+- Jobs that were locked more than 4 hours will be reattempted as before, however
+  they are slightly de-prioritised by virtue of having their `run_at` updated,
+  giving interrim jobs a chance to be executed (and lessening the impact of
+  queue stalling through hanging tasks).
 
 ### v0.13.0
 

--- a/src/sql/resetLockedAt.ts
+++ b/src/sql/resetLockedAt.ts
@@ -19,7 +19,7 @@ export async function resetLockedAt(
       text: `\
 with j as (
 update ${escapedWorkerSchema}.jobs
-set locked_at = null, locked_by = null
+set locked_at = null, locked_by = null, run_at = greatest(run_at, now())
 where locked_at < ${now} - interval '4 hours'
 )
 update ${escapedWorkerSchema}.job_queues


### PR DESCRIPTION
## Description

Imagine we have a number of jobs (say for example twice our `concurrency` setting's worth) that hang indefinitely. Our queue looks like it's not progressing. After 4 hours, those jobs will be unlocked, and because their run_at is unchanged, they will still be front of the queue. When a worker becomes available they will be re-attempted before any other tasks. Thus this locked situation might persist indefinitely.

When we reset the `locked_at`/`locked_by` of jobs that were locked 4+ hours ago, we should _also_ update the `run_at` to ensure that any jobs queued in the interrim can be attempted first, since this is already defacto a failed job.

## Performance impact

Fixes potential locked job queue situation.

## Security impact

Fixes potential locked job queue situation.

## Checklist

<!-- If this PR is work in progress, please open it as a "Draft PR". -->
<!-- To tick a checkbox, change it from `[ ]` to `[x]` -->

- [x] My code matches the project's code style and `yarn lint:fix` passes.
- [ ] ~~I've added tests for the new feature, and `yarn test` passes.~~
- [ ] ~~I have detailed the new feature in the relevant documentation.~~
- [x] I have added this feature to 'Pending' in the `RELEASE_NOTES.md` file (if one exists).
- [ ] ~~If this is a breaking change I've explained why.~~

<!-- For some Graphile projects the documentation is the README.md file, for
      others please see https://github.com/graphile/graphile.github.io -->
