### PR TITLE
Change `add_job` signature back to using `int` instead of `smallint`

### DIFF
--- a/README.md
+++ b/README.md
@@ -958,14 +958,15 @@ NOTE: the [`addJob`](#addjob) JavaScript method simply defers to this underlying
   same named queue (defaults to `null`)
 - `run_at` - a timestamp after which to run the job; defaults to now.
 - `max_attempts` - if this task fails, how many times should we retry it?
-  Default: 25.
+  Default: `25::smallint`. You must cast the value you specify as `::smallint`.
 - `job_key` - unique identifier for the job, used to replace, update or remove
   it later if needed (see
   [Replacing, updating and removing jobs](#replacing-updating-and-removing-jobs));
   can also be used for de-duplication
 - `priority` - an integer representing the jobs priority. Jobs are executed in
   numerically ascending order of priority (jobs with a numerically smaller
-  priority are run first).
+  priority are run first). Default: `0::smallint`. You must cast the value you
+  specify as `::smallint`.
 - `flags` - an optional text array (`text[]`) representing a flags to attach to
   the job. Can be used alongside the `forbiddenFlags` option in library mode to
   implement complex rate limiting or other behaviors which requiring skipping
@@ -1011,7 +1012,7 @@ SELECT graphile_worker.add_job(
   $1,
   payload := $2,
   queue_name := $3,
-  max_attempts := $4,
+  max_attempts := $4::smallint,
   run_at := NOW() + ($5 * INTERVAL '1 second')
 );
 ```
@@ -1040,9 +1041,9 @@ the `add_job` option of the same name above.
 - `payload`
 - `queue_name`
 - `run_at`
-- `max_attempts`
+- `max_attempts` (don't forget to cast to `::smallint`)
 - `job_key`
-- `priority`
+- `priority` (don't forget to cast to `::smallint`)
 - `flags`
 
 Note: `job_key_mode='unsafe_dedupe'` is not supported in `add_jobs` - you must
@@ -1240,9 +1241,9 @@ SQL:
 SELECT * FROM graphile_worker.reschedule_jobs(
   ARRAY[7, 99, 38674, ...],
   run_at := NOW() + interval '5 minutes',
-  priority := 5,
-  attempts := 5,
-  max_attempts := 25
+  priority := 5::smallint,
+  attempts := 5::smallint,
+  max_attempts := 25::smallint
 );
 ```
 

--- a/README.md
+++ b/README.md
@@ -958,15 +958,14 @@ NOTE: the [`addJob`](#addjob) JavaScript method simply defers to this underlying
   same named queue (defaults to `null`)
 - `run_at` - a timestamp after which to run the job; defaults to now.
 - `max_attempts` - if this task fails, how many times should we retry it?
-  Default: `25::smallint`. You must cast the value you specify as `::smallint`.
+  Default: `25`. Must be castable to `smallint`.
 - `job_key` - unique identifier for the job, used to replace, update or remove
   it later if needed (see
   [Replacing, updating and removing jobs](#replacing-updating-and-removing-jobs));
   can also be used for de-duplication
 - `priority` - an integer representing the jobs priority. Jobs are executed in
   numerically ascending order of priority (jobs with a numerically smaller
-  priority are run first). Default: `0::smallint`. You must cast the value you
-  specify as `::smallint`.
+  priority are run first). Default: `0`. Must be castable to `smallint`.
 - `flags` - an optional text array (`text[]`) representing a flags to attach to
   the job. Can be used alongside the `forbiddenFlags` option in library mode to
   implement complex rate limiting or other behaviors which requiring skipping
@@ -1012,7 +1011,7 @@ SELECT graphile_worker.add_job(
   $1,
   payload := $2,
   queue_name := $3,
-  max_attempts := $4::smallint,
+  max_attempts := $4,
   run_at := NOW() + ($5 * INTERVAL '1 second')
 );
 ```
@@ -1041,9 +1040,9 @@ the `add_job` option of the same name above.
 - `payload`
 - `queue_name`
 - `run_at`
-- `max_attempts` (don't forget to cast to `::smallint`)
+- `max_attempts`
 - `job_key`
-- `priority` (don't forget to cast to `::smallint`)
+- `priority`
 - `flags`
 
 Note: `job_key_mode='unsafe_dedupe'` is not supported in `add_jobs` - you must
@@ -1241,9 +1240,9 @@ SQL:
 SELECT * FROM graphile_worker.reschedule_jobs(
   ARRAY[7, 99, 38674, ...],
   run_at := NOW() + interval '5 minutes',
-  priority := 5::smallint,
-  attempts := 5::smallint,
-  max_attempts := 25::smallint
+  priority := 5,
+  attempts := 5,
+  max_attempts := 25
 );
 ```
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -19,12 +19,17 @@ the old jobs table. The jobs table itself is not a public interface - you should
 use the documented SQL functions and TypeScript APIs only - but if you are
 referencing the jobs table in a database function you may have a bad time.
 
+**IMPORTANT**: `priority`, `attempts` and `max_attempts` are all now `smallint`,
+so please make sure that your values fit into these ranges before starting the
+migration process. (Really these values should never be larger than about `100`
+or smaller than about `-100` anyway.)
+
 #### Breaking changes
 
 - BREAKING: Bump minimum Node version to 14 since 12.x is now end-of-life
 - BREAKING: Bump minimum PG version to 12 for `generated always as (expression)`
 - BREAKING: `jobs.priority`, `attempts` and `max_attempts` are now `int2` rather
-  than `int4` (please ensure your `priority` values fit in `int2` -
+  than `int4` (please ensure your values fit in `int2` -
   `-32768 <= priority <= +32767`)
 - BREAKING: CronItem.pattern has been renamed to CronItem.match
 - BREAKING: database error codes have been removed because we've moved to

--- a/__tests__/main.runTaskListOnce.test.ts
+++ b/__tests__/main.runTaskListOnce.test.ts
@@ -452,7 +452,7 @@ select * from ${ESCAPED_GRAPHILE_WORKER_SCHEMA}.add_job(
   '{"a": 1}',
   queue_name := 'queue1',
   run_at := '${runAt.toISOString()}',
-  max_attempts := 10::smallint,
+  max_attempts := 10,
   job_key := 'abc'
 ) jobs`,
     );
@@ -512,7 +512,7 @@ select * from ${ESCAPED_GRAPHILE_WORKER_SCHEMA}.add_job(
         '{"a": 2}',
         queue_name := 'queue2',
         run_at := '${runAt2.toISOString()}',
-        max_attempts := 100::smallint,
+        max_attempts := 100,
         job_key := 'abc'
       )`,
     );

--- a/__tests__/migrate.test.ts
+++ b/__tests__/migrate.test.ts
@@ -34,7 +34,7 @@ test("migration installs schema; second migration does no harm", async () => {
     const { rows: migrationRows } = await pgClient.query(
       `select * from ${ESCAPED_GRAPHILE_WORKER_SCHEMA}.migrations`,
     );
-    expect(migrationRows).toHaveLength(13);
+    expect(migrationRows).toHaveLength(14);
     const migration = migrationRows[0];
     expect(migration.id).toEqual(1);
 

--- a/__tests__/schema.sql
+++ b/__tests__/schema.sql
@@ -31,7 +31,7 @@ CREATE TABLE graphile_worker.jobs (
     CONSTRAINT jobs_key_check CHECK (((length(key) > 0) AND (length(key) <= 512))),
     CONSTRAINT jobs_max_attempts_check CHECK ((max_attempts >= 1))
 );
-CREATE FUNCTION graphile_worker.add_job(identifier text, payload json DEFAULT NULL::json, queue_name text DEFAULT NULL::text, run_at timestamp with time zone DEFAULT NULL::timestamp with time zone, max_attempts smallint DEFAULT NULL::smallint, job_key text DEFAULT NULL::text, priority smallint DEFAULT NULL::smallint, flags text[] DEFAULT NULL::text[], job_key_mode text DEFAULT 'replace'::text) RETURNS graphile_worker.jobs
+CREATE FUNCTION graphile_worker.add_job(identifier text, payload json DEFAULT NULL::json, queue_name text DEFAULT NULL::text, run_at timestamp with time zone DEFAULT NULL::timestamp with time zone, max_attempts integer DEFAULT NULL::integer, job_key text DEFAULT NULL::text, priority integer DEFAULT NULL::integer, flags text[] DEFAULT NULL::text[], job_key_mode text DEFAULT 'replace'::text) RETURNS graphile_worker.jobs
     LANGUAGE plpgsql
     AS $$
 declare
@@ -45,9 +45,9 @@ begin
         payload,
         queue_name,
         run_at,
-        max_attempts,
+        max_attempts::smallint,
         job_key,
-        priority,
+        priority::smallint,
         flags
       )::"graphile_worker".job_spec],
       (job_key_mode = 'preserve_run_at')
@@ -87,9 +87,9 @@ begin
         tasks.id,
         coalesce(add_job.payload, '{}'::json),
         coalesce(add_job.run_at, now()),
-        coalesce(add_job.max_attempts, 25),
+        coalesce(add_job.max_attempts::smallint, 25::smallint),
         add_job.job_key,
-        coalesce(add_job.priority, 0),
+        coalesce(add_job.priority::smallint, 0::smallint),
         (
           select jsonb_object_agg(flag, true)
           from unnest(add_job.flags) as item(flag)
@@ -280,15 +280,15 @@ begin
   return v_job;
 end;
 $$;
-CREATE FUNCTION graphile_worker.reschedule_jobs(job_ids bigint[], run_at timestamp with time zone DEFAULT NULL::timestamp with time zone, priority smallint DEFAULT NULL::smallint, attempts smallint DEFAULT NULL::smallint, max_attempts smallint DEFAULT NULL::smallint) RETURNS SETOF graphile_worker.jobs
+CREATE FUNCTION graphile_worker.reschedule_jobs(job_ids bigint[], run_at timestamp with time zone DEFAULT NULL::timestamp with time zone, priority integer DEFAULT NULL::integer, attempts integer DEFAULT NULL::integer, max_attempts integer DEFAULT NULL::integer) RETURNS SETOF graphile_worker.jobs
     LANGUAGE sql
     AS $$
   update "graphile_worker".jobs
     set
       run_at = coalesce(reschedule_jobs.run_at, jobs.run_at),
-      priority = coalesce(reschedule_jobs.priority, jobs.priority),
-      attempts = coalesce(reschedule_jobs.attempts, jobs.attempts),
-      max_attempts = coalesce(reschedule_jobs.max_attempts, jobs.max_attempts),
+      priority = coalesce(reschedule_jobs.priority::smallint, jobs.priority),
+      attempts = coalesce(reschedule_jobs.attempts::smallint, jobs.attempts),
+      max_attempts = coalesce(reschedule_jobs.max_attempts::smallint, jobs.max_attempts),
       updated_at = now()
     where id = any(job_ids)
     and (

--- a/sql/000014.sql
+++ b/sql/000014.sql
@@ -1,0 +1,103 @@
+-- Go back to exposing 'int' on public interfaces, use smallint internally.
+
+drop function :GRAPHILE_WORKER_SCHEMA.add_job;
+CREATE FUNCTION :GRAPHILE_WORKER_SCHEMA.add_job(identifier text, payload json DEFAULT NULL::json, queue_name text DEFAULT NULL::text, run_at timestamp with time zone DEFAULT NULL::timestamp with time zone, max_attempts int DEFAULT NULL::int, job_key text DEFAULT NULL::text, priority int DEFAULT NULL::int, flags text[] DEFAULT NULL::text[], job_key_mode text DEFAULT 'replace'::text) RETURNS :GRAPHILE_WORKER_SCHEMA.jobs
+    LANGUAGE plpgsql
+    AS $$
+declare
+  v_job :GRAPHILE_WORKER_SCHEMA.jobs;
+begin
+  if (job_key is null or job_key_mode is null or job_key_mode in ('replace', 'preserve_run_at')) then
+    select * into v_job
+    from :GRAPHILE_WORKER_SCHEMA.add_jobs(
+      ARRAY[(
+        identifier,
+        payload,
+        queue_name,
+        run_at,
+        max_attempts::smallint,
+        job_key,
+        priority::smallint,
+        flags
+      ):::GRAPHILE_WORKER_SCHEMA.job_spec],
+      (job_key_mode = 'preserve_run_at')
+    )
+    limit 1;
+    return v_job;
+  elsif job_key_mode = 'unsafe_dedupe' then
+    -- Ensure all the tasks exist
+    insert into :GRAPHILE_WORKER_SCHEMA.tasks (identifier)
+    values (add_job.identifier)
+    on conflict do nothing;
+    -- Ensure all the queues exist
+    if add_job.queue_name is not null then
+      insert into :GRAPHILE_WORKER_SCHEMA.job_queues (queue_name)
+      values (add_job.queue_name)
+      on conflict do nothing;
+    end if;
+    -- Insert job, but if one already exists then do nothing, even if the
+    -- existing job has already started (and thus represents an out-of-date
+    -- world state). This is dangerous because it means that whatever state
+    -- change triggered this add_job may not be acted upon (since it happened
+    -- after the existing job started executing, but no further job is being
+    -- scheduled), but it is useful in very rare circumstances for
+    -- de-duplication. If in doubt, DO NOT USE THIS.
+    insert into :GRAPHILE_WORKER_SCHEMA.jobs (
+      job_queue_id,
+      task_id,
+      payload,
+      run_at,
+      max_attempts,
+      key,
+      priority,
+      flags
+    )
+      select
+        job_queues.id,
+        tasks.id,
+        coalesce(add_job.payload, '{}'::json),
+        coalesce(add_job.run_at, now()),
+        coalesce(add_job.max_attempts::smallint, 25::smallint),
+        add_job.job_key,
+        coalesce(add_job.priority::smallint, 0::smallint),
+        (
+          select jsonb_object_agg(flag, true)
+          from unnest(add_job.flags) as item(flag)
+        )
+      from :GRAPHILE_WORKER_SCHEMA.tasks
+      left join :GRAPHILE_WORKER_SCHEMA.job_queues
+      on job_queues.queue_name = add_job.queue_name
+      where tasks.identifier = add_job.identifier
+    on conflict (key)
+      -- Bump the updated_at so that there's something to return
+      do update set
+        revision = jobs.revision + 1,
+        updated_at = now()
+      returning *
+      into v_job;
+    return v_job;
+  else
+    raise exception 'Invalid job_key_mode value, expected ''replace'', ''preserve_run_at'' or ''unsafe_dedupe''.' using errcode = 'GWBKM';
+  end if;
+end;
+$$;
+
+DROP FUNCTION :GRAPHILE_WORKER_SCHEMA.reschedule_jobs;
+CREATE FUNCTION :GRAPHILE_WORKER_SCHEMA.reschedule_jobs(job_ids bigint[], run_at timestamp with time zone DEFAULT NULL::timestamp with time zone, priority int DEFAULT NULL::int, attempts int DEFAULT NULL::int, max_attempts int DEFAULT NULL::int) RETURNS SETOF :GRAPHILE_WORKER_SCHEMA.jobs
+    LANGUAGE sql
+    AS $$
+  update :GRAPHILE_WORKER_SCHEMA.jobs
+    set
+      run_at = coalesce(reschedule_jobs.run_at, jobs.run_at),
+      priority = coalesce(reschedule_jobs.priority::smallint, jobs.priority),
+      attempts = coalesce(reschedule_jobs.attempts::smallint, jobs.attempts),
+      max_attempts = coalesce(reschedule_jobs.max_attempts::smallint, jobs.max_attempts),
+      updated_at = now()
+    where id = any(job_ids)
+    and (
+      locked_at is null
+    or
+      locked_at < NOW() - interval '4 hours'
+    )
+    returning *;
+$$;

--- a/src/cron.ts
+++ b/src/cron.ts
@@ -128,8 +128,8 @@ async function scheduleCronJobs(
         insert into ${escapedWorkerSchema}.known_crontabs (identifier, known_since, last_execution)
         select
           specs.identifier,
-          $2 as known_since,
-          $2 as last_execution
+          $2::timestamptz as known_since,
+          $2::timestamptz as last_execution
         from specs
         on conflict (identifier)
         do update set last_execution = excluded.last_execution
@@ -182,7 +182,7 @@ async function registerAndBackfillItems(
     await pgPool.query(
       `
       INSERT INTO ${escapedWorkerSchema}.known_crontabs (identifier, known_since)
-      SELECT identifier, $2
+      SELECT identifier, $2::timestamptz
       FROM unnest($1::text[]) AS unnest (identifier)
       ON CONFLICT DO NOTHING
       `,

--- a/src/cron.ts
+++ b/src/cron.ts
@@ -108,6 +108,8 @@ async function scheduleCronJobs(
   ts: string,
   useNodeTime: boolean,
 ) {
+  // TODO: refactor this to use `add_jobs`
+
   // Note that `identifier` is guaranteed to be unique for every record
   // in `specs`.
   await pgPool.query(
@@ -120,8 +122,8 @@ async function scheduleCronJobs(
           ((json->'job')->'payload')::json as payload,
           ((json->'job')->>'queueName')::text as queue_name,
           ((json->'job')->>'runAt')::timestamptz as run_at,
-          ((json->'job')->>'maxAttempts')::smallint as max_attempts,
-          ((json->'job')->>'priority')::smallint as priority
+          ((json->'job')->>'maxAttempts')::int as max_attempts,
+          ((json->'job')->>'priority')::int as priority
         from json_array_elements($1::json) with ordinality AS entries (json, index)
       ),
       locks as (

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -25,9 +25,9 @@ export function makeAddJob(
           payload => $2::json,
           queue_name => $3::text,
           run_at => $4::timestamptz,
-          max_attempts => $5::smallint,
+          max_attempts => $5::int,
           job_key => $6::text,
-          priority => $7::smallint,
+          priority => $7::int,
           flags => $8::text[],
           job_key_mode => $9::text
         );

--- a/src/sql/completeJob.ts
+++ b/src/sql/completeJob.ts
@@ -20,13 +20,13 @@ export async function completeJob(
         text: `\
 with j as (
 delete from ${escapedWorkerSchema}.jobs
-where id = $1
+where id = $1::bigint
 returning *
 )
 update ${escapedWorkerSchema}.job_queues
 set locked_by = null, locked_at = null
 from j
-where job_queues.id = j.job_queue_id and job_queues.locked_by = $2;`,
+where job_queues.id = j.job_queue_id and job_queues.locked_by = $2::text;`,
         values: [job.id, workerId],
         name: noPreparedStatements
           ? undefined
@@ -38,7 +38,7 @@ where job_queues.id = j.job_queue_id and job_queues.locked_by = $2;`,
       client.query({
         text: `\
 delete from ${escapedWorkerSchema}.jobs
-where id = $1`,
+where id = $1::bigint`,
         values: [job.id],
         name: noPreparedStatements ? undefined : `complete_job/${workerSchema}`,
       }),

--- a/src/sql/failJob.ts
+++ b/src/sql/failJob.ts
@@ -23,18 +23,18 @@ export async function failJob(
 with j as (
 update ${escapedWorkerSchema}.jobs
 set
-last_error = $2,
+last_error = $2::text,
 run_at = greatest(now(), run_at) + (exp(least(attempts, 10)) * interval '1 second'),
 locked_by = null,
 locked_at = null,
 payload = coalesce($4::json, jobs.payload)
-where id = $1 and locked_by = $3
+where id = $1::bigint and locked_by = $3::text
 returning *
 )
 update ${escapedWorkerSchema}.job_queues
 set locked_by = null, locked_at = null
 from j
-where job_queues.id = j.job_queue_id and job_queues.locked_by = $3;`,
+where job_queues.id = j.job_queue_id and job_queues.locked_by = $3::text;`,
         values: [
           job.id,
           message,
@@ -52,12 +52,12 @@ where job_queues.id = j.job_queue_id and job_queues.locked_by = $3;`,
         text: `\
 update ${escapedWorkerSchema}.jobs
 set
-last_error = $2,
+last_error = $2::text,
 run_at = greatest(now(), run_at) + (exp(least(attempts, 10)) * interval '1 second'),
 locked_by = null,
 locked_at = null,
 payload = coalesce($4::json, jobs.payload)
-where id = $1 and locked_by = $3;`,
+where id = $1::bigint and locked_by = $3::text;`,
         values: [
           job.id,
           message,
@@ -91,7 +91,7 @@ export async function failJobs(
 with j as (
 update ${escapedWorkerSchema}.jobs
 set
-last_error = $2,
+last_error = $2::text,
 run_at = greatest(now(), run_at) + (exp(least(attempts, 10)) * interval '1 second'),
 locked_by = null,
 locked_at = null

--- a/src/workerUtils.ts
+++ b/src/workerUtils.ts
@@ -46,11 +46,11 @@ export async function makeWorkerUtils(
       const { rows } = await withPgClient((client) =>
         client.query<DbJob>(
           `select * from ${escapedWorkerSchema}.reschedule_jobs(
-            $1,
-            run_at := $2,
-            priority := $3,
-            attempts := $4,
-            max_attempts := $5
+            $1::bigint[],
+            run_at := $2::timestamptz,
+            priority := $3::smallint,
+            attempts := $4::smallint,
+            max_attempts := $5::smallint
           )`,
           [
             ids,

--- a/src/workerUtils.ts
+++ b/src/workerUtils.ts
@@ -48,9 +48,9 @@ export async function makeWorkerUtils(
           `select * from ${escapedWorkerSchema}.reschedule_jobs(
             $1::bigint[],
             run_at := $2::timestamptz,
-            priority := $3::smallint,
-            attempts := $4::smallint,
-            max_attempts := $5::smallint
+            priority := $3::int,
+            attempts := $4::int,
+            max_attempts := $5::int
           )`,
           [
             ids,

--- a/src/workerUtils.ts
+++ b/src/workerUtils.ts
@@ -25,7 +25,7 @@ export async function makeWorkerUtils(
     async completeJobs(ids) {
       const { rows } = await withPgClient((client) =>
         client.query<DbJob>(
-          `select * from ${escapedWorkerSchema}.complete_jobs($1)`,
+          `select * from ${escapedWorkerSchema}.complete_jobs($1::bigint[])`,
           [ids],
         ),
       );
@@ -35,7 +35,7 @@ export async function makeWorkerUtils(
     async permanentlyFailJobs(ids, reason) {
       const { rows } = await withPgClient((client) =>
         client.query<DbJob>(
-          `select * from ${escapedWorkerSchema}.permanently_fail_jobs($1, $2)`,
+          `select * from ${escapedWorkerSchema}.permanently_fail_jobs($1::bigint[], $2::text)`,
           [ids, reason || null],
         ),
       );


### PR DESCRIPTION
## Description

This does _not_ change the underlying data in the jobs table, instead it just restores the old `add_job` signature so that `add_job('foo', priority => 7)` works without needing a `::smallint` cast.

This does **not** change the `add_jobs` signature - you must cast to `smallint` to use that - we see that method a performance critical, so no unnecessary casting.

## Performance impact

Trivially small casting cost from `::int` to `::smallint` inside the `add_job` and `reschedule_jobs` functions.

## Security impact

None known.

## Checklist

- [x] My code matches the project's code style and `yarn lint:fix` passes.
- [x] ~~I've added tests for the new feature, and~~ `yarn test` passes.
- [x] I have detailed the new feature in the relevant documentation.
- [x] I have added this feature to 'Pending' in the `RELEASE_NOTES.md` file (if one exists).
- [x] If this is a breaking change I've explained why.

Fixes #319 