### PR TITLE
docs: add some info regarding pg roles

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,11 +244,13 @@ yarn add graphile-worker
 ## Running
 
 `graphile-worker` manages its own database schema (`graphile_worker`). Just
-point graphile-worker at your database and we handle our own migrations:
+point graphile-worker at your database and we handle our own migratiDons:
 
 ```
 npx graphile-worker -c "postgres:///my_db"
 ```
+
+Note: Graphile Worker expects the runtime postgres role to be the same as the one used while running the migrations. If for some reason you need to run your migrations as a different role, you can fix this by changing the owner role of the tables to be the runtime one.
 
 (`npx` looks for the `graphile-worker` binary locally; it's often better to use
 the `"scripts"` entry in `package.json` instead.)

--- a/README.md
+++ b/README.md
@@ -244,7 +244,7 @@ yarn add graphile-worker
 ## Running
 
 `graphile-worker` manages its own database schema (`graphile_worker`). Just
-point graphile-worker at your database and we handle our own migratiDons:
+point graphile-worker at your database and we handle our own migrations:
 
 ```
 npx graphile-worker -c "postgres:///my_db"

--- a/README.md
+++ b/README.md
@@ -250,10 +250,10 @@ point graphile-worker at your database and we handle our own migratiDons:
 npx graphile-worker -c "postgres:///my_db"
 ```
 
-Note: Graphile Worker expects the runtime postgres role to be the same as the one used while running the migrations. If for some reason you need to run your migrations as a different role, you can fix this by changing the owner role of the tables to be the runtime one.
-
 (`npx` looks for the `graphile-worker` binary locally; it's often better to use
 the `"scripts"` entry in `package.json` instead.)
+
+Note: Graphile Worker expects the runtime postgres role to be the same as the one used while running the migrations. If for some reason you need to run your migrations as a different role, you can fix this by changing the owner role of the tables to be the runtime one.
 
 The following CLI options are available:
 

--- a/README.md
+++ b/README.md
@@ -253,7 +253,10 @@ npx graphile-worker -c "postgres:///my_db"
 (`npx` looks for the `graphile-worker` binary locally; it's often better to use
 the `"scripts"` entry in `package.json` instead.)
 
-Note: Graphile Worker expects the runtime postgres role to be the same as the one used while running the migrations. If for some reason you need to run your migrations as a different role, you can fix this by changing the owner role of the tables to be the runtime one.
+Note: Graphile Worker expects the Postgres role used at runtime to be the same
+as the role used while running the migrations. If you need to run your
+migrations as a different role, one solution is to explicitly change the owner
+of the `graphile_worker.*` tables to be the same role as is used at runtime.
 
 The following CLI options are available:
 


### PR DESCRIPTION
## Description

<!-- If this PR adds a feature, what does it add and what was the motivation for it? -->
<!-- If this PR fixes an issue, what is the issue? -->
<!-- Please link to the relevant GitHub issues/Discord discussion/etc as appropriate -->

Simple doc update to point out that Graphile Worker expects the tables to be owned by Postgres role that you use at runtime, as discussed in the Discord channel!


## Performance impact
None

## Security impact
None

## Checklist

<!-- If this PR is work in progress, please open it as a "Draft PR". -->
<!-- To tick a checkbox, change it from `[ ]` to `[x]` -->

- [ ] My code matches the project's code style and `yarn lint:fix` passes.
- [ ] I've added tests for the new feature, and `yarn test` passes.
- [ ] I have detailed the new feature in the relevant documentation.
- [ ] I have added this feature to 'Pending' in the `RELEASE_NOTES.md` file (if one exists).
- [ ] If this is a breaking change I've explained why.

<!-- For some Graphile projects the documentation is the README.md file, for
      others please see https://github.com/graphile/graphile.github.io -->
