### PR TITLE
Fix gracefulShutdown and introduce forcefulShutdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -1657,11 +1657,14 @@ If a job throws an error, the job is failed and scheduled for retries with
 exponential back-off. We use async/await so assuming you write your task code
 well all errors should be cascaded down automatically.
 
-If the worker is terminated (`SIGTERM`, `SIGINT`, etc), it
-[triggers a graceful shutdown](https://github.com/graphile/worker/blob/3540df5ab4eb73f846d54959fdfad07897b616f0/src/main.ts#L39-L66) -
-i.e. it stops accepting new jobs, waits for the existing jobs to complete, and
-then exits. If you need to restart your worker, you should do so using this
-graceful process.
+If the worker is sent a termination signal (`SIGTERM`, `SIGINT`, etc), it
+triggers a graceful shutdown - i.e. it stops accepting new jobs, waits for the
+existing jobs to complete, and then exits. If you need to restart your worker,
+you should do so using this graceful process. After 5 seconds (during which
+duplicate signals are ignored), if this same signal is sent again it will
+trigger a forceful shutdown: all running jobs will be "failed" (i.e. will retry
+on another worker after their exponential back-off) and then the worker will
+exit.
 
 If the worker completely dies unexpectedly (e.g. `process.exit()`, segfault,
 `SIGKILL`) then the jobs that that worker was executing remain locked for at

--- a/README.md
+++ b/README.md
@@ -1660,8 +1660,8 @@ well all errors should be cascaded down automatically.
 If the worker is sent a termination signal (`SIGTERM`, `SIGINT`, etc), it
 triggers a graceful shutdown - i.e. it stops accepting new jobs, waits for the
 existing jobs to complete, and then exits. If you need to restart your worker,
-you should do so using this graceful process. After 5 seconds (during which
-duplicate signals are ignored), if this same signal is sent again it will
+you should do so using this graceful process. After 5 seconds (during which more
+terminal signals are ignored), if another terminal signal is sent it will
 trigger a forceful shutdown: all running jobs will be "failed" (i.e. will retry
 on another worker after their exponential back-off) and then the worker will
 exit.

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,23 @@
 # Release notes
 
+### v0.15.1
+
+Fixes issues with graceful worker shutdowns:
+
+- Deprecates `workerPool.release()` in favour of (equivalent)
+  `workerPool.gracefulShutdown()`
+- Fixes `workerPool.gracefulShutdown()` to shut down gracefully (waiting for
+  jobs to complete)
+- Adds `workerPool.forcefulShutdown()` to "fail" the running jobs (so they'll be
+  re-attempted elsewhere) and force-release the pool
+- Fixes handling of signals:
+  - First termination signal triggers graceful shutdown
+  - Signal over next 5 seconds are ignored
+  - Second termination signal triggers forceful shutdown
+  - Signal over next 5 seconds are ignored
+  - Further termination signals are handled by Node (i.e. will likely instantly
+    exit the process)
+
 ### v0.15.0
 
 Migration files are no longer read from filesystem (via `fs` module); instead

--- a/__tests__/main.runTaskList.test.ts
+++ b/__tests__/main.runTaskList.test.ts
@@ -63,7 +63,7 @@ test("main will execute jobs as they come up, and exits cleanly", () =>
 
       await sleep(1);
       expect(finished).toBeFalsy();
-      await workerPool.release();
+      await workerPool.gracefulShutdown();
       expect(job1).toHaveBeenCalledTimes(5);
       await sleep(1);
       expect(finished).toBeTruthy();
@@ -90,7 +90,7 @@ test("doesn't bail on deprecated `debug` function", () =>
       await addJob(pgPool);
       await sleepUntil(() => !!jobPromise);
       jobPromise!.resolve();
-      await workerPool.release();
+      await workerPool.gracefulShutdown();
     } finally {
       if (jobPromise) {
         (jobPromise as Deferred).resolve();

--- a/__tests__/resetLockedAt.test.ts
+++ b/__tests__/resetLockedAt.test.ts
@@ -65,7 +65,7 @@ where task_id = (select id from ${ESCAPED_GRAPHILE_WORKER_SCHEMA}.tasks where id
     const states: string[] = [];
     events.on("resetLocked:started", () => {
       states.push("started");
-      workerPool.release();
+      workerPool.gracefulShutdown();
     });
     events.on("resetLocked:success", () => {
       states.push("success");

--- a/perfTest/latencyTest.js
+++ b/perfTest/latencyTest.js
@@ -76,7 +76,7 @@ async function main() {
     )}ms, avg: ${average.toFixed(2)}ms`,
   );
 
-  await workerPool.release();
+  await workerPool.gracefulShutdown();
   await pgPool.end();
   console.log("Done");
 }

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -339,8 +339,10 @@ export interface Worker {
 }
 
 export interface WorkerPool {
+  /** @deprecated Use gracefulShutdown instead */
   release: () => Promise<void>;
-  gracefulShutdown: (message: string) => Promise<void>;
+  gracefulShutdown: (message?: string) => Promise<void>;
+  forcefulShutdown: (message: string) => Promise<void>;
   promise: Promise<void>;
 }
 
@@ -647,6 +649,36 @@ export type WorkerEventMap = {
   "pool:gracefulShutdown:error": { pool: WorkerPool; error: any };
 
   /**
+   * When a worker pool graceful shutdown is successful, but one of the workers
+   * throws an error from release()
+   */
+  "pool:gracefulShutdown:workerError": {
+    pool: WorkerPool;
+    error: any;
+    job: Job | null;
+  };
+
+  /**
+   * When a worker pool graceful shutdown throws an error
+   */
+  "pool:gracefulShutdown:complete": { pool: WorkerPool };
+
+  /**
+   * When a worker pool starts a forceful shutdown
+   */
+  "pool:forcefulShutdown": { pool: WorkerPool; message: string };
+
+  /**
+   * When a worker pool forceful shutdown throws an error
+   */
+  "pool:forcefulShutdown:error": { pool: WorkerPool; error: any };
+
+  /**
+   * When a worker pool forceful shutdown throws an error
+   */
+  "pool:forcefulShutdown:complete": { pool: WorkerPool };
+
+  /**
    * When a worker is created
    */
   "worker:create": { worker: Worker; tasks: TaskList };
@@ -812,6 +844,11 @@ export type WorkerEventMap = {
    * When the runner is terminated by a signal
    */
   gracefulShutdown: { signal: Signal };
+
+  /**
+   * When the runner is terminated by a signal _again_ after 5 seconds
+   */
+  forcefulShutdown: { signal: Signal };
 
   /**
    * When the runner is stopped

--- a/src/main.ts
+++ b/src/main.ts
@@ -331,7 +331,9 @@ export function runTaskList(
                 reason: workerReleaseResult.reason,
               },
             );
-            if (job) jobsToRelease.push(job);
+            if (job) {
+              jobsToRelease.push(job);
+            }
           }
         }
         if (jobsToRelease.length > 0) {

--- a/src/main.ts
+++ b/src/main.ts
@@ -292,10 +292,18 @@ export function runTaskList(
     }
   }
 
+  let terminated = false;
   function terminate() {
-    const idx = allWorkerPools.indexOf(workerPool);
-    allWorkerPools.splice(idx, 1);
-    promise.resolve(resetLockedAtPromise);
+    if (!terminated) {
+      terminated = true;
+      const idx = allWorkerPools.indexOf(workerPool);
+      allWorkerPools.splice(idx, 1);
+      promise.resolve(resetLockedAtPromise);
+    } else {
+      logger.error(
+        `Graphile Worker internal error: terminate() was called twice for worker pool. Ignoring second call; but this indicates a bug - please file an issue.`,
+      );
+    }
   }
 
   // This is a representation of us that can be interacted with externally

--- a/src/main.ts
+++ b/src/main.ts
@@ -157,7 +157,7 @@ function registerSignalHandlers(logger: Logger, events: WorkerEvents) {
         removeForcefulHandler();
         clearTimeout(removeTimeout);
         logger.error(
-          `Global forceful shutdown attempted; killing self via ${signal}`,
+          `Global forceful shutdown completed; killing self via ${signal}`,
         );
         process.kill(process.pid, signal);
       });
@@ -347,8 +347,6 @@ export function runTaskList(
             cancelledJobs,
           });
           logger.debug("Jobs released");
-        } else {
-          logger.debug("No active jobs to release");
         }
         events.emit("pool:gracefulShutdown:complete", { pool: this });
         logger.debug("Graceful shutdown complete");
@@ -400,6 +398,8 @@ export function runTaskList(
         } else {
           logger.debug("No active jobs to release");
         }
+        events.emit("pool:forcefulShutdown:complete", { pool: this });
+        logger.debug("Forceful shutdown complete");
       } catch (e) {
         events.emit("pool:forcefulShutdown:error", { pool: this, error: e });
         logger.error(`Error occurred during forceful shutdown: ${e.message}`, {

--- a/src/main.ts
+++ b/src/main.ts
@@ -113,7 +113,7 @@ function registerSignalHandlers(logger: Logger, events: WorkerEvents) {
       }
 
       logger.error(
-        `Received '${signal}'; attempting graceful shutdown... (all ${signal} signals will be ignored for the next 5 seconds)`,
+        `Received '${signal}'; attempting global graceful shutdown... (all ${signal} signals will be ignored for the next 5 seconds)`,
       );
       const switchTimeout = setTimeout(switchToForcefulHandler, 5000);
       _signalHandlersEventEmitter.emit("gracefulShutdown", { signal });
@@ -127,7 +127,7 @@ function registerSignalHandlers(logger: Logger, events: WorkerEvents) {
         process.removeListener(signal, gracefulHandler);
         if (!_shuttingDownForcefully) {
           logger.error(
-            `Graceful shutdown attempted; killing self via ${signal}`,
+            `Global graceful shutdown complete; killing self via ${signal}`,
           );
           process.kill(process.pid, signal);
         }
@@ -144,7 +144,7 @@ function registerSignalHandlers(logger: Logger, events: WorkerEvents) {
       }
 
       logger.error(
-        `Received '${signal}'; attempting forceful shutdown... (all ${signal} signals will be ignored for the next 5 seconds)`,
+        `Received '${signal}'; attempting global forceful shutdown... (all ${signal} signals will be ignored for the next 5 seconds)`,
       );
       const removeTimeout = setTimeout(removeForcefulHandler, 5000);
       _signalHandlersEventEmitter.emit("forcefulShutdown", { signal });
@@ -156,7 +156,9 @@ function registerSignalHandlers(logger: Logger, events: WorkerEvents) {
       ).finally(() => {
         removeForcefulHandler();
         clearTimeout(removeTimeout);
-        logger.error(`Graceful shutdown attempted; killing self via ${signal}`);
+        logger.error(
+          `Global forceful shutdown attempted; killing self via ${signal}`,
+        );
         process.kill(process.pid, signal);
       });
     };

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -118,7 +118,7 @@ function buildRunner(input: {
   releasers.push(() => cron.release());
 
   const workerPool = runTaskList(options, taskList, pgPool);
-  releasers.push(() => workerPool.release());
+  releasers.push(() => workerPool.gracefulShutdown("Runner is shutting down"));
 
   let running = true;
   const stop = async () => {


### PR DESCRIPTION
## Description

Previously we claimed that a graceful shutdown would wait for jobs to complete; but it didn't.

Previously we had a `.release()` method and a `.gracefulShutdown()` method on worker pools... But these were badly named. Really `.release()` was the graceful shutdown (would wait for jobs to complete), and `.gracefulShutdown()` was more of a forceful shutdown (would "fail" all active jobs).

This PR:

- Deprecates `workerPool.release()` in favour of `workerPool.gracefulShutdown()`
- Fixes `workerPool.gracefulShutdown()` to shut down gracefully (waiting for jobs to complete)
- Adds `workerPool.forcefulShutdown()` to "fail" the running jobs and force-release the pool
- Fixes handling of signals:
  - First termination signal triggers graceful shutdown
  - Signal over next 5 seconds are ignored
  - Second termination signal triggers forceful shutdown
  - Signal over next 5 seconds are ignored
  - Further termination signals are handled by Node (i.e. will likely instantly exit the process)

Fixes #352 

## Performance impact

Only applies to shutdown, so ignoring.

## Security impact

None known.

## Checklist

- [x] My code matches the project's code style and `yarn lint:fix` passes.
- [ ] ~~I've added tests for the new feature, and `yarn test` passes.~~
- [x] I have detailed the new feature in the relevant documentation.
- [x] I have added this feature to 'Pending' in the `RELEASE_NOTES.md` file (if one exists).
- [x] If this is a breaking change I've explained why.

<!-- For some Graphile projects the documentation is the README.md file, for
      others please see https://github.com/graphile/graphile.github.io -->
