### PR TITLE
Unregister signal handlers on worker shutdown

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -16,6 +16,8 @@ Adds support for `graphile-config` - configuration can now be read from a
 
 Crontab: now supports `jobKey` and `jobKeyMode` opts (thanks @spiffytech!)
 
+Signals: now releases signal handlers when shut down via the API.
+
 ### v0.15.1
 
 Fixes issues with graceful worker shutdowns:

--- a/__tests__/main.runTaskList.test.ts
+++ b/__tests__/main.runTaskList.test.ts
@@ -43,7 +43,9 @@ test("main will execute jobs as they come up, and exits cleanly", () =>
       };
 
       // Run the worker
+      expect(process.listeners("SIGTERM")).toHaveLength(0);
       const workerPool = runTaskList({ concurrency: 3 }, tasks, pgPool);
+      expect(process.listeners("SIGTERM")).toHaveLength(1);
       let finished = false;
       workerPool.promise.then(() => {
         finished = true;
@@ -69,6 +71,7 @@ test("main will execute jobs as they come up, and exits cleanly", () =>
       expect(finished).toBeTruthy();
       await workerPool.promise;
       expect(await jobCount(pgPool)).toEqual(0);
+      expect(process.listeners("SIGTERM")).toHaveLength(0);
     } finally {
       Object.values(jobPromises).forEach((p) => p?.resolve());
     }


### PR DESCRIPTION
## Description

If you cleanly shut down a worker, we shouldn't need the global event listeners any more. This PR removes them (but only when you shut down via the API - a shutdown via SIGTERM/SIGINT/etc is expected to terminate the process).

Fixes #305.

## Performance impact

Marginal increase on boot up and shutdown.

## Security impact

None known.

## Checklist

- [x] My code matches the project's code style and `yarn lint:fix` passes.
- [x] I've added tests for the new feature, and `yarn test` passes.
- [ ] ~~I have detailed the new feature in the relevant documentation.~~
- [x] I have added this feature to 'Pending' in the `RELEASE_NOTES.md` file (if one exists).
- [ ] ~~If this is a breaking change I've explained why.~~

<!-- For some Graphile projects the documentation is the README.md file, for
      others please see https://github.com/graphile/graphile.github.io -->
