### PR TITLE
Assert that database schema isn't more up to date than current worker

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -18,6 +18,9 @@ Crontab: now supports `jobKey` and `jobKeyMode` opts (thanks @spiffytech!)
 
 Signals: now releases signal handlers when shut down via the API.
 
+Schema: checks that current schema in database isn't more up to date than the
+current worker. (This won't be useful until future schema changes.)
+
 ### v0.15.1
 
 Fixes issues with graceful worker shutdowns:

--- a/src/migrate.ts
+++ b/src/migrate.ts
@@ -93,7 +93,9 @@ export async function migrate(
   let highestMigration = 0;
   for (const migrationFile of migrationFiles) {
     const migrationNumber = parseInt(migrationFile.slice(0, 6), 10);
-    if (migrationNumber > highestMigration) highestMigration = migrationNumber;
+    if (migrationNumber > highestMigration) {
+      highestMigration = migrationNumber;
+    }
     if (latestMigration == null || migrationNumber > latestMigration) {
       await runMigration(options, client, migrationFile, migrationNumber);
     }

--- a/src/migrate.ts
+++ b/src/migrate.ts
@@ -90,10 +90,17 @@ export async function migrate(
   }
 
   const migrationFiles = Object.keys(migrations) as (keyof typeof migrations)[];
+  let highestMigration = 0;
   for (const migrationFile of migrationFiles) {
     const migrationNumber = parseInt(migrationFile.slice(0, 6), 10);
+    if (migrationNumber > highestMigration) highestMigration = migrationNumber;
     if (latestMigration == null || migrationNumber > latestMigration) {
       await runMigration(options, client, migrationFile, migrationNumber);
     }
+  }
+  if (latestMigration && highestMigration < latestMigration) {
+    throw new Error(
+      `Database is using Graphile Worker schema revision ${latestMigration}, but the currently running worker only supports up to revision ${highestMigration}. Please ensure all versions of Graphile Worker you're running are compatible.`,
+    );
   }
 }


### PR DESCRIPTION
## Description

Checks that the current DB revision isn't higher than the revisions the current worker supports.

Fixes #280 

## Performance impact

Negligible.

## Security impact

None known.

## Checklist

- [x] My code matches the project's code style and `yarn lint:fix` passes.
- [x] I've added tests for the new feature, and `yarn test` passes.
- [x] I have detailed the new feature in the relevant documentation.
- [x] I have added this feature to 'Pending' in the `RELEASE_NOTES.md` file (if one exists).
- [x] If this is a breaking change I've explained why.

<!-- For some Graphile projects the documentation is the README.md file, for
      others please see https://github.com/graphile/graphile.github.io -->
