### PR TITLE
Detect migrations and shut down

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -21,6 +21,9 @@ Signals: now releases signal handlers when shut down via the API.
 Schema: checks that current schema in database isn't more up to date than the
 current worker. (This won't be useful until future schema changes.)
 
+Schema: trigger a graceful shutdown if a new Graphile Worker process migrates
+the database schema.
+
 ### v0.15.1
 
 Fixes issues with graceful worker shutdowns:

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -162,6 +162,15 @@ async function main() {
     // Continue forever(ish)
     await promise;
   }
+  watchedTasks.release();
+  watchedCronItems.release();
+  const timer = setTimeout(() => {
+    console.error(
+      `Worker failed to exit naturally after 10 seconds; terminating manually. This may indicate a bug in Graphile Worker.`,
+    );
+    process.exit(1);
+  }, 10000);
+  timer.unref();
 }
 
 main().catch((e) => {

--- a/src/main.ts
+++ b/src/main.ts
@@ -573,6 +573,7 @@ export function runTaskList(
             console.warn(
               `Graphile Worker detected migration to database schema revision '${payload?.migrationNumber}'; it would be unsafe to continue, so shutting down...`,
             );
+            process.exitCode = 54;
             workerPool.gracefulShutdown();
             break;
           }

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,5 +1,5 @@
 import { EventEmitter } from "events";
-import { Pool, PoolClient } from "pg";
+import { Notification, Pool, PoolClient } from "pg";
 import { inspect } from "util";
 
 import { defaults } from "./config";
@@ -555,10 +555,33 @@ export function runTaskList(
       reconnectWithExponentialBackoff(e);
     }
 
-    function handleNotification() {
+    function handleNotification(message: Notification) {
       if (changeListener?.client === client) {
-        // Find a worker that's available
-        workers.some((worker) => worker.nudge());
+        switch (message.channel) {
+          case "jobs:insert": {
+            // Find a worker that's available
+            workers.some((worker) => worker.nudge());
+            break;
+          }
+          case "jobs:migrate": {
+            let payload: null | { migrationNumber?: number } = null;
+            try {
+              payload = message.payload ? JSON.parse(message.payload) : null;
+            } catch (e) {
+              /* noop */
+            }
+            console.warn(
+              `Graphile Worker detected migration to database schema revision '${payload?.migrationNumber}'; it would be unsafe to continue, so shutting down...`,
+            );
+            workerPool.gracefulShutdown();
+            break;
+          }
+          default: {
+            console.warn(
+              `Unhandled NOTIFY message on channel '${message.channel}'`,
+            );
+          }
+        }
       }
     }
 
@@ -586,6 +609,9 @@ export function runTaskList(
       // Successful listen; reset attempts
       attempts = 0;
     }, onErrorReleaseClientAndTryAgain);
+    client
+      .query('LISTEN "jobs:migrate"')
+      .then(null, onErrorReleaseClientAndTryAgain);
 
     const supportedTaskNames = Object.keys(tasks);
 

--- a/src/migrate.ts
+++ b/src/migrate.ts
@@ -60,7 +60,7 @@ async function runMigration(
     });
     await client.query("select pg_notify($1, $2)", [
       "jobs:migrate",
-      { migrationNumber },
+      JSON.stringify({ migrationNumber }),
     ]);
     await client.query("commit");
   } catch (e) {

--- a/src/migrate.ts
+++ b/src/migrate.ts
@@ -58,6 +58,10 @@ async function runMigration(
       text: `insert into ${escapedWorkerSchema}.migrations (id) values ($1)`,
       values: [migrationNumber],
     });
+    await client.query("select pg_notify($1, $2)", [
+      "jobs:migrate",
+      { migrationNumber },
+    ]);
     await client.query("commit");
   } catch (e) {
     await client.query("rollback");

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -93,7 +93,14 @@ export const run = async (
       parsedCronItems,
     });
   } catch (e) {
-    await release();
+    try {
+      await release();
+    } catch (e2) {
+      console.error(
+        `Error occurred whilst attempting to release options after error occurred`,
+        e2,
+      );
+    }
     throw e;
   }
 };
@@ -125,20 +132,38 @@ function buildRunner(input: {
     if (running) {
       running = false;
       events.emit("stop", {});
-      await release();
+      try {
+        await release();
+      } catch (e) {
+        console.error(
+          `Error occurred whilst attempting to release runner options`,
+          e,
+        );
+      }
     } else {
       throw new Error("Runner is already stopped");
     }
   };
 
+  workerPool.promise.finally(() => {
+    if (running) {
+      stop();
+    }
+  });
+  cron.promise.finally(() => {
+    if (running) {
+      stop();
+    }
+  });
+
   const promise = Promise.all([cron.promise, workerPool.promise]).then(
     () => {
-      /* void */
+      /* noop */
     },
-    (e) => {
+    async (e) => {
       if (running) {
         console.error(`Stopping worker due to an error: ${e}`);
-        stop();
+        await stop();
       } else {
         console.error(`Error occurred, but worker is already stopping: ${e}`);
       }

--- a/website/docs/error-handling.md
+++ b/website/docs/error-handling.md
@@ -46,6 +46,12 @@ ERROR: relation "graphile_worker.migrations" does not exist at character 16
 STATEMENT: select id from "graphile_worker".migrations order by id desc limit 1;
 ```
 
+## Database migration
+
+If a new version of Graphile Worker is ran against the database, and this
+version includes new migrations, then a NOTIFY event will be issued. Graphile
+Worker 0.16+ will LISTEN for this event, and will shut down if it is received.
+
 ## Error codes
 
 - `GWBKM` - Invalid `job_key_mode` value, expected `'replace'`,


### PR DESCRIPTION
## Description

When a new version of Graphile Worker that contains new migrations executes, it is likely unsafe for existing workers to continue to run since they no longer understand the schema. This PR has the new worker announce the migration and existing workers detect this (via a `NOTIFY` event; which is not a 100% reliable means of communication but should be fine for this) and shut down gracefully.

Fixes #175

## Performance impact

Negligible.

## Security impact

If someone can issue `NOTIFY "jobs:migrate";` on the database then they can cause all Graphile Worker instances to shut down gracefully. This is deemed to not be a security vulnerability since Graphile Worker explicitly trusts that only authorized people will be able to trigger notifications on the database.

## Checklist

- [x] My code matches the project's code style and `yarn lint:fix` passes.
- [ ] ~~I've added tests for the new feature, and `yarn test` passes.~~
- [ ] ~~I have detailed the new feature in the relevant documentation.~~
- [x] I have added this feature to 'Pending' in the `RELEASE_NOTES.md` file (if one exists).
- [x] If this is a breaking change I've explained why.

<!-- For some Graphile projects the documentation is the README.md file, for
      others please see https://github.com/graphile/graphile.github.io -->
