### PR TITLE
Refactoring

### DIFF
--- a/__tests__/forbiddenFlags.test.ts
+++ b/__tests__/forbiddenFlags.test.ts
@@ -2,6 +2,7 @@ import {
   makeWorkerUtils,
   runTaskListOnce,
   Task,
+  TaskList,
   WorkerSharedOptions,
 } from "../src/index";
 import {
@@ -24,7 +25,7 @@ test("supports the flags API", () =>
     const utils = await makeWorkerUtils({
       connectionString: TEST_CONNECTION_STRING,
     });
-    await utils.addJob("job1", { a: 1 }, { flags: ["a", "b"] });
+    await utils.addJob("job3", { a: 1 }, { flags: ["a", "b"] });
     await utils.release();
 
     // Assert that it has an entry in jobs / job_queues
@@ -34,7 +35,7 @@ test("supports the flags API", () =>
     expect(jobs[0].flags).toEqual({ a: true, b: true });
 
     const task: Task = jest.fn();
-    const taskList = { task };
+    const taskList: TaskList = { task };
     await runTaskListOnce(options, taskList, pgClient);
   }));
 

--- a/__tests__/helpers.ts
+++ b/__tests__/helpers.ts
@@ -194,11 +194,11 @@ export async function makeSelectionOfJobs(
   pgClient: pg.PoolClient,
 ) {
   const future = new Date(Date.now() + 60 * 60 * 1000);
-  let failedJob: DbJob = await utils.addJob("job1", { a: 1, runAt: future });
-  const regularJob1 = await utils.addJob("job1", { a: 2, runAt: future });
-  let lockedJob: DbJob = await utils.addJob("job1", { a: 3, runAt: future });
-  const regularJob2 = await utils.addJob("job1", { a: 4, runAt: future });
-  const untouchedJob = await utils.addJob("job1", { a: 5, runAt: future });
+  let failedJob: DbJob = await utils.addJob("job3", { a: 1, runAt: future });
+  const regularJob1 = await utils.addJob("job3", { a: 2, runAt: future });
+  let lockedJob: DbJob = await utils.addJob("job3", { a: 3, runAt: future });
+  const regularJob2 = await utils.addJob("job3", { a: 4, runAt: future });
+  const untouchedJob = await utils.addJob("job3", { a: 5, runAt: future });
   ({
     rows: [lockedJob],
   } = await pgClient.query<DbJob>(

--- a/__tests__/workerUtils.addJob.test.ts
+++ b/__tests__/workerUtils.addJob.test.ts
@@ -27,7 +27,7 @@ test("runs a job added through the worker utils", () =>
     const utils = await makeWorkerUtils({
       connectionString: TEST_CONNECTION_STRING,
     });
-    await utils.addJob("job1", { a: 1 });
+    await utils.addJob("job3", { a: 1 });
     await utils.release();
 
     // Assert that it has an entry in jobs / job_queues
@@ -47,10 +47,10 @@ test("supports the jobKey API", () =>
     const utils = await makeWorkerUtils({
       connectionString: TEST_CONNECTION_STRING,
     });
-    await utils.addJob("job1", { a: 1 }, { jobKey: "UNIQUE" });
-    await utils.addJob("job1", { a: 2 }, { jobKey: "UNIQUE" });
-    await utils.addJob("job1", { a: 3 }, { jobKey: "UNIQUE" });
-    await utils.addJob("job1", { a: 4 }, { jobKey: "UNIQUE" });
+    await utils.addJob("job3", { a: 1 }, { jobKey: "UNIQUE" });
+    await utils.addJob("job3", { a: 2 }, { jobKey: "UNIQUE" });
+    await utils.addJob("job3", { a: 3 }, { jobKey: "UNIQUE" });
+    await utils.addJob("job3", { a: 4 }, { jobKey: "UNIQUE" });
     await utils.release();
 
     // Assert that it has an entry in jobs / job_queues
@@ -80,7 +80,7 @@ test("supports the jobKey API with jobKeyMode", () =>
 
     // Job first added in replace mode:
     job = await utils.addJob(
-      "job1",
+      "job3",
       { a: 1 },
       { jobKey: "UNIQUE", runAt: runAt1, jobKeyMode: "replace" },
     );
@@ -90,7 +90,7 @@ test("supports the jobKey API with jobKeyMode", () =>
 
     // Now updated, but preserve run_at
     job = await utils.addJob(
-      "job1",
+      "job3",
       { a: 2 },
       { jobKey: "UNIQUE", runAt: runAt2, jobKeyMode: "preserve_run_at" },
     );
@@ -100,7 +100,7 @@ test("supports the jobKey API with jobKeyMode", () =>
 
     // unsafe_dedupe should take no action other than to bump the revision number
     job = await utils.addJob(
-      "job1",
+      "job3",
       { a: 3 },
       { jobKey: "UNIQUE", runAt: runAt3, jobKeyMode: "unsafe_dedupe" },
     );
@@ -110,7 +110,7 @@ test("supports the jobKey API with jobKeyMode", () =>
 
     // Replace the job one final time
     job = await utils.addJob(
-      "job1",
+      "job3",
       { a: 4 },
       { jobKey: "UNIQUE", runAt: runAt4, jobKeyMode: "replace" },
     );
@@ -137,7 +137,7 @@ test("runs a job added through the addJob shortcut function", () =>
     await reset(pgClient, options);
 
     // Schedule a job
-    await quickAddJob({ connectionString: TEST_CONNECTION_STRING }, "job1", {
+    await quickAddJob({ connectionString: TEST_CONNECTION_STRING }, "job3", {
       a: 1,
     });
 
@@ -162,7 +162,7 @@ test("adding job respects useNodeTime", () =>
     });
     const timeOfAddJob = REFERENCE_TIMESTAMP + 1 * HOUR;
     await setTime(timeOfAddJob);
-    await utils.addJob("job1", { a: 1 });
+    await utils.addJob("job3", { a: 1 });
     await utils.release();
 
     // Assert that it has an entry in jobs / job_queues

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -1,10 +1,10 @@
 import { Pool, PoolClient } from "pg";
 
 import {
+  AddJobFunction,
   Job,
   JobHelpers,
   SharedOptions,
-  TaskSpec,
   WithPgClient,
   WorkerSharedOptions,
 } from "./interfaces";
@@ -14,9 +14,9 @@ import { Logger } from "./logger";
 export function makeAddJob(
   options: WorkerSharedOptions,
   withPgClient: WithPgClient,
-) {
+): AddJobFunction {
   const { escapedWorkerSchema, useNodeTime } = processSharedOptions(options);
-  return (identifier: string, payload: unknown = {}, spec: TaskSpec = {}) => {
+  return (identifier, payload, spec = {}) => {
     return withPgClient(async (pgClient) => {
       const { rows } = await pgClient.query(
         `
@@ -34,7 +34,7 @@ export function makeAddJob(
         `,
         [
           identifier,
-          JSON.stringify(payload),
+          JSON.stringify(payload ?? {}),
           spec.queueName || null,
           // If there's an explicit run at, use that. Otherwise, if we've been
           // told to use Node time, use the current timestamp. Otherwise we'll


### PR DESCRIPTION
No real functional changes; just noticed that `task1` was used in some places with `{id}` payload, and others with `{a}`; figured consistency is better. Also a few other minor tweaks.