### PR TITLE
Make tasks generic

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -8,8 +8,12 @@ LTS and Node 18 is maintainence LTS; previous versions are no longer supported.
 **REMOVES `maxContiguousErrors`**. See #307; it wasn't fit for purpose, so best
 to remove it for now.
 
-**LOTS OF `any` CHANGED TO `unknown`**. In particular, errors in the event
-emitter payloads are now `unknown` rather than `any`, so you might need to cast.
+**TYPESCRIPT**: lots of `any` changed to `unknown`. In particular, errors in the
+event emitter payloads are now `unknown` rather than `any`, so you might need to
+cast.
+
+**TYPESCRIPT**: payload is now marked as required in `addJob` (just set to `{}`
+if your task doesn't need a payload).
 
 Adds the ability to type task payloads and `addJob()` calls (**please** read the
 caveats in the documentation before doing so).

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -11,6 +11,9 @@ to remove it for now.
 **LOTS OF `any` CHANGED TO `unknown`**. In particular, errors in the event
 emitter payloads are now `unknown` rather than `any`, so you might need to cast.
 
+Adds the ability to type task payloads and `addJob()` calls (**please** read the
+caveats in the documentation before doing so).
+
 Adds support for `graphile-config` - configuration can now be read from a
 `graphile.config.ts` (or `.js`, `.cjs`, etc) file.
 

--- a/__tests__/events.test.ts
+++ b/__tests__/events.test.ts
@@ -54,7 +54,7 @@ test("emits the expected events", () =>
       [id: string]: Deferred | undefined;
     } = {};
     try {
-      const job1: Task = jest.fn(({ id }: { id: string }) => {
+      const job1: Task<"job1"> = jest.fn(({ id }) => {
         const jobPromise = deferred();
         if (jobPromises[id]) {
           throw new Error("Job with this id already registered");

--- a/__tests__/getTasks.test.ts
+++ b/__tests__/getTasks.test.ts
@@ -21,11 +21,11 @@ Array [
     const helpers = makeJobHelpers(options, makeMockJob("would you like"), {
       withPgClient: makeWithPgClientFromClient(client),
     });
-    expect(await tasks.wouldyoulike(helpers.job.payload, helpers)).toEqual(
+    expect(await tasks.wouldyoulike!(helpers.job.payload, helpers)).toEqual(
       "some sausages",
     );
     expect(
-      await tasks.wouldyoulike_default(helpers.job.payload, helpers),
+      await tasks.wouldyoulike_default!(helpers.job.payload, helpers),
     ).toEqual("some more sausages");
     await release();
   }));
@@ -47,8 +47,8 @@ Array [
     const helpers = makeJobHelpers(options, makeMockJob("task1"), {
       withPgClient: makeWithPgClientFromClient(client),
     });
-    expect(await tasks.task1(helpers.job.payload, helpers)).toEqual("hi");
-    expect(await tasks.task2(helpers.job.payload, helpers)).toEqual("hello");
+    expect(await tasks.task1!(helpers.job.payload, helpers)).toEqual("hi");
+    expect(await tasks.task2!(helpers.job.payload, helpers)).toEqual("hello");
 
     await release();
   }));
@@ -70,10 +70,10 @@ Array [
     const helpers = makeJobHelpers(options, makeMockJob("t1"), {
       withPgClient: makeWithPgClientFromClient(client),
     });
-    expect(await tasks.t1(helpers.job.payload, helpers)).toEqual(
+    expect(await tasks.t1!(helpers.job.payload, helpers)).toEqual(
       "come with me",
     );
-    expect(await tasks.t2(helpers.job.payload, helpers)).toEqual(
+    expect(await tasks.t2!(helpers.job.payload, helpers)).toEqual(
       "if you want to live",
     );
 

--- a/__tests__/helpers.ts
+++ b/__tests__/helpers.ts
@@ -14,6 +14,15 @@ import {
 } from "../src/interfaces";
 import { migrate } from "../src/migrate";
 
+declare global {
+  namespace GraphileWorker {
+    interface Tasks {
+      job1: { id: string };
+      job2: { id: string };
+    }
+  }
+}
+
 export {
   DAY,
   HOUR,

--- a/__tests__/main.runTaskList.test.ts
+++ b/__tests__/main.runTaskList.test.ts
@@ -30,7 +30,7 @@ test("main will execute jobs as they come up, and exits cleanly", () =>
       [id: string]: Deferred | undefined;
     } = {};
     try {
-      const job1: Task = jest.fn(({ id }: { id: string }) => {
+      const job1: Task<"job1"> = jest.fn(({ id }) => {
         const jobPromise = deferred();
         if (jobPromises[id]) {
           throw new Error("Job with this id already registered");

--- a/__tests__/resetLockedAt.test.ts
+++ b/__tests__/resetLockedAt.test.ts
@@ -43,7 +43,7 @@ where task_id = (select id from ${ESCAPED_GRAPHILE_WORKER_SCHEMA}.tasks where id
 `,
     );
 
-    const job2: Task = jest.fn(({ id }: { id: string }) => {
+    const job2: Task<"job2"> = jest.fn(({ id }) => {
       id;
     });
     const tasks: TaskList = {

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -47,7 +47,7 @@ export type AddJobFunction = <
   /**
    * The payload (typically a JSON object) that will be passed to the task executor.
    */
-  payload?: TIdentifier extends keyof GraphileWorker.Tasks
+  payload: TIdentifier extends keyof GraphileWorker.Tasks
     ? GraphileWorker.Tasks[TIdentifier]
     : unknown,
 

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/ban-types */
 import { EventEmitter } from "events";
 import { Pool, PoolClient, QueryResult, QueryResultRow } from "pg";
 
@@ -179,6 +180,7 @@ export type TaskList = {
     | (string & {})]?: Key extends keyof GraphileWorker.Tasks
     ? Task<Key>
     : // The `any` here is required otherwise declaring something as a `TaskList` can cause issues.
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
       Task<any>;
 };
 

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -5,6 +5,14 @@ import { Release } from "./lib";
 import { Logger } from "./logger";
 import { Signal } from "./signals";
 
+declare global {
+  namespace GraphileWorker {
+    interface Tasks {
+      /* extend this through declaration merging */
+    }
+  }
+}
+
 /*
  * Terminology:
  *
@@ -27,16 +35,20 @@ export type WithPgClient = <T = void>(
  * The `addJob` interface is implemented in many places in the library, all
  * conforming to this.
  */
-export type AddJobFunction = (
+export type AddJobFunction = <
+  TIdentifier extends keyof GraphileWorker.Tasks | (string & {}) = string,
+>(
   /**
    * The name of the task that will be executed for this job.
    */
-  identifier: string,
+  identifier: TIdentifier,
 
   /**
    * The payload (typically a JSON object) that will be passed to the task executor.
    */
-  payload?: unknown,
+  payload?: TIdentifier extends keyof GraphileWorker.Tasks
+    ? GraphileWorker.Tasks[TIdentifier]
+    : unknown,
 
   /**
    * Additional details about how the job should be handled.
@@ -143,21 +155,32 @@ export interface WorkerUtils extends Helpers {
 
 export type PromiseOrDirect<T> = Promise<T> | T;
 
-export type Task = (
-  payload: unknown,
+export type Task<
+  TName extends keyof GraphileWorker.Tasks | (string & {}) = string & {},
+> = (
+  payload: TName extends keyof GraphileWorker.Tasks
+    ? GraphileWorker.Tasks[TName]
+    : unknown,
   helpers: JobHelpers,
 ) => PromiseOrDirect<void | PromiseOrDirect<unknown>[]>;
 
-export function isValidTask(fn: unknown): fn is Task {
+export function isValidTask<T extends string = keyof GraphileWorker.Tasks>(
+  fn: unknown,
+): fn is Task<T> {
   if (typeof fn === "function") {
     return true;
   }
   return false;
 }
 
-export interface TaskList {
-  [name: string]: Task;
-}
+export type TaskList = {
+  [Key in
+    | keyof GraphileWorker.Tasks
+    | (string & {})]?: Key extends keyof GraphileWorker.Tasks
+    ? Task<Key>
+    : // The `any` here is required otherwise declaring something as a `TaskList` can cause issues.
+      Task<any>;
+};
 
 export interface WatchedTaskList {
   tasks: TaskList;

--- a/src/workerUtils.ts
+++ b/src/workerUtils.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/ban-types */
 import { DbJob, TaskSpec, WorkerUtils, WorkerUtilsOptions } from "./interfaces";
 import { getUtilsAndReleasersFromOptions } from "./lib";
 import { migrate } from "./migrate";

--- a/src/workerUtils.ts
+++ b/src/workerUtils.ts
@@ -77,14 +77,14 @@ export async function quickAddJob<
 >(
   options: WorkerUtilsOptions,
   identifier: TIdentifier,
-  payload?: TIdentifier extends keyof GraphileWorker.Tasks
+  payload: TIdentifier extends keyof GraphileWorker.Tasks
     ? GraphileWorker.Tasks[TIdentifier]
     : unknown,
   spec: TaskSpec = {},
 ) {
   const utils = await makeWorkerUtils(options);
   try {
-    return await utils.addJob(identifier, payload, spec);
+    return await utils.addJob<TIdentifier>(identifier, payload, spec);
   } finally {
     await utils.release();
   }

--- a/src/workerUtils.ts
+++ b/src/workerUtils.ts
@@ -71,10 +71,14 @@ export async function makeWorkerUtils(
  * this more than once in your process you should instead create a WorkerUtils
  * instance for efficiency and performance sake.
  */
-export async function quickAddJob(
+export async function quickAddJob<
+  TIdentifier extends keyof GraphileWorker.Tasks | (string & {}) = string,
+>(
   options: WorkerUtilsOptions,
-  identifier: string,
-  payload: unknown = {},
+  identifier: TIdentifier,
+  payload?: TIdentifier extends keyof GraphileWorker.Tasks
+    ? GraphileWorker.Tasks[TIdentifier]
+    : unknown,
   spec: TaskSpec = {},
 ) {
   const utils = await makeWorkerUtils(options);

--- a/website/docs/library/add-job.md
+++ b/website/docs/library/add-job.md
@@ -45,7 +45,7 @@ export type AddJobFunction = (
   /**
    * The payload (typically a JSON object) that will be passed to the task executor.
    */
-  payload?: any,
+  payload: any,
 
   /**
    * Additional details about how the job should be handled.

--- a/website/docs/typescript.md
+++ b/website/docs/typescript.md
@@ -1,0 +1,102 @@
+---
+title: TypeScript
+sidebar_position: 65
+---
+
+Graphile Worker is written in TypeScript. By default, for safety, `payload`s are
+typed as `unknown` since they may have been populated by out of date code, or
+even from other sources. This requires you to add a type guard or similar to
+ensure the `payload` conforms to what you expect. It can be convenient to
+declare the payload types up front to avoid this `unknown`, but doing so might
+be unsafe - please be sure to read the caveats below.
+
+## `GraphileWorker.Tasks`
+
+You can register types for Graphile Worker tasks using the following syntax in a
+shared TypeScript file in your project:
+
+```ts
+declare global {
+  namespace GraphileWorker {
+    interface Tasks {
+      // <name>: <payload type>; e.g.:
+      myTaskIdentifier: { details: "are"; specified: "here" };
+    }
+  }
+}
+```
+
+This should then enable auto-complete and payload type safety for `addJob` and
+`quickAddJob`, and should also allow the payloads of your task functions to be
+inferred when defined like this:
+
+```ts
+const task: Task<"myTaskIdentifier"> = async (payload, helpers) => {
+  const { details, specified } = payload;
+  /* ... */
+};
+```
+
+or like this:
+
+```ts
+const tasks: TaskList = {
+  async myTaskIdentifier(payload, helpers) {
+    const { details, specified } = payload;
+    /* ... */
+  },
+};
+```
+
+:::warning
+
+Using TypeScript types like this can be misleading. Graphile Worker jobs can be
+created in the database directly via the `graphile_worker.add_job()` or
+`.add_jobs()` APIs; and these APIs cannot check that the payloads added conform
+to your TypeScript types. Further, you may modify the payload type of a task in
+a later version of your application, but existing jobs may exist in the database
+using the old format. This can lead to you assuming that something is a number
+when actually it's `null`, resulting in more bugs in your code, so care must be
+taken.
+
+We recommend you use type guards instead.
+
+:::
+
+## Using type guards
+
+To ensure your system is as safe as possible (and guard against old jobs, or
+jobs specified outside of TypeScript's type checking) we recommend that you use
+type guards to assert that your payload is of the expected type.
+
+```ts
+interface MyPayload {
+  username: string;
+}
+
+function assertMyPayload(payload: any): asserts payload is MyPayload {
+  if (
+    typeof payload === "object" &&
+    payload &&
+    typeof payload.username === "string"
+  ) {
+    return;
+  }
+  throw new Error("Invalid payload, expected a MyPayload");
+}
+
+const task: Task = async (payload) => {
+  assertMyPayload(payload);
+  console.log(payload.username);
+};
+```
+
+If this is too manual, you might prefer to use a library such as `runtypes` or
+the many others of a similar ilk. If you're not concerned with the type safety
+of the payload, you can work around it with a couple casts:
+
+```ts
+const task: Task = (inPayload) => {
+  const payload = inPayload as any as MyPayload;
+};
+```


### PR DESCRIPTION
## Description

Fixes #142
Fixes #57
Fixes #150
Fixes #237
Fixes #56

For anyone involved in the above issues/PRs, you may know that I've been extremely hesitant to change the payload type from `unknown` to a concrete user-defined type. The main reason for this is that there are no guarantees that `payload` will actually conform to the runtime type because a) it might have been populated by an older runtime (with different types), or b) it might have been populated by something that doesn't even use TypeScript - e.g. a database trigger. Nonetheless, it has been a common request, and I think people are generally okay with the warnings, and know that if they get burned by these assumptions then that's on them. As such, I've finally made the decision to add generic types.

To do so, I've added a central registry `GraphileWorker.Tasks` which is a map from task name to payload. You can still define tasks that aren't in this map and they will be typed as `unknown`, but for those that are the types will be enforced via `addJob` and `quickAddJob`, and will be available on your task's payload if the task is defined correctly.

```ts
declare global {
  namespace GraphileWorker {
    interface Tasks {
      // <name>: <payload type>; e.g.:
      myTaskIdentifier: { details: "are"; specified: "here" };
    }
  }
}
```

I suspect that there's some issues with these TypeScript types that I haven't considered, so I'm CC-ing people who've been involved in this before in case they have any feedback. Let me know what you think!

cc @keithlayne @jhoch @moltar @elnygren @ncrmro @joelmukuthu @JonParton

## Performance impact

Just types.

## Security impact

Just types.

## Checklist

- [x] My code matches the project's code style and `yarn lint:fix` passes.
- [ ] ~~I've added tests for the new feature, and `yarn test` passes.~~
- [x] I have detailed the new feature in the relevant documentation.
- [x] I have added this feature to 'Pending' in the `RELEASE_NOTES.md` file (if one exists).
- [x] If this is a breaking change I've explained why.