### PR TITLE
Add support for importing ESM files

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [18.x, 20.x]
+        node-version: [20.x]
         postgres-version: [12, 13, 14, 15]
 
     services:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,14 +39,14 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
       - run: yarn --frozen-lockfile
-      - run: yarn jest -i --ci
+      - run: yarn node --experimental-vm-modules node_modules/.bin/jest -i --ci
 
   lint:
     runs-on: ubuntu-latest
 
     strategy:
       matrix:
-        node-version: [18.x]
+        node-version: [20.x]
 
     steps:
       - uses: actions/checkout@v3
@@ -64,7 +64,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [18.x]
+        node-version: [20.x]
         postgres-version: [12]
 
     services:
@@ -89,14 +89,14 @@ jobs:
           node-version: ${{ matrix.node-version }}
       - run: yarn --frozen-lockfile
       # - run: yarn lint # No need to lint altschema
-      - run: yarn jest -i --ci
+      - run: yarn node --experimental-vm-modules node_modules/.bin/jest -i --ci
 
   database_updated:
     runs-on: ubuntu-latest
 
     strategy:
       matrix:
-        node-version: [18.x]
+        node-version: [20.x]
         postgres-version: [12]
 
     services:

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -39,6 +39,9 @@ the database schema.
 
 Events: add more detail to `cron:backfill` event.
 
+Tasks: now use `await import(...)` rather than `require(...)`, so ESM can be
+imported.
+
 ### v0.15.1
 
 Fixes issues with graceful worker shutdowns:

--- a/__tests__/fixtures-esm/blah.js
+++ b/__tests__/fixtures-esm/blah.js
@@ -1,0 +1,1 @@
+export const rand = () => 100 * Math.random();

--- a/__tests__/fixtures-esm/package.json
+++ b/__tests__/fixtures-esm/package.json
@@ -1,0 +1,3 @@
+{
+  "type": "module"
+}

--- a/__tests__/fixtures-esm/tasks/wouldyoulike.js
+++ b/__tests__/fixtures-esm/tasks/wouldyoulike.js
@@ -1,0 +1,5 @@
+import { rand } from "../blah";
+export default (_payload, helpers) => {
+  helpers.logger.debug(rand());
+  return "some sausages";
+};

--- a/__tests__/fixtures-esm/tasks/wouldyoulike_default.js
+++ b/__tests__/fixtures-esm/tasks/wouldyoulike_default.js
@@ -1,0 +1,2 @@
+const defaultCb = () => "some more sausages";
+export { defaultCb as default };

--- a/__tests__/fixtures-esm/tasksFile.js
+++ b/__tests__/fixtures-esm/tasksFile.js
@@ -1,0 +1,2 @@
+export const task1 = () => "hi";
+export const task2 = () => "hello";

--- a/__tests__/fixtures-esm/tasksFile_default.js
+++ b/__tests__/fixtures-esm/tasksFile_default.js
@@ -1,0 +1,2 @@
+export const t1 = () => "come with me";
+export const t2 = () => "if you want to live";

--- a/__tests__/getTasks.test.ts
+++ b/__tests__/getTasks.test.ts
@@ -5,77 +5,156 @@ import { makeMockJob, withPgClient } from "./helpers";
 
 const options: WorkerSharedOptions = {};
 
-test("gets tasks from folder", () =>
-  withPgClient(async (client) => {
-    const { tasks, release } = await getTasks(
-      options,
-      `${__dirname}/fixtures/tasks`,
-    );
-    expect(tasks).toBeTruthy();
-    expect(Object.keys(tasks).sort()).toMatchInlineSnapshot(`
+describe("commonjs", () => {
+  test("gets tasks from folder", () =>
+    withPgClient(async (client) => {
+      const { tasks, release } = await getTasks(
+        options,
+        `${__dirname}/fixtures/tasks`,
+      );
+      expect(tasks).toBeTruthy();
+      expect(Object.keys(tasks).sort()).toMatchInlineSnapshot(`
 Array [
   "wouldyoulike",
   "wouldyoulike_default",
 ]
 `);
-    const helpers = makeJobHelpers(options, makeMockJob("would you like"), {
-      withPgClient: makeWithPgClientFromClient(client),
-    });
-    expect(await tasks.wouldyoulike!(helpers.job.payload, helpers)).toEqual(
-      "some sausages",
-    );
-    expect(
-      await tasks.wouldyoulike_default!(helpers.job.payload, helpers),
-    ).toEqual("some more sausages");
-    await release();
-  }));
+      const helpers = makeJobHelpers(options, makeMockJob("would you like"), {
+        withPgClient: makeWithPgClientFromClient(client),
+      });
+      expect(await tasks.wouldyoulike!(helpers.job.payload, helpers)).toEqual(
+        "some sausages",
+      );
+      expect(
+        await tasks.wouldyoulike_default!(helpers.job.payload, helpers),
+      ).toEqual("some more sausages");
+      await release();
+    }));
 
-test("get tasks from file (vanilla)", () =>
-  withPgClient(async (client) => {
-    const { tasks, release } = await getTasks(
-      options,
-      `${__dirname}/fixtures/tasksFile.js`,
-    );
-    expect(tasks).toBeTruthy();
-    expect(Object.keys(tasks).sort()).toMatchInlineSnapshot(`
+  test("get tasks from file (vanilla)", () =>
+    withPgClient(async (client) => {
+      const { tasks, release } = await getTasks(
+        options,
+        `${__dirname}/fixtures/tasksFile.js`,
+      );
+      expect(tasks).toBeTruthy();
+      expect(Object.keys(tasks).sort()).toMatchInlineSnapshot(`
 Array [
   "task1",
   "task2",
 ]
 `);
 
-    const helpers = makeJobHelpers(options, makeMockJob("task1"), {
-      withPgClient: makeWithPgClientFromClient(client),
-    });
-    expect(await tasks.task1!(helpers.job.payload, helpers)).toEqual("hi");
-    expect(await tasks.task2!(helpers.job.payload, helpers)).toEqual("hello");
+      const helpers = makeJobHelpers(options, makeMockJob("task1"), {
+        withPgClient: makeWithPgClientFromClient(client),
+      });
+      expect(await tasks.task1!(helpers.job.payload, helpers)).toEqual("hi");
+      expect(await tasks.task2!(helpers.job.payload, helpers)).toEqual("hello");
 
-    await release();
-  }));
+      await release();
+    }));
 
-test("get tasks from file (default)", () =>
-  withPgClient(async (client) => {
-    const { tasks, release } = await getTasks(
-      options,
-      `${__dirname}/fixtures/tasksFile_default.js`,
-    );
-    expect(tasks).toBeTruthy();
-    expect(Object.keys(tasks).sort()).toMatchInlineSnapshot(`
+  test("get tasks from file (default)", () =>
+    withPgClient(async (client) => {
+      const { tasks, release } = await getTasks(
+        options,
+        `${__dirname}/fixtures/tasksFile_default.js`,
+      );
+      expect(tasks).toBeTruthy();
+      expect(Object.keys(tasks).sort()).toMatchInlineSnapshot(`
 Array [
   "t1",
   "t2",
 ]
 `);
 
-    const helpers = makeJobHelpers(options, makeMockJob("t1"), {
-      withPgClient: makeWithPgClientFromClient(client),
-    });
-    expect(await tasks.t1!(helpers.job.payload, helpers)).toEqual(
-      "come with me",
-    );
-    expect(await tasks.t2!(helpers.job.payload, helpers)).toEqual(
-      "if you want to live",
-    );
+      const helpers = makeJobHelpers(options, makeMockJob("t1"), {
+        withPgClient: makeWithPgClientFromClient(client),
+      });
+      expect(await tasks.t1!(helpers.job.payload, helpers)).toEqual(
+        "come with me",
+      );
+      expect(await tasks.t2!(helpers.job.payload, helpers)).toEqual(
+        "if you want to live",
+      );
 
-    await release();
-  }));
+      await release();
+    }));
+});
+
+describe("esm", () => {
+  test("gets tasks from folder", () =>
+    withPgClient(async (client) => {
+      const { tasks, release } = await getTasks(
+        options,
+        `${__dirname}/fixtures-esm/tasks`,
+      );
+      expect(tasks).toBeTruthy();
+      expect(Object.keys(tasks).sort()).toMatchInlineSnapshot(`
+Array [
+  "wouldyoulike",
+  "wouldyoulike_default",
+]
+`);
+      const helpers = makeJobHelpers(options, makeMockJob("would you like"), {
+        withPgClient: makeWithPgClientFromClient(client),
+      });
+      expect(await tasks.wouldyoulike!(helpers.job.payload, helpers)).toEqual(
+        "some sausages",
+      );
+      expect(
+        await tasks.wouldyoulike_default!(helpers.job.payload, helpers),
+      ).toEqual("some more sausages");
+      await release();
+    }));
+
+  test("get tasks from file (vanilla)", () =>
+    withPgClient(async (client) => {
+      const { tasks, release } = await getTasks(
+        options,
+        `${__dirname}/fixtures-esm/tasksFile.js`,
+      );
+      expect(tasks).toBeTruthy();
+      expect(Object.keys(tasks).sort()).toMatchInlineSnapshot(`
+Array [
+  "task1",
+  "task2",
+]
+`);
+
+      const helpers = makeJobHelpers(options, makeMockJob("task1"), {
+        withPgClient: makeWithPgClientFromClient(client),
+      });
+      expect(await tasks.task1!(helpers.job.payload, helpers)).toEqual("hi");
+      expect(await tasks.task2!(helpers.job.payload, helpers)).toEqual("hello");
+
+      await release();
+    }));
+
+  test("get tasks from file (default)", () =>
+    withPgClient(async (client) => {
+      const { tasks, release } = await getTasks(
+        options,
+        `${__dirname}/fixtures-esm/tasksFile_default.js`,
+      );
+      expect(tasks).toBeTruthy();
+      expect(Object.keys(tasks).sort()).toMatchInlineSnapshot(`
+Array [
+  "t1",
+  "t2",
+]
+`);
+
+      const helpers = makeJobHelpers(options, makeMockJob("t1"), {
+        withPgClient: makeWithPgClientFromClient(client),
+      });
+      expect(await tasks.t1!(helpers.job.payload, helpers)).toEqual(
+        "come with me",
+      );
+      expect(await tasks.t2!(helpers.job.payload, helpers)).toEqual(
+        "if you want to live",
+      );
+
+      await release();
+    }));
+});

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "lint": "yarn prettier:check && eslint --ext .js,.jsx,.ts,.tsx,.graphql .",
     "lint:fix": "eslint --ext .js,.jsx,.ts,.tsx,.graphql . --fix; prettier --cache --ignore-path .eslintignore --write '**/*.{js,jsx,ts,tsx,graphql,md,json}'",
     "prettier:check": "prettier --cache --ignore-path .eslintignore --check '**/*.{js,jsx,ts,tsx,graphql,md,json}'",
-    "test": "yarn prepack && depcheck && createdb graphile_worker_test || true && psql -X -v GRAPHILE_WORKER_SCHEMA=\"${GRAPHILE_WORKER_SCHEMA:-graphile_worker}\" -v ON_ERROR_STOP=1 -f __tests__/reset-db.sql graphile_worker_test && jest -i",
+    "test": "yarn prepack && depcheck && createdb graphile_worker_test || true && psql -X -v GRAPHILE_WORKER_SCHEMA=\"${GRAPHILE_WORKER_SCHEMA:-graphile_worker}\" -v ON_ERROR_STOP=1 -f __tests__/reset-db.sql graphile_worker_test && node --experimental-vm-modules node_modules/.bin/jest -i",
     "db:dump": "./scripts/dump_db",
     "perfTest": "cd perfTest && node ./run.js",
     "preversion": "grep '^### Pending' RELEASE_NOTES.md && echo \"⚠️ Cannot publish with 'Pending' in RELEASE_NOTES ⚠️\" && exit 1 || true",

--- a/src/getTasks.ts
+++ b/src/getTasks.ts
@@ -39,8 +39,7 @@ async function loadFileIntoTasks(
   filename: string,
   name: string | null = null,
 ) {
-  // eslint-disable-next-line @typescript-eslint/no-var-requires
-  const replacementModule = require(filename);
+  const replacementModule = await import(filename);
 
   if (!replacementModule) {
     throw new Error(`Module '${filename}' doesn't have an export`);

--- a/website/docs/requirements.md
+++ b/website/docs/requirements.md
@@ -10,7 +10,10 @@ support it and may drop support in a minor update. Should you require support
 for an end-of-life version of one of these projects, please get in touch about
 our commercial support options.
 
-[^1]: Might work with older versions, but has not been tested.
+[^1]:
+    Might work with older versions, but has not been tested. Node 18 won't run
+    our jest tests due to segfault, fixed in Node 20.8.1, so CI cannot run
+    against Node 18.
 
 :::note
 


### PR DESCRIPTION
## Description

Fixes #226.

Now we don't have watch mode and we support minimum Node 18, supporting ESM is more straightforward.

## Performance impact

Negligible.

## Security impact

Unknown.

## Checklist

- [x] My code matches the project's code style and `yarn lint:fix` passes.
- [ ] ~~I've added tests for the new feature, and `yarn test` passes.~~
- [ ] ~~I have detailed the new feature in the relevant documentation.~~
- [x] I have added this feature to 'Pending' in the `RELEASE_NOTES.md` file (if one exists).
- [ ] ~~If this is a breaking change I've explained why.~~

