### PR TITLE
Rename tables to make privacy clear

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -5,6 +5,10 @@
 **DROPS SUPPORT FOR NODE <18**. As of 24th October 2023, Node 20 is the active
 LTS and Node 18 is maintainence LTS; previous versions are no longer supported.
 
+**RENAMES** all of the tables `*` to `_private_*` to make it clear that you
+should not rely on their schema being stable. We might change them in a patch
+release. This has always been the case, but the naming makes this clearer.
+
 **REMOVES `maxContiguousErrors`**. See #307; it wasn't fit for purpose, so best
 to remove it for now.
 

--- a/__tests__/cron.test.ts
+++ b/__tests__/cron.test.ts
@@ -45,7 +45,7 @@ test("backfills if identifier already registered (5h)", () =>
     const expectedTime = now - (now % FOUR_HOURS);
     await pgPool.query(
       `
-        insert into ${ESCAPED_GRAPHILE_WORKER_SCHEMA}.known_crontabs (
+        insert into ${ESCAPED_GRAPHILE_WORKER_SCHEMA}._private_known_crontabs as known_crontabs (
           identifier,
           known_since,
           last_execution
@@ -99,7 +99,7 @@ test("backfills if identifier already registered (25h)", () =>
     const expectedTime = now - (now % FOUR_HOURS);
     await pgPool.query(
       `
-        insert into ${ESCAPED_GRAPHILE_WORKER_SCHEMA}.known_crontabs (
+        insert into ${ESCAPED_GRAPHILE_WORKER_SCHEMA}._private_known_crontabs as known_crontabs (
           identifier,
           known_since,
           last_execution

--- a/__tests__/main.runTaskListOnce.test.ts
+++ b/__tests__/main.runTaskListOnce.test.ts
@@ -153,7 +153,13 @@ test("retries job", () =>
 
     // Tell the job to be runnable
     await pgClient.query(
-      `update ${ESCAPED_GRAPHILE_WORKER_SCHEMA}.jobs set run_at = now() where task_id = (select id from ${ESCAPED_GRAPHILE_WORKER_SCHEMA}.tasks where identifier = 'job3')`,
+      `\
+update ${ESCAPED_GRAPHILE_WORKER_SCHEMA}._private_jobs as jobs
+set run_at = now()
+where task_id = (
+  select id from ${ESCAPED_GRAPHILE_WORKER_SCHEMA}._private_tasks as tasks
+  where identifier = 'job3'
+)`,
     );
 
     // Run the job
@@ -209,7 +215,13 @@ test("supports future-scheduled jobs", () =>
 
     // Tell the job to be runnable
     await pgClient.query(
-      `update ${ESCAPED_GRAPHILE_WORKER_SCHEMA}.jobs set run_at = now() where task_id = (select id from ${ESCAPED_GRAPHILE_WORKER_SCHEMA}.tasks where identifier = 'future')`,
+      `\
+update ${ESCAPED_GRAPHILE_WORKER_SCHEMA}._private_jobs as jobs
+set run_at = now()
+where task_id = (
+  select id from ${ESCAPED_GRAPHILE_WORKER_SCHEMA}._private_tasks as tasks
+  where identifier = 'future'
+)`,
     );
 
     // Run the job

--- a/__tests__/migrate.test.ts
+++ b/__tests__/migrate.test.ts
@@ -34,7 +34,7 @@ test("migration installs schema; second migration does no harm", async () => {
     const { rows: migrationRows } = await pgClient.query(
       `select * from ${ESCAPED_GRAPHILE_WORKER_SCHEMA}.migrations`,
     );
-    expect(migrationRows).toHaveLength(15);
+    expect(migrationRows).toHaveLength(16);
     const migration = migrationRows[0];
     expect(migration.id).toEqual(1);
 
@@ -89,7 +89,7 @@ test("aborts if database is more up to date than current worker", async () => {
     await expect(
       migrate(options, pgClient),
     ).rejects.toThrowErrorMatchingInlineSnapshot(
-      `"Database is using Graphile Worker schema revision 999999, but the currently running worker only supports up to revision 15. Please ensure all versions of Graphile Worker you're running are compatible."`,
+      `"Database is using Graphile Worker schema revision 999999, but the currently running worker only supports up to revision 16. Please ensure all versions of Graphile Worker you're running are compatible."`,
     );
   });
 });

--- a/__tests__/resetLockedAt.test.ts
+++ b/__tests__/resetLockedAt.test.ts
@@ -30,7 +30,7 @@ test("main will execute jobs as they come up, and exits cleanly", () =>
     );
     await pgPool.query(
       `\
-update ${ESCAPED_GRAPHILE_WORKER_SCHEMA}.jobs
+update ${ESCAPED_GRAPHILE_WORKER_SCHEMA}._private_jobs as jobs
 set
   locked_by = 'some_worker_id',
   locked_at = now() - (
@@ -39,7 +39,7 @@ set
     else interval '4 hours 1 minute'
     end
   )
-where task_id = (select id from ${ESCAPED_GRAPHILE_WORKER_SCHEMA}.tasks where identifier = 'job1') and payload->>'id' like 'locked_%';
+where task_id = (select id from ${ESCAPED_GRAPHILE_WORKER_SCHEMA}._private_tasks as tasks where identifier = 'job1') and payload->>'id' like 'locked_%';
 `,
     );
 
@@ -78,7 +78,7 @@ where task_id = (select id from ${ESCAPED_GRAPHILE_WORKER_SCHEMA}.tasks where id
     expect(states).toEqual(["started", "success"]);
     await sleep(20);
     const { rows: jobs } = await pgPool.query(
-      `select * from ${ESCAPED_GRAPHILE_WORKER_SCHEMA}.jobs`,
+      `select * from ${ESCAPED_GRAPHILE_WORKER_SCHEMA}._private_jobs as jobs`,
     );
     expect(jobs.length).toEqual(3);
     const unlocked = jobs.find((j) => j.payload.id === "unlocked");

--- a/perfTest/init.js
+++ b/perfTest/init.js
@@ -27,7 +27,7 @@ begin
     )
   );
 
-  update graphile_worker.job_queues
+  update graphile_worker._private_job_queues as job_queues
   set locked_at = now(), locked_by = 'fakelock'
   where queue_name like '${taskIdentifier}%';
 end;

--- a/perfTest/latencyTest.js
+++ b/perfTest/latencyTest.js
@@ -92,7 +92,13 @@ async function forEmptyQueue(pgPool) {
     const {
       rows: [row],
     } = await pgPool.query(
-      `select count(*) from graphile_worker.jobs where task_id = (select id from graphile_worker.tasks where identifier = 'latency')`,
+      `\
+select count(*)
+from graphile_worker._private_jobs as jobs
+where task_id = (
+  select id from graphile_worker._private_tasks as tasks
+  where identifier = 'latency'
+)`,
     );
     remaining = (row && row.count) || 0;
     sleep(2000);

--- a/sql/000016.sql
+++ b/sql/000016.sql
@@ -1,0 +1,267 @@
+alter table :GRAPHILE_WORKER_SCHEMA.jobs rename to _private_jobs;
+alter table :GRAPHILE_WORKER_SCHEMA.job_queues rename to _private_job_queues;
+alter table :GRAPHILE_WORKER_SCHEMA.tasks rename to _private_tasks;
+alter table :GRAPHILE_WORKER_SCHEMA.known_crontabs rename to _private_known_crontabs;
+
+DROP FUNCTION :GRAPHILE_WORKER_SCHEMA.add_job;
+CREATE FUNCTION :GRAPHILE_WORKER_SCHEMA.add_job(identifier text, payload json DEFAULT NULL::json, queue_name text DEFAULT NULL::text, run_at timestamp with time zone DEFAULT NULL::timestamp with time zone, max_attempts integer DEFAULT NULL::integer, job_key text DEFAULT NULL::text, priority integer DEFAULT NULL::integer, flags text[] DEFAULT NULL::text[], job_key_mode text DEFAULT 'replace'::text) RETURNS :GRAPHILE_WORKER_SCHEMA._private_jobs
+    LANGUAGE plpgsql
+    AS $$
+declare
+  v_job :GRAPHILE_WORKER_SCHEMA._private_jobs;
+begin
+  if (job_key is null or job_key_mode is null or job_key_mode in ('replace', 'preserve_run_at')) then
+    select * into v_job
+    from :GRAPHILE_WORKER_SCHEMA.add_jobs(
+      ARRAY[(
+        identifier,
+        payload,
+        queue_name,
+        run_at,
+        max_attempts::smallint,
+        job_key,
+        priority::smallint,
+        flags
+      ):::GRAPHILE_WORKER_SCHEMA.job_spec],
+      (job_key_mode = 'preserve_run_at')
+    )
+    limit 1;
+    return v_job;
+  elsif job_key_mode = 'unsafe_dedupe' then
+    -- Ensure all the tasks exist
+    insert into :GRAPHILE_WORKER_SCHEMA._private_tasks as tasks (identifier)
+    values (add_job.identifier)
+    on conflict do nothing;
+    -- Ensure all the queues exist
+    if add_job.queue_name is not null then
+      insert into :GRAPHILE_WORKER_SCHEMA._private_job_queues as job_queues (queue_name)
+      values (add_job.queue_name)
+      on conflict do nothing;
+    end if;
+    -- Insert job, but if one already exists then do nothing, even if the
+    -- existing job has already started (and thus represents an out-of-date
+    -- world state). This is dangerous because it means that whatever state
+    -- change triggered this add_job may not be acted upon (since it happened
+    -- after the existing job started executing, but no further job is being
+    -- scheduled), but it is useful in very rare circumstances for
+    -- de-duplication. If in doubt, DO NOT USE THIS.
+    insert into :GRAPHILE_WORKER_SCHEMA._private_jobs as jobs (
+      job_queue_id,
+      task_id,
+      payload,
+      run_at,
+      max_attempts,
+      key,
+      priority,
+      flags
+    )
+      select
+        job_queues.id,
+        tasks.id,
+        coalesce(add_job.payload, '{}'::json),
+        coalesce(add_job.run_at, now()),
+        coalesce(add_job.max_attempts::smallint, 25::smallint),
+        add_job.job_key,
+        coalesce(add_job.priority::smallint, 0::smallint),
+        (
+          select jsonb_object_agg(flag, true)
+          from unnest(add_job.flags) as item(flag)
+        )
+      from :GRAPHILE_WORKER_SCHEMA._private_tasks as tasks
+      left join :GRAPHILE_WORKER_SCHEMA._private_job_queues as job_queues
+      on job_queues.queue_name = add_job.queue_name
+      where tasks.identifier = add_job.identifier
+    on conflict (key)
+      -- Bump the updated_at so that there's something to return
+      do update set
+        revision = jobs.revision + 1,
+        updated_at = now()
+      returning *
+      into v_job;
+    return v_job;
+  else
+    raise exception 'Invalid job_key_mode value, expected ''replace'', ''preserve_run_at'' or ''unsafe_dedupe''.' using errcode = 'GWBKM';
+  end if;
+end;
+$$;
+
+DROP FUNCTION :GRAPHILE_WORKER_SCHEMA.add_jobs;
+CREATE FUNCTION :GRAPHILE_WORKER_SCHEMA.add_jobs(specs :GRAPHILE_WORKER_SCHEMA.job_spec[], job_key_preserve_run_at boolean DEFAULT false) RETURNS SETOF :GRAPHILE_WORKER_SCHEMA._private_jobs
+    LANGUAGE plpgsql
+    AS $$
+begin
+  -- Ensure all the tasks exist
+  insert into :GRAPHILE_WORKER_SCHEMA._private_tasks as tasks (identifier)
+  select distinct spec.identifier
+  from unnest(specs) spec
+  on conflict do nothing;
+  -- Ensure all the queues exist
+  insert into :GRAPHILE_WORKER_SCHEMA._private_job_queues as job_queues (queue_name)
+  select distinct spec.queue_name
+  from unnest(specs) spec
+  where spec.queue_name is not null
+  on conflict do nothing;
+  -- Ensure any locked jobs have their key cleared - in the case of locked
+  -- existing job create a new job instead as it must have already started
+  -- executing (i.e. it's world state is out of date, and the fact add_job
+  -- has been called again implies there's new information that needs to be
+  -- acted upon).
+  update :GRAPHILE_WORKER_SCHEMA._private_jobs as jobs
+  set
+    key = null,
+    attempts = jobs.max_attempts,
+    updated_at = now()
+  from unnest(specs) spec
+  where spec.job_key is not null
+  and jobs.key = spec.job_key
+  and is_available is not true;
+  -- TODO: is there a risk that a conflict could occur depending on the
+  -- isolation level?
+  return query insert into :GRAPHILE_WORKER_SCHEMA._private_jobs as jobs (
+    job_queue_id,
+    task_id,
+    payload,
+    run_at,
+    max_attempts,
+    key,
+    priority,
+    flags
+  )
+    select
+      job_queues.id,
+      tasks.id,
+      coalesce(spec.payload, '{}'::json),
+      coalesce(spec.run_at, now()),
+      coalesce(spec.max_attempts, 25),
+      spec.job_key,
+      coalesce(spec.priority, 0),
+      (
+        select jsonb_object_agg(flag, true)
+        from unnest(spec.flags) as item(flag)
+      )
+    from unnest(specs) spec
+    inner join :GRAPHILE_WORKER_SCHEMA._private_tasks as tasks
+    on tasks.identifier = spec.identifier
+    left join :GRAPHILE_WORKER_SCHEMA._private_job_queues as job_queues
+    on job_queues.queue_name = spec.queue_name
+  on conflict (key) do update set
+    job_queue_id = excluded.job_queue_id,
+    task_id = excluded.task_id,
+    payload =
+      case
+      when json_typeof(jobs.payload) = 'array' and json_typeof(excluded.payload) = 'array' then
+        (jobs.payload::jsonb || excluded.payload::jsonb)::json
+      else
+        excluded.payload
+      end,
+    max_attempts = excluded.max_attempts,
+    run_at = (case
+      when job_key_preserve_run_at is true and jobs.attempts = 0 then jobs.run_at
+      else excluded.run_at
+    end),
+    priority = excluded.priority,
+    revision = jobs.revision + 1,
+    flags = excluded.flags,
+    -- always reset error/retry state
+    attempts = 0,
+    last_error = null,
+    updated_at = now()
+  where jobs.locked_at is null
+  returning *;
+end;
+$$;
+
+DROP FUNCTION :GRAPHILE_WORKER_SCHEMA.complete_jobs;
+CREATE FUNCTION :GRAPHILE_WORKER_SCHEMA.complete_jobs(job_ids bigint[]) RETURNS SETOF :GRAPHILE_WORKER_SCHEMA._private_jobs
+    LANGUAGE sql
+    AS $$
+  delete from :GRAPHILE_WORKER_SCHEMA._private_jobs as jobs
+    where id = any(job_ids)
+    and (
+      locked_at is null
+    or
+      locked_at < now() - interval '4 hours'
+    )
+    returning *;
+$$;
+
+DROP FUNCTION :GRAPHILE_WORKER_SCHEMA.force_unlock_workers;
+CREATE FUNCTION :GRAPHILE_WORKER_SCHEMA.force_unlock_workers(worker_ids text[]) RETURNS void
+    LANGUAGE sql
+    AS $$
+update :GRAPHILE_WORKER_SCHEMA._private_jobs as jobs
+set locked_at = null, locked_by = null
+where locked_by = any(worker_ids);
+update :GRAPHILE_WORKER_SCHEMA._private_job_queues as job_queues
+set locked_at = null, locked_by = null
+where locked_by = any(worker_ids);
+$$;
+
+DROP FUNCTION :GRAPHILE_WORKER_SCHEMA.permanently_fail_jobs;
+CREATE FUNCTION :GRAPHILE_WORKER_SCHEMA.permanently_fail_jobs(job_ids bigint[], error_message text DEFAULT NULL::text) RETURNS SETOF :GRAPHILE_WORKER_SCHEMA._private_jobs
+    LANGUAGE sql
+    AS $$
+  update :GRAPHILE_WORKER_SCHEMA._private_jobs as jobs
+    set
+      last_error = coalesce(error_message, 'Manually marked as failed'),
+      attempts = max_attempts,
+      updated_at = now()
+    where id = any(job_ids)
+    and (
+      locked_at is null
+    or
+      locked_at < NOW() - interval '4 hours'
+    )
+    returning *;
+$$;
+
+DROP FUNCTION :GRAPHILE_WORKER_SCHEMA.remove_job;
+CREATE FUNCTION :GRAPHILE_WORKER_SCHEMA.remove_job(job_key text) RETURNS :GRAPHILE_WORKER_SCHEMA._private_jobs
+    LANGUAGE plpgsql STRICT
+    AS $$
+declare
+  v_job :GRAPHILE_WORKER_SCHEMA._private_jobs;
+begin
+  -- Delete job if not locked
+  delete from :GRAPHILE_WORKER_SCHEMA._private_jobs as jobs
+    where key = job_key
+    and (
+      locked_at is null
+    or
+      locked_at < NOW() - interval '4 hours'
+    )
+  returning * into v_job;
+  if not (v_job is null) then
+    return v_job;
+  end if;
+  -- Otherwise prevent job from retrying, and clear the key
+  update :GRAPHILE_WORKER_SCHEMA._private_jobs as jobs
+  set
+    key = null,
+    attempts = jobs.max_attempts,
+    updated_at = now()
+  where key = job_key
+  returning * into v_job;
+  return v_job;
+end;
+$$;
+
+DROP FUNCTION :GRAPHILE_WORKER_SCHEMA.reschedule_jobs;
+CREATE FUNCTION :GRAPHILE_WORKER_SCHEMA.reschedule_jobs(job_ids bigint[], run_at timestamp with time zone DEFAULT NULL::timestamp with time zone, priority integer DEFAULT NULL::integer, attempts integer DEFAULT NULL::integer, max_attempts integer DEFAULT NULL::integer) RETURNS SETOF :GRAPHILE_WORKER_SCHEMA._private_jobs
+    LANGUAGE sql
+    AS $$
+  update :GRAPHILE_WORKER_SCHEMA._private_jobs as jobs
+    set
+      run_at = coalesce(reschedule_jobs.run_at, jobs.run_at),
+      priority = coalesce(reschedule_jobs.priority::smallint, jobs.priority),
+      attempts = coalesce(reschedule_jobs.attempts::smallint, jobs.attempts),
+      max_attempts = coalesce(reschedule_jobs.max_attempts::smallint, jobs.max_attempts),
+      updated_at = now()
+    where id = any(job_ids)
+    and (
+      locked_at is null
+    or
+      locked_at < NOW() - interval '4 hours'
+    )
+    returning *;
+$$;

--- a/src/generated/sql.ts
+++ b/src/generated/sql.ts
@@ -1855,4 +1855,272 @@ set locked_at = null, locked_by = null
 where locked_by = any(worker_ids);
 $$ language sql volatile;
 `,
+  "000016.sql": String.raw`alter table :GRAPHILE_WORKER_SCHEMA.jobs rename to _private_jobs;
+alter table :GRAPHILE_WORKER_SCHEMA.job_queues rename to _private_job_queues;
+alter table :GRAPHILE_WORKER_SCHEMA.tasks rename to _private_tasks;
+alter table :GRAPHILE_WORKER_SCHEMA.known_crontabs rename to _private_known_crontabs;
+
+DROP FUNCTION :GRAPHILE_WORKER_SCHEMA.add_job;
+CREATE FUNCTION :GRAPHILE_WORKER_SCHEMA.add_job(identifier text, payload json DEFAULT NULL::json, queue_name text DEFAULT NULL::text, run_at timestamp with time zone DEFAULT NULL::timestamp with time zone, max_attempts integer DEFAULT NULL::integer, job_key text DEFAULT NULL::text, priority integer DEFAULT NULL::integer, flags text[] DEFAULT NULL::text[], job_key_mode text DEFAULT 'replace'::text) RETURNS :GRAPHILE_WORKER_SCHEMA._private_jobs
+    LANGUAGE plpgsql
+    AS $$
+declare
+  v_job :GRAPHILE_WORKER_SCHEMA._private_jobs;
+begin
+  if (job_key is null or job_key_mode is null or job_key_mode in ('replace', 'preserve_run_at')) then
+    select * into v_job
+    from :GRAPHILE_WORKER_SCHEMA.add_jobs(
+      ARRAY[(
+        identifier,
+        payload,
+        queue_name,
+        run_at,
+        max_attempts::smallint,
+        job_key,
+        priority::smallint,
+        flags
+      ):::GRAPHILE_WORKER_SCHEMA.job_spec],
+      (job_key_mode = 'preserve_run_at')
+    )
+    limit 1;
+    return v_job;
+  elsif job_key_mode = 'unsafe_dedupe' then
+    -- Ensure all the tasks exist
+    insert into :GRAPHILE_WORKER_SCHEMA._private_tasks as tasks (identifier)
+    values (add_job.identifier)
+    on conflict do nothing;
+    -- Ensure all the queues exist
+    if add_job.queue_name is not null then
+      insert into :GRAPHILE_WORKER_SCHEMA._private_job_queues as job_queues (queue_name)
+      values (add_job.queue_name)
+      on conflict do nothing;
+    end if;
+    -- Insert job, but if one already exists then do nothing, even if the
+    -- existing job has already started (and thus represents an out-of-date
+    -- world state). This is dangerous because it means that whatever state
+    -- change triggered this add_job may not be acted upon (since it happened
+    -- after the existing job started executing, but no further job is being
+    -- scheduled), but it is useful in very rare circumstances for
+    -- de-duplication. If in doubt, DO NOT USE THIS.
+    insert into :GRAPHILE_WORKER_SCHEMA._private_jobs as jobs (
+      job_queue_id,
+      task_id,
+      payload,
+      run_at,
+      max_attempts,
+      key,
+      priority,
+      flags
+    )
+      select
+        job_queues.id,
+        tasks.id,
+        coalesce(add_job.payload, '{}'::json),
+        coalesce(add_job.run_at, now()),
+        coalesce(add_job.max_attempts::smallint, 25::smallint),
+        add_job.job_key,
+        coalesce(add_job.priority::smallint, 0::smallint),
+        (
+          select jsonb_object_agg(flag, true)
+          from unnest(add_job.flags) as item(flag)
+        )
+      from :GRAPHILE_WORKER_SCHEMA._private_tasks as tasks
+      left join :GRAPHILE_WORKER_SCHEMA._private_job_queues as job_queues
+      on job_queues.queue_name = add_job.queue_name
+      where tasks.identifier = add_job.identifier
+    on conflict (key)
+      -- Bump the updated_at so that there's something to return
+      do update set
+        revision = jobs.revision + 1,
+        updated_at = now()
+      returning *
+      into v_job;
+    return v_job;
+  else
+    raise exception 'Invalid job_key_mode value, expected ''replace'', ''preserve_run_at'' or ''unsafe_dedupe''.' using errcode = 'GWBKM';
+  end if;
+end;
+$$;
+
+DROP FUNCTION :GRAPHILE_WORKER_SCHEMA.add_jobs;
+CREATE FUNCTION :GRAPHILE_WORKER_SCHEMA.add_jobs(specs :GRAPHILE_WORKER_SCHEMA.job_spec[], job_key_preserve_run_at boolean DEFAULT false) RETURNS SETOF :GRAPHILE_WORKER_SCHEMA._private_jobs
+    LANGUAGE plpgsql
+    AS $$
+begin
+  -- Ensure all the tasks exist
+  insert into :GRAPHILE_WORKER_SCHEMA._private_tasks as tasks (identifier)
+  select distinct spec.identifier
+  from unnest(specs) spec
+  on conflict do nothing;
+  -- Ensure all the queues exist
+  insert into :GRAPHILE_WORKER_SCHEMA._private_job_queues as job_queues (queue_name)
+  select distinct spec.queue_name
+  from unnest(specs) spec
+  where spec.queue_name is not null
+  on conflict do nothing;
+  -- Ensure any locked jobs have their key cleared - in the case of locked
+  -- existing job create a new job instead as it must have already started
+  -- executing (i.e. it's world state is out of date, and the fact add_job
+  -- has been called again implies there's new information that needs to be
+  -- acted upon).
+  update :GRAPHILE_WORKER_SCHEMA._private_jobs as jobs
+  set
+    key = null,
+    attempts = jobs.max_attempts,
+    updated_at = now()
+  from unnest(specs) spec
+  where spec.job_key is not null
+  and jobs.key = spec.job_key
+  and is_available is not true;
+  -- TODO: is there a risk that a conflict could occur depending on the
+  -- isolation level?
+  return query insert into :GRAPHILE_WORKER_SCHEMA._private_jobs as jobs (
+    job_queue_id,
+    task_id,
+    payload,
+    run_at,
+    max_attempts,
+    key,
+    priority,
+    flags
+  )
+    select
+      job_queues.id,
+      tasks.id,
+      coalesce(spec.payload, '{}'::json),
+      coalesce(spec.run_at, now()),
+      coalesce(spec.max_attempts, 25),
+      spec.job_key,
+      coalesce(spec.priority, 0),
+      (
+        select jsonb_object_agg(flag, true)
+        from unnest(spec.flags) as item(flag)
+      )
+    from unnest(specs) spec
+    inner join :GRAPHILE_WORKER_SCHEMA._private_tasks as tasks
+    on tasks.identifier = spec.identifier
+    left join :GRAPHILE_WORKER_SCHEMA._private_job_queues as job_queues
+    on job_queues.queue_name = spec.queue_name
+  on conflict (key) do update set
+    job_queue_id = excluded.job_queue_id,
+    task_id = excluded.task_id,
+    payload =
+      case
+      when json_typeof(jobs.payload) = 'array' and json_typeof(excluded.payload) = 'array' then
+        (jobs.payload::jsonb || excluded.payload::jsonb)::json
+      else
+        excluded.payload
+      end,
+    max_attempts = excluded.max_attempts,
+    run_at = (case
+      when job_key_preserve_run_at is true and jobs.attempts = 0 then jobs.run_at
+      else excluded.run_at
+    end),
+    priority = excluded.priority,
+    revision = jobs.revision + 1,
+    flags = excluded.flags,
+    -- always reset error/retry state
+    attempts = 0,
+    last_error = null,
+    updated_at = now()
+  where jobs.locked_at is null
+  returning *;
+end;
+$$;
+
+DROP FUNCTION :GRAPHILE_WORKER_SCHEMA.complete_jobs;
+CREATE FUNCTION :GRAPHILE_WORKER_SCHEMA.complete_jobs(job_ids bigint[]) RETURNS SETOF :GRAPHILE_WORKER_SCHEMA._private_jobs
+    LANGUAGE sql
+    AS $$
+  delete from :GRAPHILE_WORKER_SCHEMA._private_jobs as jobs
+    where id = any(job_ids)
+    and (
+      locked_at is null
+    or
+      locked_at < now() - interval '4 hours'
+    )
+    returning *;
+$$;
+
+DROP FUNCTION :GRAPHILE_WORKER_SCHEMA.force_unlock_workers;
+CREATE FUNCTION :GRAPHILE_WORKER_SCHEMA.force_unlock_workers(worker_ids text[]) RETURNS void
+    LANGUAGE sql
+    AS $$
+update :GRAPHILE_WORKER_SCHEMA._private_jobs as jobs
+set locked_at = null, locked_by = null
+where locked_by = any(worker_ids);
+update :GRAPHILE_WORKER_SCHEMA._private_job_queues as job_queues
+set locked_at = null, locked_by = null
+where locked_by = any(worker_ids);
+$$;
+
+DROP FUNCTION :GRAPHILE_WORKER_SCHEMA.permanently_fail_jobs;
+CREATE FUNCTION :GRAPHILE_WORKER_SCHEMA.permanently_fail_jobs(job_ids bigint[], error_message text DEFAULT NULL::text) RETURNS SETOF :GRAPHILE_WORKER_SCHEMA._private_jobs
+    LANGUAGE sql
+    AS $$
+  update :GRAPHILE_WORKER_SCHEMA._private_jobs as jobs
+    set
+      last_error = coalesce(error_message, 'Manually marked as failed'),
+      attempts = max_attempts,
+      updated_at = now()
+    where id = any(job_ids)
+    and (
+      locked_at is null
+    or
+      locked_at < NOW() - interval '4 hours'
+    )
+    returning *;
+$$;
+
+DROP FUNCTION :GRAPHILE_WORKER_SCHEMA.remove_job;
+CREATE FUNCTION :GRAPHILE_WORKER_SCHEMA.remove_job(job_key text) RETURNS :GRAPHILE_WORKER_SCHEMA._private_jobs
+    LANGUAGE plpgsql STRICT
+    AS $$
+declare
+  v_job :GRAPHILE_WORKER_SCHEMA._private_jobs;
+begin
+  -- Delete job if not locked
+  delete from :GRAPHILE_WORKER_SCHEMA._private_jobs as jobs
+    where key = job_key
+    and (
+      locked_at is null
+    or
+      locked_at < NOW() - interval '4 hours'
+    )
+  returning * into v_job;
+  if not (v_job is null) then
+    return v_job;
+  end if;
+  -- Otherwise prevent job from retrying, and clear the key
+  update :GRAPHILE_WORKER_SCHEMA._private_jobs as jobs
+  set
+    key = null,
+    attempts = jobs.max_attempts,
+    updated_at = now()
+  where key = job_key
+  returning * into v_job;
+  return v_job;
+end;
+$$;
+
+DROP FUNCTION :GRAPHILE_WORKER_SCHEMA.reschedule_jobs;
+CREATE FUNCTION :GRAPHILE_WORKER_SCHEMA.reschedule_jobs(job_ids bigint[], run_at timestamp with time zone DEFAULT NULL::timestamp with time zone, priority integer DEFAULT NULL::integer, attempts integer DEFAULT NULL::integer, max_attempts integer DEFAULT NULL::integer) RETURNS SETOF :GRAPHILE_WORKER_SCHEMA._private_jobs
+    LANGUAGE sql
+    AS $$
+  update :GRAPHILE_WORKER_SCHEMA._private_jobs as jobs
+    set
+      run_at = coalesce(reschedule_jobs.run_at, jobs.run_at),
+      priority = coalesce(reschedule_jobs.priority::smallint, jobs.priority),
+      attempts = coalesce(reschedule_jobs.attempts::smallint, jobs.attempts),
+      max_attempts = coalesce(reschedule_jobs.max_attempts::smallint, jobs.max_attempts),
+      updated_at = now()
+    where id = any(job_ids)
+    and (
+      locked_at is null
+    or
+      locked_at < NOW() - interval '4 hours'
+    )
+    returning *;
+$$;
+`,
 };

--- a/src/sql/completeJob.ts
+++ b/src/sql/completeJob.ts
@@ -19,11 +19,11 @@ export async function completeJob(
       client.query({
         text: `\
 with j as (
-delete from ${escapedWorkerSchema}.jobs
+delete from ${escapedWorkerSchema}._private_jobs as jobs
 where id = $1::bigint
 returning *
 )
-update ${escapedWorkerSchema}.job_queues
+update ${escapedWorkerSchema}._private_job_queues as job_queues
 set locked_by = null, locked_at = null
 from j
 where job_queues.id = j.job_queue_id and job_queues.locked_by = $2::text;`,
@@ -37,7 +37,7 @@ where job_queues.id = j.job_queue_id and job_queues.locked_by = $2::text;`,
     await withPgClient((client) =>
       client.query({
         text: `\
-delete from ${escapedWorkerSchema}.jobs
+delete from ${escapedWorkerSchema}._private_jobs as jobs
 where id = $1::bigint`,
         values: [job.id],
         name: noPreparedStatements ? undefined : `complete_job/${workerSchema}`,

--- a/src/sql/failJob.ts
+++ b/src/sql/failJob.ts
@@ -21,7 +21,7 @@ export async function failJob(
       client.query({
         text: `\
 with j as (
-update ${escapedWorkerSchema}.jobs
+update ${escapedWorkerSchema}._private_jobs as jobs
 set
 last_error = $2::text,
 run_at = greatest(now(), run_at) + (exp(least(attempts, 10)) * interval '1 second'),
@@ -31,7 +31,7 @@ payload = coalesce($4::json, jobs.payload)
 where id = $1::bigint and locked_by = $3::text
 returning *
 )
-update ${escapedWorkerSchema}.job_queues
+update ${escapedWorkerSchema}._private_job_queues as job_queues
 set locked_by = null, locked_at = null
 from j
 where job_queues.id = j.job_queue_id and job_queues.locked_by = $3::text;`,
@@ -50,7 +50,7 @@ where job_queues.id = j.job_queue_id and job_queues.locked_by = $3::text;`,
     await withPgClient((client) =>
       client.query({
         text: `\
-update ${escapedWorkerSchema}.jobs
+update ${escapedWorkerSchema}._private_jobs as jobs
 set
 last_error = $2::text,
 run_at = greatest(now(), run_at) + (exp(least(attempts, 10)) * interval '1 second'),
@@ -89,7 +89,7 @@ export async function failJobs(
     client.query<DbJob>({
       text: `\
 with j as (
-update ${escapedWorkerSchema}.jobs
+update ${escapedWorkerSchema}._private_jobs as jobs
 set
 last_error = $2::text,
 run_at = greatest(now(), run_at) + (exp(least(attempts, 10)) * interval '1 second'),
@@ -98,7 +98,7 @@ locked_at = null
 where id = any($1::int[]) and locked_by = any($3::text[])
 returning *
 ), queues as (
-update ${escapedWorkerSchema}.job_queues
+update ${escapedWorkerSchema}._private_job_queues as job_queues
 set locked_by = null, locked_at = null
 from j
 where job_queues.id = j.job_queue_id and job_queues.locked_by = any($3::text[])

--- a/src/sql/resetLockedAt.ts
+++ b/src/sql/resetLockedAt.ts
@@ -18,11 +18,11 @@ export async function resetLockedAt(
     client.query({
       text: `\
 with j as (
-update ${escapedWorkerSchema}.jobs
+update ${escapedWorkerSchema}._private_jobs as jobs
 set locked_at = null, locked_by = null, run_at = greatest(run_at, now())
 where locked_at < ${now} - interval '4 hours'
 )
-update ${escapedWorkerSchema}.job_queues
+update ${escapedWorkerSchema}._private_job_queues as job_queues
 set locked_at = null, locked_by = null
 where locked_at < ${now} - interval '4 hours'`,
       values: useNodeTime ? [new Date().toISOString()] : [],

--- a/src/taskIdentifiers.ts
+++ b/src/taskIdentifiers.ts
@@ -43,11 +43,11 @@ export function getTaskDetails(
     cache.lastDigest = (async () => {
       const { rows } = await withPgClient(async (client) => {
         await client.query({
-          text: `insert into ${escapedWorkerSchema}.tasks (identifier) select unnest($1::text[]) on conflict do nothing`,
+          text: `insert into ${escapedWorkerSchema}._private_tasks as tasks (identifier) select unnest($1::text[]) on conflict do nothing`,
           values: [supportedTaskNames],
         });
         return client.query<{ id: number; identifier: string }>({
-          text: `select id, identifier from ${escapedWorkerSchema}.tasks where identifier = any($1::text[])`,
+          text: `select id, identifier from ${escapedWorkerSchema}._private_tasks as tasks where identifier = any($1::text[])`,
           values: [supportedTaskNames],
         });
       });

--- a/website/docs/glossary.md
+++ b/website/docs/glossary.md
@@ -38,9 +38,8 @@ export const send_email: Task = async (payload, helpers) => {
 
 ## Job
 
-A record in the `graphile_worker.jobs` table which represents a single
-&ldquo;job to be done&rdquo;: which Task to execute and what parameters
-(Payload) to execute it with. Also stores additional details such as how many
+A single &ldquo;job to be done&rdquo;: which Task to execute and what parameters
+(Payload) to execute it with. Also contains additional details such as how many
 attempts it has had so far, what the max attempts are, when it will be attempted
 next, etc. Created via the [JS `addJob()`](/docs/library/add-job) or
 [SQL `graphile_worker.add_job()`](/docs/sql-add-job) function.

--- a/website/docs/schema.md
+++ b/website/docs/schema.md
@@ -50,10 +50,12 @@ store additional details.
    `graphile_worker.add_job(...)` under the hood
 2. In your function, insert details of the job into your own "shadow" table
 3. If you want, add a reference from your "shadow" table to the
-   `graphile_worker.jobs` table but be sure to add `ON DELETE CASCADE` (to
-   delete the row) or `ON DELETE SET NULL` (to nullify the job id column). Note
-   that doing this has performance overhead for the queue, so you should be very
-   certain that you need it before doing it.
+   `graphile_worker._private_jobs` table but be sure to add `ON DELETE CASCADE`
+   (to delete the row) or `ON DELETE SET NULL` (to nullify the job id column).
+   Note that doing this has performance overhead for the queue, so you should be
+   very certain that you need it before doing it. Also this is a private table
+   so its schema is likely to change, but you're only referencing the primary
+   key here so it should be fine.
 4. Optionally, add the id of this "shadow" record into the job payload (before
    calling `graphile_worker.add_job(...)`); then you can update this "shadow"
    row from your task code. This is particularly useful to keep the end user


### PR DESCRIPTION
## Description

Renames all tables to `_private_*` to make it clear that users should not rely on their shapes.

The tables were already private interfaces so this is not technically a breaking change; however it's likely that a small proportion of users were reading from these tables so we'll count it as one anyway.

## Performance impact

Negligible (slightly longer table names, using aliases in SQL).

## Security impact

None known.

## Checklist

- [x] My code matches the project's code style and `yarn lint:fix` passes.
- [x] I've added tests for the new feature, and `yarn test` passes.
- [x] I have detailed the new feature in the relevant documentation.
- [x] I have added this feature to 'Pending' in the `RELEASE_NOTES.md` file (if one exists).
- [x] If this is a breaking change I've explained why.

<!-- For some Graphile projects the documentation is the README.md file, for
      others please see https://github.com/graphile/graphile.github.io -->
