### PR TITLE
Add a 'jobs' view that people can select from

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -9,6 +9,9 @@ LTS and Node 18 is maintainence LTS; previous versions are no longer supported.
 should not rely on their schema being stable. We might change them in a patch
 release. This has always been the case, but the naming makes this clearer.
 
+**ADDS** `graphile_worker.jobs` view as a public interface to view details of
+jobs. NOTE: this interface DELIBERATELY excludes the `payload` field.
+
 **REMOVES `maxContiguousErrors`**. See #307; it wasn't fit for purpose, so best
 to remove it for now.
 

--- a/__tests__/helpers.ts
+++ b/__tests__/helpers.ts
@@ -202,6 +202,7 @@ export function makeMockJob(taskIdentifier: string): Job {
     revision: 0,
     key: null,
     flags: null,
+    is_available: true,
   };
 }
 
@@ -210,23 +211,25 @@ export async function makeSelectionOfJobs(
   pgClient: pg.PoolClient,
 ) {
   const future = new Date(Date.now() + 60 * 60 * 1000);
-  let failedJob: DbJob = await utils.addJob("job3", { a: 1, runAt: future });
+  const failedJob: DbJob = await utils.addJob("job3", { a: 1, runAt: future });
   const regularJob1 = await utils.addJob("job3", { a: 2, runAt: future });
-  let lockedJob: DbJob = await utils.addJob("job3", { a: 3, runAt: future });
+  const lockedJob: DbJob = await utils.addJob("job3", { a: 3, runAt: future });
   const regularJob2 = await utils.addJob("job3", { a: 4, runAt: future });
   const untouchedJob = await utils.addJob("job3", { a: 5, runAt: future });
-  ({
-    rows: [lockedJob],
+  const {
+    rows: [lockedJobUpdate],
   } = await pgClient.query<DbJob>(
     `update ${ESCAPED_GRAPHILE_WORKER_SCHEMA}._private_jobs as jobs set locked_by = 'test', locked_at = now() where id = $1 returning *`,
     [lockedJob.id],
-  ));
-  ({
-    rows: [failedJob],
+  );
+  Object.assign(lockedJob, lockedJobUpdate);
+  const {
+    rows: [failedJobUpdate],
   } = await pgClient.query<DbJob>(
     `update ${ESCAPED_GRAPHILE_WORKER_SCHEMA}._private_jobs as jobs set attempts = max_attempts, last_error = 'Failed forever' where id = $1 returning *`,
     [failedJob.id],
-  ));
+  );
+  Object.assign(failedJob, failedJobUpdate);
 
   return {
     failedJob,

--- a/__tests__/jobsView.test.ts
+++ b/__tests__/jobsView.test.ts
@@ -1,0 +1,53 @@
+import { Job, WorkerSharedOptions, makeWorkerUtils } from "../src";
+import {
+  makeSelectionOfJobs,
+  reset,
+  withPgClient,
+  TEST_CONNECTION_STRING,
+  ESCAPED_GRAPHILE_WORKER_SCHEMA,
+} from "./helpers";
+
+const options: WorkerSharedOptions = {};
+
+test("jobs view renders jobs", () =>
+  withPgClient(async (pgClient) => {
+    await reset(pgClient, options);
+
+    const utils = await makeWorkerUtils({
+      connectionString: TEST_CONNECTION_STRING,
+    });
+    const jobs = Object.values(
+      await makeSelectionOfJobs(utils, pgClient),
+    ) as Job[];
+
+    const { rows: jobsFromView } = await pgClient.query(
+      `select * from ${ESCAPED_GRAPHILE_WORKER_SCHEMA}.jobs order by id asc`,
+    );
+    const queueNames: Record<number, string> = {};
+    const { rows: queues } = await pgClient.query<{
+      id: number;
+      queue_name: string;
+    }>(
+      `select id, queue_name from ${ESCAPED_GRAPHILE_WORKER_SCHEMA}._private_job_queues`,
+    );
+    for (const queue of queues) {
+      queueNames[queue.id] = queue.queue_name;
+    }
+
+    const l = jobs.length;
+    expect(l).toBeGreaterThan(0);
+    expect(jobsFromView).toHaveLength(l);
+    for (let i = 0; i < l; i++) {
+      const job = jobs[i];
+      const jobFromView = jobsFromView[i];
+      const { payload, is_available, job_queue_id, task_id, ...jobRest } = job;
+      const { queue_name, ...jobFromViewRest } = jobFromView;
+      expect(jobFromViewRest).toEqual(jobRest);
+      if (job_queue_id == null) {
+        expect(queue_name).toBeNull();
+      } else {
+        expect(queue_name).toEqual(queueNames[job_queue_id]);
+      }
+    }
+    await utils.release();
+  }));

--- a/__tests__/jobsView.test.ts
+++ b/__tests__/jobsView.test.ts
@@ -1,10 +1,10 @@
-import { Job, WorkerSharedOptions, makeWorkerUtils } from "../src";
+import { Job, makeWorkerUtils, WorkerSharedOptions } from "../src";
 import {
+  ESCAPED_GRAPHILE_WORKER_SCHEMA,
   makeSelectionOfJobs,
   reset,
-  withPgClient,
   TEST_CONNECTION_STRING,
-  ESCAPED_GRAPHILE_WORKER_SCHEMA,
+  withPgClient,
 } from "./helpers";
 
 const options: WorkerSharedOptions = {};

--- a/__tests__/migrate.test.ts
+++ b/__tests__/migrate.test.ts
@@ -34,7 +34,7 @@ test("migration installs schema; second migration does no harm", async () => {
     const { rows: migrationRows } = await pgClient.query(
       `select * from ${ESCAPED_GRAPHILE_WORKER_SCHEMA}.migrations`,
     );
-    expect(migrationRows).toHaveLength(16);
+    expect(migrationRows).toHaveLength(17);
     const migration = migrationRows[0];
     expect(migration.id).toEqual(1);
 
@@ -89,7 +89,7 @@ test("aborts if database is more up to date than current worker", async () => {
     await expect(
       migrate(options, pgClient),
     ).rejects.toThrowErrorMatchingInlineSnapshot(
-      `"Database is using Graphile Worker schema revision 999999, but the currently running worker only supports up to revision 16. Please ensure all versions of Graphile Worker you're running are compatible."`,
+      `"Database is using Graphile Worker schema revision 999999, but the currently running worker only supports up to revision 17. Please ensure all versions of Graphile Worker you're running are compatible."`,
     );
   });
 });

--- a/__tests__/schema.sql
+++ b/__tests__/schema.sql
@@ -314,6 +314,25 @@ ALTER TABLE graphile_worker._private_job_queues ALTER COLUMN id ADD GENERATED AL
     NO MAXVALUE
     CACHE 1
 );
+CREATE VIEW graphile_worker.jobs AS
+ SELECT jobs.id,
+    job_queues.queue_name,
+    tasks.identifier AS task_identifier,
+    jobs.priority,
+    jobs.run_at,
+    jobs.attempts,
+    jobs.max_attempts,
+    jobs.last_error,
+    jobs.created_at,
+    jobs.updated_at,
+    jobs.key,
+    jobs.locked_at,
+    jobs.locked_by,
+    jobs.revision,
+    jobs.flags
+   FROM ((graphile_worker._private_jobs jobs
+     JOIN graphile_worker._private_tasks tasks ON ((tasks.id = jobs.task_id)))
+     LEFT JOIN graphile_worker._private_job_queues job_queues ON ((job_queues.id = jobs.job_queue_id)));
 ALTER TABLE graphile_worker._private_jobs ALTER COLUMN id ADD GENERATED ALWAYS AS IDENTITY (
     SEQUENCE NAME graphile_worker.jobs_id_seq1
     START WITH 1

--- a/sql/000017.sql
+++ b/sql/000017.sql
@@ -1,0 +1,23 @@
+create view :GRAPHILE_WORKER_SCHEMA.jobs as (
+  select
+    jobs.id,
+    job_queues.queue_name,
+    tasks.identifier as task_identifier,
+    jobs.priority,
+    jobs.run_at,
+    jobs.attempts,
+    jobs.max_attempts,
+    jobs.last_error,
+    jobs.created_at,
+    jobs.updated_at,
+    jobs.key,
+    jobs.locked_at,
+    jobs.locked_by,
+    jobs.revision,
+    jobs.flags
+  from :GRAPHILE_WORKER_SCHEMA._private_jobs as jobs
+  inner join :GRAPHILE_WORKER_SCHEMA._private_tasks as tasks
+  on tasks.id = jobs.task_id
+  left join :GRAPHILE_WORKER_SCHEMA._private_job_queues as job_queues
+  on job_queues.id = jobs.job_queue_id
+);

--- a/src/generated/sql.ts
+++ b/src/generated/sql.ts
@@ -2123,4 +2123,28 @@ CREATE FUNCTION :GRAPHILE_WORKER_SCHEMA.reschedule_jobs(job_ids bigint[], run_at
     returning *;
 $$;
 `,
+  "000017.sql": String.raw`create view :GRAPHILE_WORKER_SCHEMA.jobs as (
+  select
+    jobs.id,
+    job_queues.queue_name,
+    tasks.identifier as task_identifier,
+    jobs.priority,
+    jobs.run_at,
+    jobs.attempts,
+    jobs.max_attempts,
+    jobs.last_error,
+    jobs.created_at,
+    jobs.updated_at,
+    jobs.key,
+    jobs.locked_at,
+    jobs.locked_by,
+    jobs.revision,
+    jobs.flags
+  from :GRAPHILE_WORKER_SCHEMA._private_jobs as jobs
+  inner join :GRAPHILE_WORKER_SCHEMA._private_tasks as tasks
+  on tasks.id = jobs.task_id
+  left join :GRAPHILE_WORKER_SCHEMA._private_job_queues as job_queues
+  on job_queues.id = jobs.job_queue_id
+);
+`,
 };

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -358,6 +358,7 @@ export interface DbJob {
   locked_at: Date | null;
   locked_by: string | null;
   flags: { [flag: string]: true } | null;
+  is_available: boolean;
 }
 
 export interface Job extends DbJob {

--- a/website/docs/jobs-view.md
+++ b/website/docs/jobs-view.md
@@ -1,0 +1,67 @@
+---
+title: "The 'jobs' view"
+sidebar_position: 105
+---
+
+The private tables that jobs are actually stored into are unstable: we may
+change them in a patch release, so you should not use them. As of Graphile
+Worker 0.16, the `graphile_worker.jobs` view exists as a stable interface to let
+you see details of enqueued jobs. The `jobs` view may gain additional columns
+over time, but any column deletions or type changes will require a semver major
+release of Graphile Worker.
+
+## Performance considerations
+
+:::warning
+
+You should not read from the `jobs` view frequently; any reading from Graphile
+Worker's tables can cause a performance impact on the running workers, and doing
+this too often could cause major performance degradation for you - especially if
+you access many rows, or your read does not use an index.
+
+:::
+
+When reading from the `jobs` view, it's recommended that you only select the
+columns you truly need, and that you apply efficient filters to ensure that
+Postgres looks at the fewest number of jobs possible.
+
+:::warning
+
+Do not read from the `jobs` view from within a transaction; this could cause
+performance issues!
+
+:::
+
+## Columns
+
+- `id` - the primary key of the job
+- `queue_name` - the name of the queue (if any) this job was added to
+- `task_identifier` - the identifier of the task this job wants to execute
+- `priority` - the "priority" (really the "nice") of the job; a numerically
+  lower (including negative) value indicates the job should execute before tasks
+  with a numerically higher value
+- `run_at` - when the job is scheduled to run
+- `attempts` - how many times we've attempted to execute this job
+- `max_attempts` - the maximum number of times we'll attempt this job
+- `last_error` - if an error occurred the last time this job was executed, what
+  the error was
+- `created_at` - when the job was inserted into the database
+- `updated_at` - when the job was last updated
+- `key` - the `job_key` of the job, if any
+- `locked_at` - when the job was locked, if locked
+- `locked_by` - the worker id that the job was locked by, if locked
+- `revision` - the revision number of the job, bumped each time the record is
+  updated
+- `flags` - the [forbidden flags](/docs/forbidden-flags) associated with this
+  job
+
+:::info
+
+The job `payload` is deliberately not included in the `jobs` view to avoid
+people from performing expensive filtering using it. If you need to see the
+payload of a job, you should use a [tracking table](/docs/schema#tracking-jobs)
+instead. If you need it for debugging then you can read it from the private
+tables, just be careful, and don't write scripts to do it for you since it might
+change in a patch release.
+
+:::


### PR DESCRIPTION
## Description

Adds a public `graphile_worker.jobs` view that can be selected from. It is not recommended to use this since it has performance overhead, but it's better to use it than to read from the underlying tables.

## Performance impact

Should not have any impact unless the view is used. We recommend that you only use the view when essential, and that you don't poll it frequently.

## Security impact

Since it's a view it does bypass the row-level security policies on the underlying tables, but the `payload` has been removed so this is unlikely to cause a significant security issue. We aren't using security barrier because this would require us to bump the minimum supported version of Postgres. We do not `GRANT` any access to this view, so most roles should get permission denied errors when they attempt to select from it, depending on the default privileges your database is configured with.

## Checklist

- [x] My code matches the project's code style and `yarn lint:fix` passes.
- [x] I've added tests for the new feature, and `yarn test` passes.
- [x] I have detailed the new feature in the relevant documentation.
- [x] I have added this feature to 'Pending' in the `RELEASE_NOTES.md` file (if one exists).
- [x] If this is a breaking change I've explained why.

<!-- For some Graphile projects the documentation is the README.md file, for
      others please see https://github.com/graphile/graphile.github.io -->
