### PR TITLE
fix `docker-compose up -d`

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -12,6 +12,7 @@ RUN yarn install --frozen-lockfile && yarn cache clean
 COPY ./__tests__ ./__tests__
 COPY ./sql ./sql
 COPY ./src  ./src
+COPY ./scripts ./scripts
 COPY ./perfTest  ./perfTest
 COPY ./tsconfig.json ./
 COPY ./jest.config.js ./


### PR DESCRIPTION
## Description
fixes `docker-compose up -d`  by adding `./scripts` to dev container so prepack can build sql artifacts
```
 => ERROR [app 12/12] RUN yarn prepack                                                                                                  1.0s 
------
 > [app 12/12] RUN yarn prepack:
0.397 yarn run v1.22.19
0.441 $ rm -Rf dist && npm run build:sql && tsc && chmod +x dist/cli.js
0.871
0.871 > graphile-worker@0.15.1 build:sql
0.871 > node ./scripts/buildSqlModule.mjs
0.871
0.912 node:internal/modules/cjs/loader:1080
0.912   throw err;
0.912   ^
0.912
0.912 Error: Cannot find module '/app/scripts/buildSqlModule.mjs'
0.912     at Module._resolveFilename (node:internal/modules/cjs/loader:1077:15)
```
## Performance impact

-

## Security impact

-

## Checklist

<!-- If this PR is work in progress, please open it as a "Draft PR". -->
<!-- To tick a checkbox, change it from `[ ]` to `[x]` -->

- [x] My code matches the project's code style and `yarn lint:fix` passes.
- [ ] I've added tests for the new feature, and `yarn test` passes.
- [ ] I have detailed the new feature in the relevant documentation.
- [ ] I have added this feature to 'Pending' in the `RELEASE_NOTES.md` file (if one exists).
- [ ] If this is a breaking change I've explained why.

<!-- For some Graphile projects the documentation is the README.md file, for
      others please see https://github.com/graphile/graphile.github.io -->
