### PR TITLE
Reduce calls to processSharedOptions by passing pre-processed values more consistently

### DIFF
--- a/__tests__/getTasks.test.ts
+++ b/__tests__/getTasks.test.ts
@@ -8,7 +8,7 @@ const options: WorkerSharedOptions = {};
 describe("commonjs", () => {
   test("gets tasks from folder", () =>
     withPgClient(async (client) => {
-      const { tasks, release } = await getTasks(
+      const { tasks, release, compiledSharedOptions } = await getTasks(
         options,
         `${__dirname}/fixtures/tasks`,
       );
@@ -19,10 +19,14 @@ Array [
   "wouldyoulike_default",
 ]
 `);
-      const helpers = makeJobHelpers(options, makeMockJob("would you like"), {
-        withPgClient: makeWithPgClientFromClient(client),
-        abortSignal: undefined,
-      });
+      const helpers = makeJobHelpers(
+        compiledSharedOptions,
+        makeMockJob("would you like"),
+        {
+          withPgClient: makeWithPgClientFromClient(client),
+          abortSignal: undefined,
+        },
+      );
       expect(await tasks.wouldyoulike!(helpers.job.payload, helpers)).toEqual(
         "some sausages",
       );
@@ -34,7 +38,7 @@ Array [
 
   test("get tasks from file (vanilla)", () =>
     withPgClient(async (client) => {
-      const { tasks, release } = await getTasks(
+      const { tasks, release, compiledSharedOptions } = await getTasks(
         options,
         `${__dirname}/fixtures/tasksFile.js`,
       );
@@ -46,10 +50,14 @@ Array [
 ]
 `);
 
-      const helpers = makeJobHelpers(options, makeMockJob("task1"), {
-        withPgClient: makeWithPgClientFromClient(client),
-        abortSignal: undefined,
-      });
+      const helpers = makeJobHelpers(
+        compiledSharedOptions,
+        makeMockJob("task1"),
+        {
+          withPgClient: makeWithPgClientFromClient(client),
+          abortSignal: undefined,
+        },
+      );
       expect(await tasks.task1!(helpers.job.payload, helpers)).toEqual("hi");
       expect(await tasks.task2!(helpers.job.payload, helpers)).toEqual("hello");
 
@@ -58,7 +66,7 @@ Array [
 
   test("get tasks from file (default)", () =>
     withPgClient(async (client) => {
-      const { tasks, release } = await getTasks(
+      const { tasks, release, compiledSharedOptions } = await getTasks(
         options,
         `${__dirname}/fixtures/tasksFile_default.js`,
       );
@@ -70,7 +78,7 @@ Array [
 ]
 `);
 
-      const helpers = makeJobHelpers(options, makeMockJob("t1"), {
+      const helpers = makeJobHelpers(compiledSharedOptions, makeMockJob("t1"), {
         withPgClient: makeWithPgClientFromClient(client),
         abortSignal: undefined,
       });
@@ -88,7 +96,7 @@ Array [
 describe("esm", () => {
   test("gets tasks from folder", () =>
     withPgClient(async (client) => {
-      const { tasks, release } = await getTasks(
+      const { tasks, release, compiledSharedOptions } = await getTasks(
         options,
         `${__dirname}/fixtures-esm/tasks`,
       );
@@ -99,10 +107,14 @@ Array [
   "wouldyoulike_default",
 ]
 `);
-      const helpers = makeJobHelpers(options, makeMockJob("would you like"), {
-        withPgClient: makeWithPgClientFromClient(client),
-        abortSignal: undefined,
-      });
+      const helpers = makeJobHelpers(
+        compiledSharedOptions,
+        makeMockJob("would you like"),
+        {
+          withPgClient: makeWithPgClientFromClient(client),
+          abortSignal: undefined,
+        },
+      );
       expect(await tasks.wouldyoulike!(helpers.job.payload, helpers)).toEqual(
         "some sausages",
       );
@@ -114,7 +126,7 @@ Array [
 
   test("get tasks from file (vanilla)", () =>
     withPgClient(async (client) => {
-      const { tasks, release } = await getTasks(
+      const { tasks, release, compiledSharedOptions } = await getTasks(
         options,
         `${__dirname}/fixtures-esm/tasksFile.js`,
       );
@@ -126,10 +138,14 @@ Array [
 ]
 `);
 
-      const helpers = makeJobHelpers(options, makeMockJob("task1"), {
-        withPgClient: makeWithPgClientFromClient(client),
-        abortSignal: undefined,
-      });
+      const helpers = makeJobHelpers(
+        compiledSharedOptions,
+        makeMockJob("task1"),
+        {
+          withPgClient: makeWithPgClientFromClient(client),
+          abortSignal: undefined,
+        },
+      );
       expect(await tasks.task1!(helpers.job.payload, helpers)).toEqual("hi");
       expect(await tasks.task2!(helpers.job.payload, helpers)).toEqual("hello");
 
@@ -138,7 +154,7 @@ Array [
 
   test("get tasks from file (default)", () =>
     withPgClient(async (client) => {
-      const { tasks, release } = await getTasks(
+      const { tasks, release, compiledSharedOptions } = await getTasks(
         options,
         `${__dirname}/fixtures-esm/tasksFile_default.js`,
       );
@@ -150,7 +166,7 @@ Array [
 ]
 `);
 
-      const helpers = makeJobHelpers(options, makeMockJob("t1"), {
+      const helpers = makeJobHelpers(compiledSharedOptions, makeMockJob("t1"), {
         withPgClient: makeWithPgClientFromClient(client),
         abortSignal: undefined,
       });

--- a/__tests__/helpers.ts
+++ b/__tests__/helpers.ts
@@ -12,6 +12,7 @@ import {
   WorkerPoolOptions,
   WorkerUtils,
 } from "../src/interfaces";
+import { processSharedOptions } from "../src/lib";
 import { _allWorkerPools } from "../src/main";
 import { migrate } from "../src/migrate";
 
@@ -111,12 +112,13 @@ export async function reset(
   await pgPoolOrClient.query(
     `drop schema if exists ${ESCAPED_GRAPHILE_WORKER_SCHEMA} cascade;`,
   );
+  const compiledSharedOptions = processSharedOptions(options);
   if (isPoolClient(pgPoolOrClient)) {
-    await migrate(options, pgPoolOrClient);
+    await migrate(compiledSharedOptions, pgPoolOrClient);
   } else {
     const client = await pgPoolOrClient.connect();
     try {
-      await migrate(options, client);
+      await migrate(compiledSharedOptions, client);
     } finally {
       client.release();
     }

--- a/src/getTasks.ts
+++ b/src/getTasks.ts
@@ -136,6 +136,7 @@ export default async function getTasks(
   let released = false;
   return {
     tasks,
+    compiledSharedOptions,
     release: () => {
       if (released) {
         return;

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -1,7 +1,7 @@
 import { Pool, PoolClient } from "pg";
 
 import { AddJobFunction, Job, JobHelpers, WithPgClient } from "./interfaces";
-import { CompiledSharedOptions, processSharedOptions } from "./lib";
+import { CompiledSharedOptions } from "./lib";
 import { Logger } from "./logger";
 
 export function makeAddJob(

--- a/src/index.ts
+++ b/src/index.ts
@@ -138,7 +138,7 @@ declare global {
       /**
        * Called when Graphile Worker starts up.
        */
-      init(): PromiseOrDirect<void>;
+      init(): void;
 
       /**
        * Called before migrating the DB.

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -630,6 +630,9 @@ export interface RunOnceOptions extends SharedOptions {
    * handle graceful shutdown of the worker if the process receives a signal.
    */
   noHandleSignals?: boolean;
+
+  /** Single worker only! */
+  concurrency?: 1;
 }
 
 /**

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -9,7 +9,7 @@ import type {
   QueryResultRow,
 } from "pg";
 
-import type { Release } from "./lib";
+import type { CompiledSharedOptions, Release } from "./lib";
 import type { Logger } from "./logger";
 import type { Signal } from "./signals";
 
@@ -200,6 +200,8 @@ export type TaskList = {
 export interface WatchedTaskList {
   tasks: TaskList;
   release: () => void;
+  /** @internal */
+  compiledSharedOptions: CompiledSharedOptions;
 }
 
 export interface WatchedCronItems {

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -263,7 +263,7 @@ interface ProcessOptionsExtensions {
 }
 
 export interface CompiledOptions
-  extends CompiledSharedOptions,
+  extends CompiledSharedOptions<RunnerOptions>,
     ProcessOptionsExtensions {}
 
 export const getUtilsAndReleasersFromOptions = async (

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -117,7 +117,12 @@ export function processSharedOptions(
       },
     );
     _sharedOptionsCache.set(options, compiled);
-    hooks.process("init");
+    Promise.resolve(hooks.process("init")).catch((error) => {
+      logger.error(
+        `One of the plugins you are using raised an error during 'init'; but errors during 'init' are currently ignored. Continuing. Error: ${error}`,
+        { error },
+      );
+    });
   }
   if (scope) {
     return {

--- a/src/main.ts
+++ b/src/main.ts
@@ -497,10 +497,13 @@ export function _runTaskList(
   },
 ): WorkerPool {
   const {
-    options: { preset, noHandleSignals = false },
-  } = compiledSharedOptions;
+    preset,
+    noHandleSignals = false,
+    concurrency: baseConcurrency = preset?.worker?.concurrentJobs ??
+      defaults.concurrentJobs,
+  } = compiledSharedOptions.options;
   const {
-    concurrency = preset?.worker?.concurrentJobs ?? defaults.concurrentJobs,
+    concurrency = baseConcurrency,
     continuous,
     autostart: rawAutostart = true,
     onTerminate,

--- a/src/main.ts
+++ b/src/main.ts
@@ -12,13 +12,10 @@ import {
 import {
   Job,
   RunOnceOptions,
-  RunnerOptions,
-  SharedOptions,
   TaskList,
   WithPgClient,
   WorkerEventMap,
   WorkerEvents,
-  WorkerOptions,
   WorkerPool,
   WorkerPoolOptions,
 } from "./interfaces";

--- a/src/migrate.ts
+++ b/src/migrate.ts
@@ -93,6 +93,7 @@ async function runMigration(
   }
 }
 
+/** @internal */
 export async function migrate(
   compiledSharedOptions: CompiledSharedOptions<WorkerSharedOptions>,
   client: PoolClient,

--- a/src/migrate.ts
+++ b/src/migrate.ts
@@ -2,11 +2,7 @@ import { PoolClient } from "pg";
 
 import { migrations } from "./generated/sql";
 import { WorkerSharedOptions } from "./interfaces";
-import {
-  BREAKING_MIGRATIONS,
-  CompiledSharedOptions,
-  processSharedOptions,
-} from "./lib";
+import { BREAKING_MIGRATIONS, CompiledSharedOptions } from "./lib";
 
 function checkPostgresVersion(versionString: string) {
   const version = parseInt(versionString, 10);

--- a/src/workerUtils.ts
+++ b/src/workerUtils.ts
@@ -9,19 +9,21 @@ import { migrate } from "./migrate";
 export async function makeWorkerUtils(
   options: WorkerUtilsOptions,
 ): Promise<WorkerUtils> {
+  const compiledSharedOptions = await getUtilsAndReleasersFromOptions(options, {
+    scope: {
+      label: "WorkerUtils",
+    },
+  });
   const { logger, escapedWorkerSchema, release, withPgClient, addJob } =
-    await getUtilsAndReleasersFromOptions(options, {
-      scope: {
-        label: "WorkerUtils",
-      },
-    });
+    compiledSharedOptions;
 
   return {
     withPgClient,
     logger,
     release,
     addJob,
-    migrate: () => withPgClient((pgClient) => migrate(options, pgClient)),
+    migrate: () =>
+      withPgClient((pgClient) => migrate(compiledSharedOptions, pgClient)),
 
     async completeJobs(ids) {
       const { rows } = await withPgClient((client) =>


### PR DESCRIPTION
## Description

In particular working towards values being pulled more consistently from presets.

## Performance impact

Slight improvement in places? Marginal at best.

## Security impact

None known.

## Checklist

- [x] My code matches the project's code style and `yarn lint:fix` passes.
- [ ] ~~I've added tests for the new feature, and `yarn test` passes.~~
- [ ] ~~I have detailed the new feature in the relevant documentation.~~
- [ ] ~~I have added this feature to 'Pending' in the `RELEASE_NOTES.md` file (if one exists).~~
- [x] If this is a breaking change I've explained why.

<!-- For some Graphile projects the documentation is the README.md file, for
      others please see https://github.com/graphile/graphile.github.io -->
