### PR TITLE
Add random number to notify payload to prevent deduplication

### DIFF
--- a/__tests__/schema.sql
+++ b/__tests__/schema.sql
@@ -106,7 +106,7 @@ begin
       returning *
       into v_job;
     if v_job.revision = 0 then
-      perform pg_notify('jobs:insert', '{"count":1}');
+      perform pg_notify('jobs:insert', '{"r":' || random()::text || ',"count":1}');
     end if;
     return v_job;
   else
@@ -144,7 +144,7 @@ begin
   and jobs.key = spec.job_key
   and is_available is not true;
   -- WARNING: this count is not 100% accurate; 'on conflict' clause will cause it to be an overestimate
-  perform pg_notify('jobs:insert', '{"count":' || array_length(specs, 1)::text || '}');
+  perform pg_notify('jobs:insert', '{"r":' || random()::text || ',"count":' || array_length(specs, 1)::text || '}');
   -- TODO: is there a risk that a conflict could occur depending on the
   -- isolation level?
   return query insert into "graphile_worker"._private_jobs as jobs (
@@ -254,7 +254,7 @@ begin
     )
   returning * into v_job;
   if not (v_job is null) then
-    perform pg_notify('jobs:insert', '{"count":-1}');
+    perform pg_notify('jobs:insert', '{"r":' || random()::text || ',"count":-1}');
     return v_job;
   end if;
   -- Otherwise prevent job from retrying, and clear the key

--- a/sql/000018.sql
+++ b/sql/000018.sql
@@ -76,7 +76,7 @@ begin
       returning *
       into v_job;
     if v_job.revision = 0 then
-      perform pg_notify('jobs:insert', '{"count":1}');
+      perform pg_notify('jobs:insert', '{"r":' || random()::text || ',"count":1}');
     end if;
     return v_job;
   else
@@ -116,7 +116,7 @@ begin
   and is_available is not true;
 
   -- WARNING: this count is not 100% accurate; 'on conflict' clause will cause it to be an overestimate
-  perform pg_notify('jobs:insert', '{"count":' || array_length(specs, 1)::text || '}');
+  perform pg_notify('jobs:insert', '{"r":' || random()::text || ',"count":' || array_length(specs, 1)::text || '}');
 
   -- TODO: is there a risk that a conflict could occur depending on the
   -- isolation level?
@@ -190,7 +190,7 @@ begin
     )
   returning * into v_job;
   if not (v_job is null) then
-    perform pg_notify('jobs:insert', '{"count":-1}');
+    perform pg_notify('jobs:insert', '{"r":' || random()::text || ',"count":-1}');
     return v_job;
   end if;
   -- Otherwise prevent job from retrying, and clear the key

--- a/src/generated/sql.ts
+++ b/src/generated/sql.ts
@@ -2231,7 +2231,7 @@ begin
       returning *
       into v_job;
     if v_job.revision = 0 then
-      perform pg_notify('jobs:insert', '{"count":1}');
+      perform pg_notify('jobs:insert', '{"r":' || random()::text || ',"count":1}');
     end if;
     return v_job;
   else
@@ -2271,7 +2271,7 @@ begin
   and is_available is not true;
 
   -- WARNING: this count is not 100% accurate; 'on conflict' clause will cause it to be an overestimate
-  perform pg_notify('jobs:insert', '{"count":' || array_length(specs, 1)::text || '}');
+  perform pg_notify('jobs:insert', '{"r":' || random()::text || ',"count":' || array_length(specs, 1)::text || '}');
 
   -- TODO: is there a risk that a conflict could occur depending on the
   -- isolation level?
@@ -2345,7 +2345,7 @@ begin
     )
   returning * into v_job;
   if not (v_job is null) then
-    perform pg_notify('jobs:insert', '{"count":-1}');
+    perform pg_notify('jobs:insert', '{"r":' || random()::text || ',"count":-1}');
     return v_job;
   end if;
   -- Otherwise prevent job from retrying, and clear the key


### PR DESCRIPTION
## Description

Postgres docs for NOTIFY state:

> Except for dropping later instances of duplicate notifications, NOTIFY guarantees that notifications from the same transaction get delivered in the order they were sent. It is also guaranteed that messages from different transactions are delivered in the order in which the transactions committed.

Therefore, something like:

```sql
BEGIN;
select add_job(...);
select add_job(...);
select add_job(...);
COMMIT;
```

Might result in 3 identical notifications `NOTIFY "jobs:insert", '{"count":1}';` which would be de-duplicated.

To avoid this deduplication, I've added a random number to each payload.

## Performance impact

Marginal cost on job insertion.

## Security impact

None known.

## Checklist

- [x] My code matches the project's code style and `yarn lint:fix` passes.
- [ ] ~~I've added tests for the new feature, and `yarn test` passes.~~
- [ ] ~~I have detailed the new feature in the relevant documentation.~~
- [ ] ~~I have added this feature to 'Pending' in the `RELEASE_NOTES.md` file (if one exists).~~
- [x] If this is a breaking change I've explained why.

<!-- For some Graphile projects the documentation is the README.md file, for
      others please see https://github.com/graphile/graphile.github.io -->
