### PR TITLE
Pro: document worker recovery features

### DIFF
--- a/website/docs/pro/config.md
+++ b/website/docs/pro/config.md
@@ -18,8 +18,6 @@ Type: `number | undefined`
 How often, in milliseconds, a worker should check in as active. Defaults to 1
 minute.
 
-<!--
-
 ### worker.sweepInterval
 
 Type: `number | undefined`
@@ -36,8 +34,6 @@ worker is considered inactive and eligible to be force-released. Defaults to 4
 hours, but we recommend you set it to a shorter time &mdash; how long you think
 a legitimate networking interruption might last where tasks may still
 successfully complete.
-
--->
 
 ### worker.maxMigrationWaitTime
 
@@ -65,6 +61,12 @@ const preset: GraphileConfig.Preset = {
     // Check in as active once per minute
     heartbeatInterval: 60 * 1000,
 
+    // Check for and force-release inactive workers every 3 minutes
+    sweepInterval: 3 * 60 * 1000,
+
+    // Workers are deemed "inactive" 10 minutes after their last heartbeat
+    sweepThreshold: 10 * 60 * 1000,
+
     // If old workers haven't exited within 30 minutes, go ahead and perform
     // the migration anyway:
     maxMigrationWaitTime: 30 * 60 * 1000,
@@ -73,13 +75,3 @@ const preset: GraphileConfig.Preset = {
 
 export default preset;
 ```
-
-<!--
-```
-    // Check for and force-release inactive workers every 3 minutes
-    sweepInterval: 3 * 60 * 1000,
-
-    // Workers are deemed "inactive" 10 minutes after their last heartbeat
-    sweepThreshold: 10 * 60 * 1000,
-```
--->

--- a/website/docs/pro/index.md
+++ b/website/docs/pro/index.md
@@ -10,12 +10,9 @@ essential, but they are things your team is likely to appreciate:
 
 - [Live migration](./migration.md) &mdash; remove the need to scale to zero to
   safely upgrade Worker versions
-- _More features planned_
-
-<!--
 - [Crashed worker recovery](./recovery.md) &mdash; track running workers and
   unlock jobs automatically when a worker seems to have unexpectedly stopped
--->
+- _More features planned_
 
 _~~Worker Pro is priced at USD $100/mo and helps to fund the ongoing maintenance
 of Graphile Worker and other Graphile projects. It is also available

--- a/website/docs/pro/recovery.md
+++ b/website/docs/pro/recovery.md
@@ -4,8 +4,6 @@ sidebar_position: 20
 draft: true
 ---
 
-**THIS FUNCTIONALITY IS NOT YET IMPLEMENTED**
-
 If a regular Graphile Worker process exits unexpectedly (for example someone
 pulls the power lead from the server, or the Node.js process crashes or is
 killed) it does not have a chance to unlock its active jobs, and they remain
@@ -15,7 +13,9 @@ could be far too long.
 Worker Pro tracks running workers via a &ldquo;heartbeat&rdquo;, and when a
 worker has not checked in for a configurable amount of time we can assume that
 this worker is no longer active (crashed, was terminated, server shut down, etc)
-and release its jobs back to the pool to be executed.
+and release its jobs back to the pool to be executed (honouring
+[exponential backoff](../exponential-backoff.md) to help avoid crashes from
+poorly written task executors causing worker progress to stall).
 
 :::note
 


### PR DESCRIPTION
## Description

If a regular Graphile Worker process exits unexpectedly (for example someone pulls the power lead from the server, or the Node.js process crashes or is killed) it does not have a chance to unlock its active jobs, and they remain locked for up to 4 hours. For some jobs, not being attempted again for 4 hours could be far too long.

[Worker Pro](https://worker.graphile.org/docs/pro) tracks running workers via a &ldquo;heartbeat&rdquo;, and when a worker has not checked in for a configurable amount of time we can assume that this worker is no longer active (crashed, was terminated, server shut down, etc) and release its jobs back to the pool to be executed (honouring [exponential backoff](../exponential-backoff.md) to help avoid crashes from poorly written task executors causing worker progress to stall).

## Performance impact

Marginal.

## Security impact

Crashed tasks are reattempted sooner, so a malicious actor that determines what tasks are likely to crash could re-queue these tasks more frequently increasing service disruptions from poorly written tasks. Workaround: write better tasks - your tasks should not crash the worker!

## Checklist

<!-- If this PR is work in progress, please open it as a "Draft PR". -->
<!-- To tick a checkbox, change it from `[ ]` to `[x]` -->

- [x] My code matches the project's code style and `yarn lint:fix` passes.
- [ ] ~~I've added tests for the new feature, and `yarn test` passes.~~
- [ ] ~~I have detailed the new feature in the relevant documentation.~~
- [ ] ~~I have added this feature to 'Pending' in the `RELEASE_NOTES.md` file (if one exists).~~
- [ ] ~~If this is a breaking change I've explained why.~~

<!-- For some Graphile projects the documentation is the README.md file, for
      others please see https://github.com/graphile/graphile.github.io -->
