### PR TITLE
perfTest example: move python validation earlier

### DIFF
--- a/perfTest/tasks/nested/folder/python.py
+++ b/perfTest/tasks/nested/folder/python.py
@@ -2,12 +2,12 @@
 
 import json, os, sys
 
-input_string = sys.stdin.read()
-input_object = json.loads(input_string)
-
 if os.environ["GRAPHILE_WORKER_PAYLOAD_FORMAT"] <> "json":
     print("Graphile Worker binary payload format {} unsupported".format(os.environ["GRAPHILE_WORKER_PAYLOAD_FORMAT"]))
     exit(99)
+
+input_string = sys.stdin.read()
+input_object = json.loads(input_string)
 
 current_attempts = int(os.environ["GRAPHILE_WORKER_JOB_ATTEMPTS"])
 expected_attempts = int(input_object["payload"]["attempts"])


### PR DESCRIPTION
## Description

Don't parse the JSON before you check it's JSON.

## Performance impact

None.

## Security impact

Improvement?

## Checklist

<!-- If this PR is work in progress, please open it as a "Draft PR". -->
<!-- To tick a checkbox, change it from `[ ]` to `[x]` -->

- [x] My code matches the project's code style and `yarn lint:fix` passes.
- [ ] ~~I've added tests for the new feature, and `yarn test` passes.~~
- [ ] ~~I have detailed the new feature in the relevant documentation.~~
- [ ] ~~I have added this feature to 'Pending' in the `RELEASE_NOTES.md` file (if one exists).~~
- [ ] ~~If this is a breaking change I've explained why.~~

<!-- For some Graphile projects the documentation is the README.md file, for
      others please see https://github.com/graphile/graphile.github.io -->
