### PR TITLE
website: Docs tweaks to AddJob and TypeScript pages

### DIFF
--- a/website/docs/library/add-job.md
+++ b/website/docs/library/add-job.md
@@ -49,6 +49,8 @@ export type AddJobFunction = (
 
   /**
    * The payload (typically a JSON object) that will be passed to the task executor.
+   * By default, for safety, payloads are typed as unknown since they may have been
+   * populated by out of date code, or even from other sources.
    */
   payload: unknown,
 

--- a/website/docs/library/add-job.md
+++ b/website/docs/library/add-job.md
@@ -35,7 +35,7 @@ The `addJob` arguments are as follows:
 Example:
 
 ```js
-await addJob("task_2", { foo: "bar" });
+await addJob("send_email", { to: "someone@example.com" });
 ```
 
 Definitions:
@@ -50,7 +50,7 @@ export type AddJobFunction = (
   /**
    * The payload (typically a JSON object) that will be passed to the task executor.
    */
-  payload: any,
+  payload: unknown,
 
   /**
    * Additional details about how the job should be handled.

--- a/website/docs/typescript.md
+++ b/website/docs/typescript.md
@@ -74,8 +74,8 @@ export const send_email: Task = async function (payload) {
   const { to, subject, body } = payload;
   await ses.sendEmail({
     Destination: {
-      ToAddress: [to],
-      FromAddress: ["no-reply@example.com"],
+      ToAddresses: [to],
+      FromAddresses: ["no-reply@example.com"],
     },
     Message: {
       Subject: {
@@ -123,9 +123,9 @@ export const send_email: Task = async function (payload) {
 + const { to, subject, body, from } = payload;
   await ses.sendEmail({
     Destination: {
-      ToAddress: [to],
--     FromAddress: ["no-reply@example.com"],
-+     FromAddress: [from ?? "no-reply@example.com"],
+      ToAddresses: [to],
+-     FromAddresses: ["no-reply@example.com"],
++     FromAddresses: [from ?? "no-reply@example.com"],
     },
     Message: {
       Subject: {
@@ -222,8 +222,8 @@ export const send_email: Task<"send_email"> = async function (payload) {
   const { to, subject, body } = payload;
   await ses.sendEmail({
     Destination: {
-      ToAddress: [to],
-      FromAddress: ["no-reply@example.com"],
+      ToAddresses: [to],
+      FromAddresses: ["no-reply@example.com"],
     },
     Message: {
       Subject: {
@@ -267,9 +267,9 @@ export const send_email: Task<"send_email"> = async function (payload) {
 + const { to, subject, body, from } = payload;
   await ses.sendEmail({
     Destination: {
-      ToAddress: [to],
--      FromAddress: ["no-reply@example.com"],
-+      FromAddress: [from ?? "no-reply@example.com"],
+      ToAddresses: [to],
+-      FromAddresses: ["no-reply@example.com"],
++      FromAddresses: [from ?? "no-reply@example.com"],
     },
     Message: {
       Subject: {

--- a/website/docs/typescript.md
+++ b/website/docs/typescript.md
@@ -10,38 +10,17 @@ ensure the `payload` conforms to what you expect. It can be convenient to
 declare the payload types up front to avoid this `unknown`, but doing so might
 be unsafe &mdash; please be sure to read the caveats below.
 
-## Using type guards
+## Using type assertion functions
 
 To ensure your system is as safe as possible (and guard against old jobs, or
 jobs specified outside of TypeScript's type checking) we recommend that you use
-type guards to assert that your payload is of the expected type.
-
-```ts
-interface MyPayload {
-  username: string;
-}
-
-function assertMyPayload(payload: any): asserts payload is MyPayload {
-  if (
-    typeof payload === "object" &&
-    payload &&
-    typeof payload.username === "string"
-  ) {
-    return;
-  }
-  throw new Error("Invalid payload, expected a MyPayload");
-}
-
-const task: Task = async (payload) => {
-  assertMyPayload(payload);
-  console.log(payload.username);
-};
-```
+[type assertion functions](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-3-7.html#assertion-functions)
+to assert that your payload is of the expected type.
 
 If this is too manual, you might prefer to use a library such as `runtypes` or
 one of the many others of a similar kind.
 
-### Example of using type guards
+### Example of using an assertion function
 
 The following is an example implementation of sending emails using Amazon SES.
 
@@ -138,9 +117,9 @@ export const send_email: Task = async function (payload) {
 
 ## Assuming type via `GraphileWorker.Tasks`
 
-As an alternative to the recommended use of type guards, you can register types
-for Graphile Worker tasks using the following syntax in a shared TypeScript file
-in your project:
+As an alternative to the recommended use of assertion functions, you can
+register types for Graphile Worker tasks using the following syntax in a shared
+TypeScript file in your project:
 
 ```ts
 declare global {
@@ -186,7 +165,7 @@ using the old format. This can lead to you assuming that something is a number
 when actually it&apos;s `null`, resulting in more bugs in your code, so care
 must be taken.
 
-We recommend you use type guards instead.
+We recommend you use assertion functions instead.
 
 :::
 
@@ -235,8 +214,8 @@ export const send_email: Task<"send_email"> = async function (payload) {
 ```
 
 If now we introduce the new functionality to set the `from` address, the changes
-we make have to take into account that older jobs may not have the `from` address
-set, like so:
+we make have to take into account that older jobs may not have the `from`
+address set, like so:
 
 ```diff
 import type { Task, WorkerUtils } from "graphile-worker";
@@ -279,3 +258,10 @@ export const send_email: Task<"send_email"> = async function (payload) {
   });
 };
 ```
+
+:::tip
+
+All of the declarations would normally be put in a shared interface file, or
+similar. The example above defines one with the task for ease of reading.
+
+:::

--- a/website/docs/typescript.md
+++ b/website/docs/typescript.md
@@ -8,12 +8,146 @@ typed as `unknown` since they may have been populated by out of date code, or
 even from other sources. This requires you to add a type guard or similar to
 ensure the `payload` conforms to what you expect. It can be convenient to
 declare the payload types up front to avoid this `unknown`, but doing so might
-be unsafe - please be sure to read the caveats below.
+be unsafe &mdash; please be sure to read the caveats below.
 
-## `GraphileWorker.Tasks`
+## Using type guards
 
-You can register types for Graphile Worker tasks using the following syntax in a
-shared TypeScript file in your project:
+To ensure your system is as safe as possible (and guard against old jobs, or
+jobs specified outside of TypeScript's type checking) we recommend that you use
+type guards to assert that your payload is of the expected type.
+
+```ts
+interface MyPayload {
+  username: string;
+}
+
+function assertMyPayload(payload: any): asserts payload is MyPayload {
+  if (
+    typeof payload === "object" &&
+    payload &&
+    typeof payload.username === "string"
+  ) {
+    return;
+  }
+  throw new Error("Invalid payload, expected a MyPayload");
+}
+
+const task: Task = async (payload) => {
+  assertMyPayload(payload);
+  console.log(payload.username);
+};
+```
+
+If this is too manual, you might prefer to use a library such as `runtypes` or
+one of the many others of a similar kind. If you're not concerned with the type
+safety of the payload, you can work around it with a couple casts:
+
+```ts
+const task: Task = (inPayload) => {
+  const payload = inPayload as any as MyPayload;
+};
+```
+
+### Example of using type guards
+
+The following is an example implementation of sending emails using Amazon SES.
+
+```ts
+import type { Task, WorkerUtils } from "graphile-worker";
+import { ses } from "./aws";
+
+interface Payload {
+  to: string;
+  subject: string;
+  body: string;
+}
+
+function assertPayload(payload: any): asserts payload is Payload {
+  if (typeof payload !== "object" || !payload) throw new Error("invalid");
+  if (typeof payload.to !== "string") throw new Error("invalid");
+  if (typeof payload.subject !== "string") throw new Error("invalid");
+  if (typeof payload.body !== "string") throw new Error("invalid");
+}
+
+export const send_email: Task = async function (payload) {
+  assertPayload(payload);
+  const { to, subject, body } = payload;
+  await ses.sendEmail({
+    Destination: {
+      ToAddress: [to],
+      FromAddress: ["no-reply@example.com"],
+    },
+    Message: {
+      Subject: {
+        Charset: "UTF-8",
+        Data: subject,
+      },
+      Body: {
+        Text: {
+          Charset: "UTF-8",
+          Data: body,
+        },
+      },
+    },
+  });
+};
+```
+
+If now we introduce a new functionality to set the from address, the changes we
+make have to take into account that older jobs may not have the from address
+set, like so:
+
+```diff
+import type { Task, WorkerUtils } from "graphile-worker";
+import { ses } from "./aws";
+
+interface Payload {
+  to: string;
+  subject: string;
+  body: string;
++ from?: string;
+}
+
+function assertPayload(payload: any): asserts payload is Payload {
+  if (typeof payload !== "object" || !payload) throw new Error("invalid");
+  if (typeof payload.to !== "string") throw new Error("invalid");
+  if (typeof payload.subject !== "string") throw new Error("invalid");
+  if (typeof payload.body !== "string") throw new Error("invalid");
++ if (typeof payload.from !== "string" && typeof payload.from !== "undefined")
++   throw new Error("invalid");
+}
+
+export const send_email: Task = async function (payload) {
+  assertPayload(payload);
+- const { to, subject, body } = payload;
++ const { to, subject, body, from } = payload;
+  await ses.sendEmail({
+    Destination: {
+      ToAddress: [to],
+-     FromAddress: ["no-reply@example.com"],
++     FromAddress: [from ?? "no-reply@example.com"],
+    },
+    Message: {
+      Subject: {
+        Charset: "UTF-8",
+        Data: subject,
+      },
+      Body: {
+        Text: {
+          Charset: "UTF-8",
+          Data: body,
+        },
+      },
+    },
+  });
+};
+```
+
+## Assuming type via `GraphileWorker.Tasks`
+
+As an alternative to the recommended use of type guards, you can register types
+for Graphile Worker tasks using the following syntax in a shared TypeScript file
+in your project:
 
 ```ts
 declare global {
@@ -56,47 +190,99 @@ created in the database directly via the `graphile_worker.add_job()` or
 to your TypeScript types. Further, you may modify the payload type of a task in
 a later version of your application, but existing jobs may exist in the database
 using the old format. This can lead to you assuming that something is a number
-when actually it's `null`, resulting in more bugs in your code, so care must be
-taken.
+when actually it&apos;s `null`, resulting in more bugs in your code, so care
+must be taken.
 
 We recommend you use type guards instead.
 
 :::
 
-## Using type guards
+### Example of assuming type
 
-To ensure your system is as safe as possible (and guard against old jobs, or
-jobs specified outside of TypeScript's type checking) we recommend that you use
-type guards to assert that your payload is of the expected type.
+The following takes the Amazon SES example above, but uses the technique of
+assuming type instead:
 
 ```ts
-interface MyPayload {
-  username: string;
-}
+import type { Task, WorkerUtils } from "graphile-worker";
+import { ses } from "./aws";
 
-function assertMyPayload(payload: any): asserts payload is MyPayload {
-  if (
-    typeof payload === "object" &&
-    payload &&
-    typeof payload.username === "string"
-  ) {
-    return;
+declare global {
+  namespace GraphileWorker {
+    interface Tasks {
+      send_email: {
+        to: string;
+        subject: string;
+        body: string;
+      };
+    }
   }
-  throw new Error("Invalid payload, expected a MyPayload");
 }
 
-const task: Task = async (payload) => {
-  assertMyPayload(payload);
-  console.log(payload.username);
+export const send_email: Task<"send_email"> = async function (payload) {
+  const { to, subject, body } = payload;
+  await ses.sendEmail({
+    Destination: {
+      ToAddress: [to],
+      FromAddress: ["no-reply@example.com"],
+    },
+    Message: {
+      Subject: {
+        Charset: "UTF-8",
+        Data: subject,
+      },
+      Body: {
+        Text: {
+          Charset: "UTF-8",
+          Data: body,
+        },
+      },
+    },
+  });
 };
 ```
 
-If this is too manual, you might prefer to use a library such as `runtypes` or
-the many others of a similar ilk. If you're not concerned with the type safety
-of the payload, you can work around it with a couple casts:
+If now we introduce the new functionality to set the from address, the changes
+we make have to take into account that older jobs may not have the from address
+set, like so:
 
-```ts
-const task: Task = (inPayload) => {
-  const payload = inPayload as any as MyPayload;
+```diff
+import type { Task, WorkerUtils } from "graphile-worker";
+import { ses } from "./aws";
+
+declare global {
+  namespace GraphileWorker {
+    interface Tasks {
+      send_email: {
+        to: string;
+        subject: string;
+        body: string;
++       from?: string;
+      };
+    }
+  }
+}
+
+export const send_email: Task<"send_email"> = async function (payload) {
+- const { to, subject, body } = payload;
++ const { to, subject, body, from } = payload;
+  await ses.sendEmail({
+    Destination: {
+      ToAddress: [to],
+-      FromAddress: ["no-reply@example.com"],
++      FromAddress: [from ?? "no-reply@example.com"],
+    },
+    Message: {
+      Subject: {
+        Charset: "UTF-8",
+        Data: subject,
+      },
+      Body: {
+        Text: {
+          Charset: "UTF-8",
+          Data: body,
+        },
+      },
+    },
+  });
 };
 ```

--- a/website/docs/typescript.md
+++ b/website/docs/typescript.md
@@ -39,14 +39,7 @@ const task: Task = async (payload) => {
 ```
 
 If this is too manual, you might prefer to use a library such as `runtypes` or
-one of the many others of a similar kind. If you're not concerned with the type
-safety of the payload, you can work around it with a couple casts:
-
-```ts
-const task: Task = (inPayload) => {
-  const payload = inPayload as any as MyPayload;
-};
-```
+one of the many others of a similar kind.
 
 ### Example of using type guards
 
@@ -93,9 +86,9 @@ export const send_email: Task = async function (payload) {
 };
 ```
 
-If now we introduce a new functionality to set the from address, the changes we
-make have to take into account that older jobs may not have the from address
-set, like so:
+If now we introduce a new functionality to set the `from` address, we have to
+take into account that older jobs will not have the `from` address set. We
+should adjust our code like so:
 
 ```diff
 import type { Task, WorkerUtils } from "graphile-worker";

--- a/website/docs/typescript.md
+++ b/website/docs/typescript.md
@@ -234,8 +234,8 @@ export const send_email: Task<"send_email"> = async function (payload) {
 };
 ```
 
-If now we introduce the new functionality to set the from address, the changes
-we make have to take into account that older jobs may not have the from address
+If now we introduce the new functionality to set the `from` address, the changes
+we make have to take into account that older jobs may not have the `from` address
 set, like so:
 
 ```diff


### PR DESCRIPTION
## Description

Some documentation tweaks:

- `addJob()` example now mirrors the example on the "Add jobs through SQL" page
-  changed `payload` to `unknown` type with an explanation, on the same `AddJob()` page
- Reordered the TypeScript page to put the recommended route at the top
- Added an Amazon SES example to the TypeScript page

## Performance impact

Docs only

## Security impact

Docs only

## Checklist

<!-- If this PR is work in progress, please open it as a "Draft PR". -->
<!-- To tick a checkbox, change it from `[ ]` to `[x]` -->

- [x] My code matches the project's code style and `yarn lint:fix` passes.
- ~~[ ] I've added tests for the new feature, and `yarn test` passes.~~
- [x] I have detailed the new feature in the relevant documentation.
- ~~[ ] I have added this feature to 'Pending' in the `RELEASE_NOTES.md` file (if one exists).~~
- ~~[ ] If this is a breaking change I've explained why.~~

<!-- For some Graphile projects the documentation is the README.md file, for
      others please see https://github.com/graphile/graphile.github.io -->
