### PR TITLE
Fix ambiguous references in add_job()

### DIFF
--- a/__tests__/schema.sql
+++ b/__tests__/schema.sql
@@ -39,16 +39,16 @@ declare
 begin
   if (job_key is null or job_key_mode is null or job_key_mode in ('replace', 'preserve_run_at')) then
     select * into v_job
-    from "graphile_worker".add_jobs(
+    from graphile_worker.add_jobs(
       ARRAY[(
-        identifier,
-        payload,
-        queue_name,
-        run_at,
-        max_attempts::smallint,
-        job_key,
-        priority::smallint,
-        flags
+        add_job.identifier,
+        add_job.payload,
+        add_job.queue_name,
+        add_job.run_at,
+        add_job.max_attempts::smallint,
+        add_job.job_key,
+        add_job.priority::smallint,
+        add_job.flags
       )::"graphile_worker".job_spec],
       (job_key_mode = 'preserve_run_at')
     )

--- a/__tests__/schema.sql
+++ b/__tests__/schema.sql
@@ -39,7 +39,7 @@ declare
 begin
   if (job_key is null or job_key_mode is null or job_key_mode in ('replace', 'preserve_run_at')) then
     select * into v_job
-    from graphile_worker.add_jobs(
+    from "graphile_worker".add_jobs(
       ARRAY[(
         add_job.identifier,
         add_job.payload,


### PR DESCRIPTION
## Summary
Fix ambiguous references in add_job() since it these things could refer to both a table column and routine parameter
This only fixes the schema file....
I still need to coordinate with Benjie (or someone else) to help me claim a new migration script and/or learn how to generate the sql.ts necessary with this change.
 
## Description

<!-- If this PR adds a feature, what does it add and what was the motivation for it? -->
<!-- If this PR fixes an issue, what is the issue? -->
This cleans up issue #408 
<!-- Please link to the relevant GitHub issues/Discord discussion/etc as appropriate -->

## Performance impact
na

## Security impact
na

## Checklist

<!-- If this PR is work in progress, please open it as a "Draft PR". -->
<!-- To tick a checkbox, change it from `[ ]` to `[x]` -->

- [ ] My code matches the project's code style and `yarn lint:fix` passes.
- [ ] I've added tests for the new feature, and `yarn test` passes.
- [ ] I have detailed the new feature in the relevant documentation.
- [ ] I have added this feature to 'Pending' in the `RELEASE_NOTES.md` file (if one exists).
- [ ] If this is a breaking change I've explained why.

<!-- For some Graphile projects the documentation is the README.md file, for
      others please see https://github.com/graphile/graphile.github.io -->
