### PR TITLE
Fix documentation on maxAttempts to match definition

### DIFF
--- a/website/docs/library/add-job.md
+++ b/website/docs/library/add-job.md
@@ -22,7 +22,7 @@ The `addJob` arguments are as follows:
 - `options`: an optional object specifying:
   - `queueName`: the queue to run this task under
   - `runAt`: a `Date` to schedule this task to run in the future
-  - `maxAttempts`: how many retries should this task get? (Default: 25)
+  - `maxAttempts`: the maximum number of attempts we'll give the job (Default: 25)
   - `jobKey`: unique identifier for the job, used to replace, update or remove
     it later if needed (see
     [Replacing and updating jobs](../job-key.md#replacingupdating-jobs) and

--- a/website/docs/library/add-job.md
+++ b/website/docs/library/add-job.md
@@ -22,7 +22,8 @@ The `addJob` arguments are as follows:
 - `options`: an optional object specifying:
   - `queueName`: the queue to run this task under
   - `runAt`: a `Date` to schedule this task to run in the future
-  - `maxAttempts`: the maximum number of attempts we'll give the job (Default: 25)
+  - `maxAttempts`: the maximum number of attempts we'll give the job
+    (Default: 25)
   - `jobKey`: unique identifier for the job, used to replace, update or remove
     it later if needed (see
     [Replacing and updating jobs](../job-key.md#replacingupdating-jobs) and


### PR DESCRIPTION
## Description

The definition says maxAttempts minimum is 1 in which case the task will only be attempted once and won't be retried.

## Performance impact

None

## Security impact

None

## Checklist

- [X] My code matches the project's code style and `yarn lint:fix` passes.
- [ ] I've added tests for the new feature, and `yarn test` passes.
- [ ] I have detailed the new feature in the relevant documentation.
- [ ] I have added this feature to 'Pending' in the `RELEASE_NOTES.md` file (if one exists).
- [ ] If this is a breaking change I've explained why.

<!-- For some Graphile projects the documentation is the README.md file, for
      others please see https://github.com/graphile/graphile.github.io -->
