### PR TITLE
Fix ESM woes

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -19,6 +19,11 @@ to make sure the system as a whole remains consistent.
 Read more:
 [Worker Pro Migration](https://worker.graphile.org/docs/pro/migration).
 
+## v0.16.1
+
+- Fixes issue importing task files that were written in TypeScript ESM format
+  but exported as CommonJS.
+
 ## v0.16.0
 
 _There's a breakdown of these release notes available on the new

--- a/__tests__/fixtures/tasks/wouldyoulike_ts.js
+++ b/__tests__/fixtures/tasks/wouldyoulike_ts.js
@@ -1,0 +1,7 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+const blah_1 = require("../blah");
+exports.default = (_payload, helpers) => {
+  helpers.logger.debug((0, blah_1.rand)());
+  return "some TS sausages";
+};

--- a/__tests__/fixtures/tasksFile-ts.js
+++ b/__tests__/fixtures/tasksFile-ts.js
@@ -1,0 +1,7 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.task2 = exports.task1 = void 0;
+const task1 = () => "hi";
+exports.task1 = task1;
+const task2 = () => "hello from TS";
+exports.task2 = task2;

--- a/__tests__/fixtures/tasksFile_default-ts.js
+++ b/__tests__/fixtures/tasksFile_default-ts.js
@@ -1,0 +1,6 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.default = {
+  t1: () => "come with me, TS",
+  t2: () => "if you want to live",
+};

--- a/__tests__/getTasks.test.ts
+++ b/__tests__/getTasks.test.ts
@@ -72,6 +72,36 @@ Array [
       await release();
     }));
 
+  test("get tasks from file (vanilla-ts)", () =>
+    withPgClient(async (client) => {
+      const { tasks, release, compiledSharedOptions } = (await getTasks(
+        options,
+        `${__dirname}/fixtures/tasksFile-ts.js`,
+      )) as WatchedTaskList & { compiledSharedOptions: CompiledSharedOptions };
+      expect(tasks).toBeTruthy();
+      expect(Object.keys(tasks).sort()).toMatchInlineSnapshot(`
+Array [
+  "task1",
+  "task2",
+]
+`);
+
+      const helpers = makeJobHelpers(
+        compiledSharedOptions,
+        makeMockJob("task1"),
+        {
+          withPgClient: makeWithPgClientFromClient(client),
+          abortSignal: undefined,
+        },
+      );
+      expect(await tasks.task1!(helpers.job.payload, helpers)).toEqual("hi");
+      expect(await tasks.task2!(helpers.job.payload, helpers)).toEqual(
+        "hello from TS",
+      );
+
+      await release();
+    }));
+
   test("get tasks from file (default)", () =>
     withPgClient(async (client) => {
       const { tasks, release, compiledSharedOptions } = (await getTasks(
@@ -92,6 +122,34 @@ Array [
       });
       expect(await tasks.t1!(helpers.job.payload, helpers)).toEqual(
         "come with me",
+      );
+      expect(await tasks.t2!(helpers.job.payload, helpers)).toEqual(
+        "if you want to live",
+      );
+
+      await release();
+    }));
+
+  test("get tasks from file (default-ts)", () =>
+    withPgClient(async (client) => {
+      const { tasks, release, compiledSharedOptions } = (await getTasks(
+        options,
+        `${__dirname}/fixtures/tasksFile_default-ts.js`,
+      )) as WatchedTaskList & { compiledSharedOptions: CompiledSharedOptions };
+      expect(tasks).toBeTruthy();
+      expect(Object.keys(tasks).sort()).toMatchInlineSnapshot(`
+Array [
+  "t1",
+  "t2",
+]
+`);
+
+      const helpers = makeJobHelpers(compiledSharedOptions, makeMockJob("t1"), {
+        withPgClient: makeWithPgClientFromClient(client),
+        abortSignal: undefined,
+      });
+      expect(await tasks.t1!(helpers.job.payload, helpers)).toEqual(
+        "come with me, TS",
       );
       expect(await tasks.t2!(helpers.job.payload, helpers)).toEqual(
         "if you want to live",

--- a/__tests__/getTasks.test.ts
+++ b/__tests__/getTasks.test.ts
@@ -21,6 +21,7 @@ describe("commonjs", () => {
 Array [
   "wouldyoulike",
   "wouldyoulike_default",
+  "wouldyoulike_ts",
 ]
 `);
       const helpers = makeJobHelpers(
@@ -37,6 +38,9 @@ Array [
       expect(
         await tasks.wouldyoulike_default!(helpers.job.payload, helpers),
       ).toEqual("some more sausages");
+      expect(
+        await tasks.wouldyoulike_ts!(helpers.job.payload, helpers),
+      ).toEqual("some TS sausages");
       await release();
     }));
 

--- a/src/plugins/LoadTaskFromJsPlugin.ts
+++ b/src/plugins/LoadTaskFromJsPlugin.ts
@@ -43,21 +43,23 @@ export const LoadTaskFromJsPlugin: GraphileConfig.Plugin = {
           const rawMod = await import(jsFile.fullPath);
 
           // Normally, import() of a commonJS module with `module.exports` write
-          // would result in `{ default: module.exports }`
-          const mod =
-            Object.keys(rawMod).length === 1 &&
-            typeof rawMod.default === "object" &&
-            rawMod.default !== null
-              ? rawMod.default
-              : rawMod;
-
+          // would result in `{ default: module.exports }`.
           // TypeScript in CommonJS mode when imported with Node ESM can lead to
           // two levels of `__esModule: true`; so we try and grab the inner one
           // if we can.
-          const tsHack = mod.default?.__esModule === true ? mod.default : mod;
+          const mod =
+            rawMod.default?.default?.__esModule === true
+              ? rawMod.default.default
+              : rawMod.default?.__esModule === true
+              ? rawMod.default
+              : Object.keys(rawMod).length === 1 &&
+                typeof rawMod.default === "object" &&
+                rawMod.default !== null
+              ? rawMod.default
+              : rawMod;
 
           // Always take the default export if there is one
-          const task = tsHack.default || tsHack;
+          const task = mod.default || mod;
 
           if (isValidTask(task)) {
             details.handler = task;

--- a/src/plugins/LoadTaskFromJsPlugin.ts
+++ b/src/plugins/LoadTaskFromJsPlugin.ts
@@ -41,18 +41,31 @@ export const LoadTaskFromJsPlugin: GraphileConfig.Plugin = {
 
         try {
           const rawMod = await import(jsFile.fullPath);
+
+          // Normally, import() of a commonJS module with `module.exports` write
+          // would result in `{ default: module.exports }`
           const mod =
             Object.keys(rawMod).length === 1 &&
             typeof rawMod.default === "object" &&
             rawMod.default !== null
               ? rawMod.default
               : rawMod;
-          const task = mod.default || mod;
+
+          // TypeScript in CommonJS mode when imported with Node ESM can lead to
+          // two levels of `__esModule: true`; so we try and grab the inner one
+          // if we can.
+          const tsHack = mod.default?.__esModule === true ? mod.default : mod;
+
+          // Always take the default export if there is one
+          const task = tsHack.default || tsHack;
+
           if (isValidTask(task)) {
             details.handler = task;
           } else {
             throw new Error(
-              `Invalid task '${name}' - expected function, received ${
+              `Invalid task '${
+                jsFile.fullPath
+              }' - expected function, received ${
                 task ? typeof task : String(task)
               }.`,
             );


### PR DESCRIPTION
## Description

Fixes #416; namely TypeScript modules that are output in CommonJS mode lead to `const rawMod = await import(file)` returning something like `{ __esModule: true, default: { __esModule: true, default: <the default export> } }` which is super weird.

## Performance impact

Marginal cost in task loading, no further runtime overhead.

## Security impact

None known.

## Checklist

- [x] My code matches the project's code style and `yarn lint:fix` passes.
- [x] I've added tests for the new feature, and `yarn test` passes.
- [ ] ~~I have detailed the new feature in the relevant documentation.~~
- [x] I have added this feature to 'Pending' in the `RELEASE_NOTES.md` file (if one exists).
- [x] If this is a breaking change I've explained why.

<!-- For some Graphile projects the documentation is the README.md file, for
      others please see https://github.com/graphile/graphile.github.io -->
