### PR TITLE
fix: window support to load worker task on library

### DIFF
--- a/src/plugins/LoadTaskFromJsPlugin.ts
+++ b/src/plugins/LoadTaskFromJsPlugin.ts
@@ -1,4 +1,5 @@
 import { GraphileConfig } from "graphile-config";
+import { pathToFileURL } from "url";
 
 import { FileDetails, isValidTask } from "../index.js";
 import { version } from "../version.js";
@@ -40,7 +41,7 @@ export const LoadTaskFromJsPlugin: GraphileConfig.Plugin = {
         }
 
         try {
-          const rawMod = await import(jsFile.fullPath);
+          const rawMod = await import(pathToFileURL(jsFile.fullPath).href);
 
           // Normally, import() of a commonJS module with `module.exports` write
           // would result in `{ default: module.exports }`.


### PR DESCRIPTION
## Description

https://discord.com/channels/489127045289476126/498852330754801666/1194588764337610752

windows worker have issue to load, it need prefix file:/// so we using nodejs method to make sure it work on this environment

## Performance impact

no

## Security impact

no

## Checklist



- [x] My code matches the project's code style and `yarn lint:fix` passes.
- [x] I've added tests for the new feature, and `yarn test` passes.


<!-- For some Graphile projects the documentation is the README.md file, for
      others please see https://github.com/graphile/graphile.github.io -->
      

