### PR TITLE
Fix logger scope for worker

### DIFF
--- a/src/worker.ts
+++ b/src/worker.ts
@@ -47,10 +47,8 @@ export function makeNewWorker(
     _rawOptions: { forbiddenFlags },
   } = compiledSharedOptions;
   const logger = compiledSharedOptions.logger.scope({
-    scope: {
-      label: "worker",
-      workerId,
-    },
+    label: "worker",
+    workerId,
   });
 
   const workerDeferred = deferred();


### PR DESCRIPTION
## Description

This change fixes https://github.com/graphile/worker/issues/418, which was a simple bug introduced where the `workerId` was no longer being set on the logger scope (it was being set on a nested `scope` property), which resulted in the default logger not outputting as expected, and the `logFactory` function not being passed the values as defined in the [documentation](https://worker.graphile.org/docs/library/logger).

When using the default logger, the output before would be something like this:
```
[job] INFO: Starting task
```
After:
```
[job(worker-2c04dcd6ba5728c822: someTask{1})] INFO: Starting task
```

## Performance impact

None

## Security impact

None

## Checklist

- [x] My code matches the project's code style and `yarn lint:fix` passes.
- [ ] I've added tests for the new feature, and `yarn test` passes.
- [ ] I have detailed the new feature in the relevant documentation.
- [ ] I have added this feature to 'Pending' in the `RELEASE_NOTES.md` file (if one exists).
- [ ] If this is a breaking change I've explained why.