### PR TITLE
Release notes, fix env in test

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -21,8 +21,11 @@ Read more:
 
 ## Pending
 
+- Fix loading tasks on Windows (use URLs rather than file paths) - thanks
+  @hiepxanh
 - Add `cleanup` function to remove unused queues, stale task identifiers, and
-  permanently failed jobs.
+  permanently failed jobs - thanks @christophemacabiau
+- Fix logger scope for workers - thanks @jcapcik
 
 ## v0.16.1
 

--- a/__tests__/runner.runOnce.test.ts
+++ b/__tests__/runner.runOnce.test.ts
@@ -11,6 +11,9 @@ import {
   withPgPool,
 } from "./helpers";
 
+delete process.env.DATABASE_URL;
+delete process.env.PGDATABASE;
+
 function setEnvvars(env: { [key: string]: string | undefined }) {
   Object.entries(env).forEach(([key, val]) => {
     if (val === undefined) {


### PR DESCRIPTION
Follow up to #421 because I couldn't push to that branch.

- Adds release notes for:
  - #415
  - #421
  - #424
- Clear environment in tests in case that's why one test was failing for @hiepxanh in #421
- ~~Have CI run on Windows and macOS too~~ -> moved to https://github.com/graphile/worker/pull/427