### PR TITLE
Add helper to get queue name of running job

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -26,6 +26,8 @@ Read more:
 - Add `cleanup` function to remove unused queues, stale task identifiers, and
   permanently failed jobs - thanks @christophemacabiau
 - Fix logger scope for workers - thanks @jcapcik
+- Add `helpers.getQueueName()` to retrieve the queue name of the currently
+  running job
 
 ## v0.16.1
 

--- a/__tests__/runner.helpers.getTaskName.test.ts
+++ b/__tests__/runner.helpers.getTaskName.test.ts
@@ -1,11 +1,11 @@
 import { Pool, PoolClient } from "pg";
 
-import { Job, Runner, RunnerOptions, DbJobSpec } from "../src/interfaces";
+import { DbJobSpec, Job, Runner, RunnerOptions } from "../src/interfaces";
 import { run } from "../src/runner";
 import {
   ESCAPED_GRAPHILE_WORKER_SCHEMA,
-  TEST_CONNECTION_STRING,
   sleepUntil,
+  TEST_CONNECTION_STRING,
   withPgClient,
 } from "./helpers";
 

--- a/__tests__/runner.helpers.getTaskName.test.ts
+++ b/__tests__/runner.helpers.getTaskName.test.ts
@@ -1,6 +1,6 @@
 import { Pool, PoolClient } from "pg";
 
-import { DbJobSpec, Job, Runner, RunnerOptions } from "../src/interfaces";
+import { DbJobSpec, Runner, RunnerOptions } from "../src/interfaces";
 import { run } from "../src/runner";
 import {
   ESCAPED_GRAPHILE_WORKER_SCHEMA,

--- a/__tests__/runner.helpers.getTaskName.test.ts
+++ b/__tests__/runner.helpers.getTaskName.test.ts
@@ -1,0 +1,158 @@
+import { Pool, PoolClient } from "pg";
+
+import { Job, Runner, RunnerOptions } from "../src/interfaces";
+import { run } from "../src/runner";
+import { TEST_CONNECTION_STRING, sleepUntil } from "./helpers";
+
+let pgPool!: Pool;
+let runner: Runner | null = null;
+
+const JOB_COUNT = 10;
+beforeAll(() => {
+  pgPool = new Pool({
+    connectionString: TEST_CONNECTION_STRING,
+    max: JOB_COUNT * 2 + 5,
+  });
+});
+afterAll(() => {
+  pgPool.end();
+});
+
+afterEach(async () => {
+  if (runner) {
+    await runner.stop();
+    runner = null;
+  }
+});
+
+test("getTaskName works as expected", async () => {
+  let results: Record<string, string | null> = Object.create(null);
+
+  const options: RunnerOptions = {
+    pgPool,
+    maxPoolSize: JOB_COUNT * 2 + 5,
+    concurrency: JOB_COUNT * 2,
+    taskList: {
+      async job1(payload, helpers) {
+        const queueNamePromise = helpers.getQueueName();
+        const queueName = await queueNamePromise;
+        results[payload.id] =
+          typeof queueNamePromise === "string" || queueName === null
+            ? `CACHE<${queueName}>`
+            : `FETCH<${queueName}>`;
+      },
+    },
+  };
+  runner = await run(options);
+
+  // Warmup pool
+  {
+    const promises: Promise<PoolClient>[] = [];
+    for (let i = 0; i < JOB_COUNT * 2 + 1; i++) {
+      promises.push(pgPool.connect());
+    }
+    const clients = await Promise.all(promises);
+    clients.forEach((client) => client.release());
+  }
+
+  // First set of tests
+  {
+    const promises: Promise<Job>[] = [];
+    for (let i = 1; i <= JOB_COUNT; i++) {
+      promises.push(
+        runner.addJob(
+          "job1",
+          { id: `j${i}` },
+          {
+            queueName: `q${i % 7}`,
+            runAt: new Date(Date.now() - (JOB_COUNT - i) * 60 * 1000),
+          },
+        ),
+      );
+    }
+    await Promise.all(promises);
+  }
+  await sleepUntil(() => Object.keys(results).length === JOB_COUNT);
+  expect(results).toEqual({
+    j1: "FETCH<q1>",
+    j2: "FETCH<q2>",
+    j3: "FETCH<q3>",
+    j4: "FETCH<q4>",
+    j5: "FETCH<q5>",
+    j6: "FETCH<q6>",
+    j7: "FETCH<q0>",
+    // Same queue as before, so runs later
+    j8: "CACHE<q1>",
+    j9: "CACHE<q2>",
+    j10: "CACHE<q3>",
+  });
+
+  // Do it again; shouldn't need a DB lookup
+  results = Object.create(null);
+  {
+    const promises: Promise<Job>[] = [];
+    for (let i = 1; i <= JOB_COUNT; i++) {
+      promises.push(
+        runner.addJob(
+          "job1",
+          { id: `j${i}` },
+          {
+            queueName: `q${i % 7}`,
+            runAt: new Date(Date.now() - (JOB_COUNT - i) * 60 * 1000),
+          },
+        ),
+      );
+    }
+    await Promise.all(promises);
+  }
+  await sleepUntil(() => Object.keys(results).length === JOB_COUNT);
+  expect(results).toEqual({
+    // All of these are already known
+    j1: "CACHE<q1>",
+    j2: "CACHE<q2>",
+    j3: "CACHE<q3>",
+    j4: "CACHE<q4>",
+    j5: "CACHE<q5>",
+    j6: "CACHE<q6>",
+    j7: "CACHE<q0>",
+    j8: "CACHE<q1>",
+    j9: "CACHE<q2>",
+    j10: "CACHE<q3>",
+  });
+
+  // Mixture of old and new queues
+  results = Object.create(null);
+  {
+    const promises: Promise<Job>[] = [];
+    for (let i = 1; i <= JOB_COUNT; i++) {
+      promises.push(
+        runner.addJob(
+          "job1",
+          { id: `j${i}` },
+          {
+            queueName: `q${(i % 7) + 5}`,
+            runAt: new Date(Date.now() - (JOB_COUNT - i) * 60 * 1000),
+          },
+        ),
+      );
+    }
+    await Promise.all(promises);
+  }
+  await sleepUntil(() => Object.keys(results).length === JOB_COUNT);
+  expect(results).toEqual({
+    // Already known
+    j1: "CACHE<q6>",
+    // New
+    j2: "FETCH<q7>",
+    j3: "FETCH<q8>",
+    j4: "FETCH<q9>",
+    j5: "FETCH<q10>",
+    j6: "FETCH<q11>",
+    // Already known
+    j7: "CACHE<q5>",
+    j8: "CACHE<q6>",
+    // Same queue, so runs later
+    j9: "CACHE<q7>",
+    j10: "CACHE<q8>",
+  });
+});

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -1,15 +1,15 @@
 import { Pool, PoolClient } from "pg";
 
+import defer, { Deferred } from "./deferred";
 import {
   AddJobFunction,
   Job,
   JobHelpers,
-  WithPgClient,
   PromiseOrDirect,
+  WithPgClient,
 } from "./interfaces";
 import { CompiledSharedOptions } from "./lib";
 import { Logger } from "./logger";
-import defer, { Deferred } from "./deferred";
 import { getQueueNames } from "./sql/getQueueNames";
 
 export function makeAddJob(
@@ -74,7 +74,9 @@ function getQueueName(
   withPgClient: WithPgClient,
   queueId: number | null | undefined,
 ): PromiseOrDirect<string> | null {
-  if (queueId == null) return null;
+  if (queueId == null) {
+    return null;
+  }
 
   let rawCache = compiledSharedOptions[$$cache];
   if (!rawCache) {

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -1,8 +1,16 @@
 import { Pool, PoolClient } from "pg";
 
-import { AddJobFunction, Job, JobHelpers, WithPgClient } from "./interfaces";
+import {
+  AddJobFunction,
+  Job,
+  JobHelpers,
+  WithPgClient,
+  PromiseOrDirect,
+} from "./interfaces";
 import { CompiledSharedOptions } from "./lib";
 import { Logger } from "./logger";
+import defer, { Deferred } from "./deferred";
+import { getQueueNames } from "./sql/getQueueNames";
 
 export function makeAddJob(
   compiledSharedOptions: CompiledSharedOptions,
@@ -56,6 +64,106 @@ export function makeAddJob(
   };
 }
 
+const $$cache = Symbol("queueNameById");
+const $$nextBatch = Symbol("pendingQueueIds");
+function getQueueName(
+  compiledSharedOptions: CompiledSharedOptions & {
+    [$$cache]?: Record<number, string | Deferred<string> | undefined>;
+    [$$nextBatch]?: number[];
+  },
+  withPgClient: WithPgClient,
+  queueId: number | null | undefined,
+): PromiseOrDirect<string> | null {
+  if (queueId == null) return null;
+
+  let rawCache = compiledSharedOptions[$$cache];
+  if (!rawCache) {
+    rawCache = compiledSharedOptions[$$cache] = Object.create(null) as Record<
+      number,
+      string | Deferred<string> | undefined
+    >;
+  }
+
+  // Appease TypeScript; this is not null
+  const cache = rawCache;
+
+  const existing = cache[queueId];
+  if (existing !== undefined) {
+    return existing;
+  }
+
+  let nextBatch = compiledSharedOptions[$$nextBatch];
+
+  // Not currently requested; queue us (and don't queue us again)
+  const promise = defer<string>();
+  cache[queueId] = promise;
+
+  if (nextBatch) {
+    // Already scheduled; add us to the next batch
+    nextBatch.push(queueId);
+  } else {
+    // Need to create the batch
+    nextBatch = compiledSharedOptions[$$nextBatch] = [];
+    nextBatch.push(queueId);
+
+    // Appease TypeScript; this is not null
+    const queueIds = nextBatch;
+
+    // Schedule the batch to run
+    setTimeout(() => {
+      // Allow another batch to start processing
+      compiledSharedOptions[$$nextBatch] = undefined;
+
+      // Get this batches names
+      getQueueNames(compiledSharedOptions, withPgClient, queueIds)
+        .then(
+          (names) => {
+            //assert.equal(queueIds.length, names.length);
+            for (let i = 0, l = queueIds.length; i < l; i++) {
+              const queueId = queueIds[i];
+              const name = names[i];
+              const cached = cache[queueId];
+              if (typeof cached === "object") {
+                // It's a deferred; need to resolve/reject
+                if (name != null) {
+                  cached.resolve(name);
+                  cache[queueId] = name;
+                } else {
+                  cached.reject(
+                    new Error(`Queue with id '${queueId}' not found`),
+                  );
+                  // Try again
+                  cache[queueId] = undefined;
+                }
+              } else {
+                // It's already cached... but we got it again?!
+                if (name != null) {
+                  cache[queueId] = name;
+                } else {
+                  // Try again
+                  cache[queueId] = undefined;
+                }
+              }
+            }
+          },
+          (e) => {
+            // An error occurred; reject all the deferreds but allow them to run again
+            for (const queueId of queueIds) {
+              (cache[queueId] as Deferred<string>).reject(e);
+              // Retry next time
+              cache[queueId] = undefined;
+            }
+          },
+        )
+        .catch((e) => {
+          // This should never happen
+          console.error(`Graphile Worker Internal Error`, e);
+        });
+    }, compiledSharedOptions.resolvedPreset.worker.getQueueNameBatchDelay ?? 50);
+  }
+  return promise;
+}
+
 export function makeJobHelpers(
   compiledSharedOptions: CompiledSharedOptions,
   job: Job,
@@ -78,6 +186,9 @@ export function makeJobHelpers(
   const helpers: JobHelpers = {
     abortSignal,
     job,
+    getQueueName(queueId = job.job_queue_id) {
+      return getQueueName(compiledSharedOptions, withPgClient, queueId);
+    },
     logger,
     withPgClient,
     query: (queryText, values) =>

--- a/src/index.ts
+++ b/src/index.ts
@@ -140,6 +140,15 @@ declare global {
       maxResetLockedInterval?: number;
 
       /**
+       * **Experimental**
+       *
+       * When getting a queue name in a job, we batch calls for efficiency. By
+       * default we do this over a 50ms window; increase this for greater efficiency,
+       * reduce this to reduce the latency for getting an individual queue name.
+       */
+      getQueueNameBatchDelay?: number;
+
+      /**
        * A Logger instance.
        */
       logger?: Logger;

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -526,9 +526,13 @@ export interface TaskSpec {
 }
 
 /** Equivalent of graphile_worker.job_spec DB type */
-export interface DbJobSpec {
-  identifier: string;
-  payload?: Record<string, any>;
+export interface DbJobSpec<
+  TIdentifier extends keyof GraphileWorker.Tasks | (string & {}) = string,
+> {
+  identifier: TIdentifier;
+  payload: TIdentifier extends keyof GraphileWorker.Tasks
+    ? GraphileWorker.Tasks[TIdentifier]
+    : unknown;
   queue_name?: string | null;
   run_at?: string | null;
   max_attempts?: number | null;

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -91,6 +91,12 @@ export interface JobHelpers extends Helpers {
   job: Job;
 
   /**
+   * Get the queue name of the give queue ID (or the currently executing job if
+   * no queue id is specified).
+   */
+  getQueueName(queueId?: number | null): PromiseOrDirect<string | null>;
+
+  /**
    * A shorthand for running an SQL query within the job.
    */
   query<R extends QueryResultRow>(

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -525,6 +525,18 @@ export interface TaskSpec {
   flags?: string[];
 }
 
+/** Equivalent of graphile_worker.job_spec DB type */
+export interface DbJobSpec {
+  identifier: string;
+  payload?: Record<string, any>;
+  queue_name?: string | null;
+  run_at?: string | null;
+  max_attempts?: number | null;
+  job_key?: string | null;
+  priority?: number | null;
+  flags?: string[] | null;
+}
+
 export type ForbiddenFlagsFn = () => null | string[] | Promise<null | string[]>;
 
 /**

--- a/src/sql/getQueueNames.ts
+++ b/src/sql/getQueueNames.ts
@@ -1,0 +1,38 @@
+import { WithPgClient } from "../interfaces";
+import { CompiledSharedOptions } from "../lib";
+
+export async function getQueueNames(
+  compiledSharedOptions: CompiledSharedOptions,
+  withPgClient: WithPgClient,
+  queueIds: number[],
+): Promise<ReadonlyArray<string | null>> {
+  const {
+    escapedWorkerSchema,
+    workerSchema,
+    resolvedPreset: {
+      worker: { preparedStatements },
+    },
+  } = compiledSharedOptions;
+  const text = `\
+select id, queue_name
+from ${escapedWorkerSchema}._private_job_queues as job_queues
+where id = any($1::int[]);`;
+  const values = [queueIds];
+  const name = !preparedStatements
+    ? undefined
+    : `get_queue_names/${workerSchema}`;
+
+  const { rows } = await withPgClient((client) =>
+    client.query<{ id: number; queue_name: string }>({
+      text,
+      values,
+      name,
+    }),
+  );
+  // Turn O(M * N) for nested loop into O(M + N) for hash table lookup
+  const lookup = Object.create(null);
+  for (const row of rows) {
+    lookup[row.id] = row.queue_name;
+  }
+  return queueIds.map((id) => lookup[id] ?? null);
+}

--- a/website/docs/tasks.md
+++ b/website/docs/tasks.md
@@ -34,6 +34,8 @@ Each task function is passed two arguments:
     tracing/debugging
   - `job` &mdash; the whole job (including `uuid`, `attempts`, etc) &mdash; you
     shouldn't need this
+  - `getQueueName()` &mdash; get the name of the queue the job is in (may or may
+    not return a promise - recommend you always `await` it)
   - `abortSignal` &mdash; could be an `AbortSignal` or `undefined`; if set, use
     this to abort your task early on graceful shutdown (can be passed to a
     number of asynchronous Node.js methods)


### PR DESCRIPTION
## Description

Since we split the queue name into a separate table in 0.14, there hasn't been a "blessed" way to get the queue name of the currently executing job. This was an oversight, we weren't expecting this value to be needed but it can be useful if you want to queue another job into the same queue.

This PR adds a `getQueueName()` helper to `helpers`; e.g.

```ts
const task: Task = async (payload, helpers) => {
  const queueName = await helpers.getQueueName();
  console.log({queueName});
};
```

(This isn't an automatic property of `Job` because retrieving it has a performance overhead and it's not generally needed.)

Fixes #423 

## Performance impact

Basically none unless you use it.

## Security impact

None known.

## Checklist

- [x] My code matches the project's code style and `yarn lint:fix` passes.
- [x] I've added tests for the new feature, and `yarn test` passes.
- [x] I have detailed the new feature in the relevant documentation.
- [x] I have added this feature to 'Pending' in the `RELEASE_NOTES.md` file (if one exists).
- [ ] ~~If this is a breaking change I've explained why.~~

<!-- For some Graphile projects the documentation is the README.md file, for
      others please see https://github.com/graphile/graphile.github.io -->
