### PR TITLE
Add '--disable-proto=delete' to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,7 @@ env:
   PGPASSWORD: postgres
   PGHOST: "127.0.0.1"
   PGPORT: 5432
+  NODE_OPTIONS: "--disable-proto=delete"
 
 jobs:
   test:


### PR DESCRIPTION
## Description

Fixes #419

## Performance impact

None

## Security impact

Helps people who want to improve security by disabling `__proto__` on objects.

## Checklist

- [x] My code matches the project's code style and `yarn lint:fix` passes.
- [x] I've added tests for the new feature, and `yarn test` passes.
- [ ] ~~I have detailed the new feature in the relevant documentation.~~
- [ ] ~~I have added this feature to 'Pending' in the `RELEASE_NOTES.md` file (if one exists).~~
- [ ] ~~If this is a breaking change I've explained why.~~

<!-- For some Graphile projects the documentation is the README.md file, for
      others please see https://github.com/graphile/graphile.github.io -->
