### PR TITLE
Give various SQL commands the ability to auto-retry on serialization failure/deadlock

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -28,6 +28,9 @@ Read more:
 - Fix logger scope for workers - thanks @jcapcik
 - Add `helpers.getQueueName()` to retrieve the queue name of the currently
   running job
+- Automatically retry certain internal operations on serialization failure or
+  deadlock detection (useful if you have changed your
+  `default_transaction_isolation` to `serializable` or similar)
 
 ## v0.16.1
 

--- a/__tests__/getTasks.test.ts
+++ b/__tests__/getTasks.test.ts
@@ -5,6 +5,7 @@ import {
 } from "../src";
 import { getTasks } from "../src/getTasks";
 import { makeJobHelpers, makeWithPgClientFromClient } from "../src/helpers";
+import { makeEnhancedWithPgClient } from "../src/lib";
 import { makeMockJob, withPgClient } from "./helpers";
 
 const options: WorkerSharedOptions = {};
@@ -28,7 +29,9 @@ Array [
         compiledSharedOptions,
         makeMockJob("would you like"),
         {
-          withPgClient: makeWithPgClientFromClient(client),
+          withPgClient: makeEnhancedWithPgClient(
+            makeWithPgClientFromClient(client),
+          ),
           abortSignal: undefined,
         },
       );
@@ -62,7 +65,9 @@ Array [
         compiledSharedOptions,
         makeMockJob("task1"),
         {
-          withPgClient: makeWithPgClientFromClient(client),
+          withPgClient: makeEnhancedWithPgClient(
+            makeWithPgClientFromClient(client),
+          ),
           abortSignal: undefined,
         },
       );
@@ -90,7 +95,9 @@ Array [
         compiledSharedOptions,
         makeMockJob("task1"),
         {
-          withPgClient: makeWithPgClientFromClient(client),
+          withPgClient: makeEnhancedWithPgClient(
+            makeWithPgClientFromClient(client),
+          ),
           abortSignal: undefined,
         },
       );
@@ -117,7 +124,9 @@ Array [
 `);
 
       const helpers = makeJobHelpers(compiledSharedOptions, makeMockJob("t1"), {
-        withPgClient: makeWithPgClientFromClient(client),
+        withPgClient: makeEnhancedWithPgClient(
+          makeWithPgClientFromClient(client),
+        ),
         abortSignal: undefined,
       });
       expect(await tasks.t1!(helpers.job.payload, helpers)).toEqual(
@@ -145,7 +154,9 @@ Array [
 `);
 
       const helpers = makeJobHelpers(compiledSharedOptions, makeMockJob("t1"), {
-        withPgClient: makeWithPgClientFromClient(client),
+        withPgClient: makeEnhancedWithPgClient(
+          makeWithPgClientFromClient(client),
+        ),
         abortSignal: undefined,
       });
       expect(await tasks.t1!(helpers.job.payload, helpers)).toEqual(
@@ -177,7 +188,9 @@ Array [
         compiledSharedOptions,
         makeMockJob("would you like"),
         {
-          withPgClient: makeWithPgClientFromClient(client),
+          withPgClient: makeEnhancedWithPgClient(
+            makeWithPgClientFromClient(client),
+          ),
           abortSignal: undefined,
         },
       );
@@ -208,7 +221,9 @@ Array [
         compiledSharedOptions,
         makeMockJob("task1"),
         {
-          withPgClient: makeWithPgClientFromClient(client),
+          withPgClient: makeEnhancedWithPgClient(
+            makeWithPgClientFromClient(client),
+          ),
           abortSignal: undefined,
         },
       );
@@ -233,7 +248,9 @@ Array [
 `);
 
       const helpers = makeJobHelpers(compiledSharedOptions, makeMockJob("t1"), {
-        withPgClient: makeWithPgClientFromClient(client),
+        withPgClient: makeEnhancedWithPgClient(
+          makeWithPgClientFromClient(client),
+        ),
         abortSignal: undefined,
       });
       expect(await tasks.t1!(helpers.job.payload, helpers)).toEqual(

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -3,6 +3,7 @@ import { Pool, PoolClient } from "pg";
 import defer, { Deferred } from "./deferred";
 import {
   AddJobFunction,
+  EnhancedWithPgClient,
   Job,
   JobHelpers,
   PromiseOrDirect,
@@ -71,7 +72,7 @@ function getQueueName(
     [$$cache]?: Record<number, string | Deferred<string> | undefined>;
     [$$nextBatch]?: number[];
   },
-  withPgClient: WithPgClient,
+  withPgClient: EnhancedWithPgClient,
   queueId: number | null | undefined,
 ): PromiseOrDirect<string> | null {
   if (queueId == null) {
@@ -174,7 +175,7 @@ export function makeJobHelpers(
     abortSignal,
     logger: overrideLogger,
   }: {
-    withPgClient: WithPgClient;
+    withPgClient: EnhancedWithPgClient;
     abortSignal: AbortSignal | undefined;
     logger?: Logger;
   },

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -32,9 +32,16 @@ import type { Signal } from "./signals";
  * - runner: the thing responsible for building a task list and running a worker pool for said list
  */
 
-export type WithPgClient = <T = void>(
-  callback: (pgClient: PoolClient) => Promise<T>,
-) => Promise<T>;
+export interface WithPgClient {
+  <T = void>(callback: (pgClient: PoolClient) => Promise<T>): Promise<T>;
+}
+
+export interface EnhancedWithPgClient extends WithPgClient {
+  /** **Experimental**; see https://github.com/graphile/worker/issues/387 */
+  withRetries: <T = void>(
+    callback: (pgClient: PoolClient) => Promise<T>,
+  ) => Promise<T>;
+}
 
 /**
  * The `addJob` interface is implemented in many places in the library, all

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -483,10 +483,8 @@ export function tryParseJson<T = object>(
 
 /** @see {@link https://www.postgresql.org/docs/current/mvcc-serialization-failure-handling.html} */
 const RETRYABLE_ERROR_CODES = [
-  "40001",
-  "serialization_failure",
-  "40P01",
-  "deadlock_detected",
+  "40001", // serialization_failure
+  "40P01", // deadlock_detected
 ];
 const MAX_RETRIES = 100;
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -13,7 +13,6 @@ import {
   Job,
   RunOnceOptions,
   TaskList,
-  WithPgClient,
   WorkerEventMap,
   WorkerEvents,
   WorkerPool,

--- a/src/main.ts
+++ b/src/main.ts
@@ -9,6 +9,7 @@ import {
   makeWithPgClientFromPool,
 } from "./helpers";
 import {
+  EnhancedWithPgClient,
   Job,
   RunOnceOptions,
   TaskList,
@@ -20,6 +21,7 @@ import {
 } from "./interfaces";
 import {
   CompiledSharedOptions,
+  makeEnhancedWithPgClient,
   processSharedOptions,
   tryParseJson,
 } from "./lib";
@@ -230,7 +232,9 @@ export function runTaskListInternal(
       worker: { minResetLockedInterval, maxResetLockedInterval },
     },
   } = compiledSharedOptions;
-  const withPgClient = makeWithPgClientFromPool(pgPool);
+  const withPgClient = makeEnhancedWithPgClient(
+    makeWithPgClientFromPool(pgPool),
+  );
   const workerPool = _runTaskList(compiledSharedOptions, tasks, withPgClient, {
     continuous: true,
     onTerminate() {
@@ -494,7 +498,7 @@ export function _runTaskList(
     RunOnceOptions | WorkerPoolOptions
   >,
   tasks: TaskList,
-  withPgClient: WithPgClient,
+  withPgClient: EnhancedWithPgClient,
   options: {
     concurrency?: number | undefined;
     noHandleSignals?: boolean | undefined;
@@ -855,7 +859,9 @@ export const runTaskListOnce = (
   tasks: TaskList,
   client: PoolClient,
 ) => {
-  const withPgClient = makeWithPgClientFromClient(client);
+  const withPgClient = makeEnhancedWithPgClient(
+    makeWithPgClientFromClient(client),
+  );
   const compiledSharedOptions = processSharedOptions(options);
 
   const pool = _runTaskList(compiledSharedOptions, tasks, withPgClient, {

--- a/src/sql/getJob.ts
+++ b/src/sql/getJob.ts
@@ -1,4 +1,4 @@
-import { DbJob, Job, TaskList, WithPgClient } from "../interfaces";
+import { DbJob, EnhancedWithPgClient, Job, TaskList } from "../interfaces";
 import { CompiledSharedOptions } from "../lib";
 import { getTaskDetails } from "../taskIdentifiers";
 
@@ -13,7 +13,7 @@ export function isPromise<T>(t: T | Promise<T>): t is Promise<T> {
 
 export async function getJob(
   compiledSharedOptions: CompiledSharedOptions,
-  withPgClient: WithPgClient,
+  withPgClient: EnhancedWithPgClient,
   tasks: TaskList,
   workerId: string,
   flagsToSkip: string[] | null,
@@ -183,7 +183,7 @@ with j as (
 
   const {
     rows: [jobRow],
-  } = await withPgClient((client) =>
+  } = await withPgClient.withRetries((client) =>
     client.query<DbJob>({
       text,
       values,

--- a/src/sql/getQueueNames.ts
+++ b/src/sql/getQueueNames.ts
@@ -1,9 +1,9 @@
-import { WithPgClient } from "../interfaces";
+import { EnhancedWithPgClient } from "../interfaces";
 import { CompiledSharedOptions } from "../lib";
 
 export async function getQueueNames(
   compiledSharedOptions: CompiledSharedOptions,
-  withPgClient: WithPgClient,
+  withPgClient: EnhancedWithPgClient,
   queueIds: number[],
 ): Promise<ReadonlyArray<string | null>> {
   const {
@@ -22,7 +22,7 @@ where id = any($1::int[]);`;
     ? undefined
     : `get_queue_names/${workerSchema}`;
 
-  const { rows } = await withPgClient((client) =>
+  const { rows } = await withPgClient.withRetries((client) =>
     client.query<{ id: number; queue_name: string }>({
       text,
       values,

--- a/src/sql/resetLockedAt.ts
+++ b/src/sql/resetLockedAt.ts
@@ -1,9 +1,9 @@
-import { WithPgClient } from "../interfaces";
+import { EnhancedWithPgClient } from "../interfaces";
 import { CompiledSharedOptions } from "../lib";
 
 export async function resetLockedAt(
   compiledSharedOptions: CompiledSharedOptions,
-  withPgClient: WithPgClient,
+  withPgClient: EnhancedWithPgClient,
 ): Promise<void> {
   const {
     escapedWorkerSchema,
@@ -15,7 +15,7 @@ export async function resetLockedAt(
 
   const now = useNodeTime ? "$1::timestamptz" : "now()";
 
-  await withPgClient((client) =>
+  await withPgClient.withRetries((client) =>
     client.query({
       text: `\
 with j as (

--- a/src/taskIdentifiers.ts
+++ b/src/taskIdentifiers.ts
@@ -1,6 +1,6 @@
 import * as assert from "assert";
 
-import { EnhancedWithPgClient, TaskList, WithPgClient } from "./interfaces";
+import { EnhancedWithPgClient, TaskList } from "./interfaces";
 import { CompiledSharedOptions } from "./lib";
 
 export interface SupportedTaskIdentifierByTaskId {

--- a/src/taskIdentifiers.ts
+++ b/src/taskIdentifiers.ts
@@ -1,6 +1,6 @@
 import * as assert from "assert";
 
-import { TaskList, WithPgClient } from "./interfaces";
+import { EnhancedWithPgClient, TaskList, WithPgClient } from "./interfaces";
 import { CompiledSharedOptions } from "./lib";
 
 export interface SupportedTaskIdentifierByTaskId {
@@ -20,7 +20,7 @@ const cacheByOptions = new Map<CompiledSharedOptions, Cache>();
 
 export function getTaskDetails(
   compiledSharedOptions: CompiledSharedOptions,
-  withPgClient: WithPgClient,
+  withPgClient: EnhancedWithPgClient,
   tasks: TaskList,
 ): TaskDetails | Promise<TaskDetails> {
   let cache = cacheByOptions.get(compiledSharedOptions);
@@ -41,7 +41,7 @@ export function getTaskDetails(
     assert.ok(supportedTaskNames.length, "No runnable tasks!");
     cache.lastStr = str;
     cache.lastDigest = (async () => {
-      const { rows } = await withPgClient(async (client) => {
+      const { rows } = await withPgClient.withRetries(async (client) => {
         await client.query({
           text: `insert into ${escapedWorkerSchema}._private_tasks as tasks (identifier) select unnest($1::text[]) on conflict do nothing`,
           values: [supportedTaskNames],
@@ -75,7 +75,7 @@ export function getTaskDetails(
 
 export function getSupportedTaskIdentifierByTaskId(
   compiledSharedOptions: CompiledSharedOptions,
-  withPgClient: WithPgClient,
+  withPgClient: EnhancedWithPgClient,
   tasks: TaskList,
 ): SupportedTaskIdentifierByTaskId | Promise<SupportedTaskIdentifierByTaskId> {
   const p = getTaskDetails(compiledSharedOptions, withPgClient, tasks);
@@ -88,7 +88,7 @@ export function getSupportedTaskIdentifierByTaskId(
 
 export function getSupportedTaskIds(
   compiledSharedOptions: CompiledSharedOptions,
-  withPgClient: WithPgClient,
+  withPgClient: EnhancedWithPgClient,
   tasks: TaskList,
 ): number[] | Promise<number[]> {
   const p = getTaskDetails(compiledSharedOptions, withPgClient, tasks);

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -8,7 +8,6 @@ import {
   Job,
   PromiseOrDirect,
   TaskList,
-  WithPgClient,
   Worker,
   WorkerPool,
   WorkerSharedOptions,

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -4,6 +4,7 @@ import { randomBytes } from "crypto";
 import deferred from "./deferred";
 import { makeJobHelpers } from "./helpers";
 import {
+  EnhancedWithPgClient,
   Job,
   PromiseOrDirect,
   TaskList,
@@ -21,7 +22,7 @@ export function makeNewWorker(
   compiledSharedOptions: CompiledSharedOptions<WorkerSharedOptions>,
   params: {
     tasks: TaskList;
-    withPgClient: WithPgClient;
+    withPgClient: EnhancedWithPgClient;
     continuous: boolean;
     abortSignal: AbortSignal;
     workerPool: WorkerPool;


### PR DESCRIPTION
## Description

Fixes #387

## Performance impact

Marginal.

## Security impact

Potentially if someone can trigger deadlocks or serialization failures then this code will multiply the impact of such events. That said; I'm more concerned about the reverse (the current status) whereby it's possible for jobs to execute but fail to be released and thus be retried again later.

## Checklist

- [x] My code matches the project's code style and `yarn lint:fix` passes.
- [ ] ~~I've added tests for the new feature, and `yarn test` passes.~~
- [ ] ~~I have detailed the new feature in the relevant documentation.~~
- [x] I have added this feature to 'Pending' in the `RELEASE_NOTES.md` file (if one exists).
- [ ] ~~If this is a breaking change I've explained why.~~

<!-- For some Graphile projects the documentation is the README.md file, for
      others please see https://github.com/graphile/graphile.github.io -->
