### PR TITLE
docs: fix link to blog post

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -40,7 +40,7 @@ Read more:
 ## v0.16.0
 
 _There's a breakdown of these release notes available on the new
-[Worker Website](https://worker.graphile.org/news/2023-12-01-016-release), where
+[Worker Website](https://worker.graphile.org/news/2023-12-11-016-release), where
 we go into more detail about the headline features._
 
 **THIS RELEASE INTRODUCES SIGNIFICANT CHANGES**, in preparation for moving


### PR DESCRIPTION
## Description

The current link 404s.

## Performance impact

N/A - docs only

## Security impact

N/A - docs only

## Checklist

<!-- If this PR is work in progress, please open it as a "Draft PR". -->
<!-- To tick a checkbox, change it from `[ ]` to `[x]` -->

- [x] My code matches the project's code style and `yarn lint:fix` passes.
- [x] I've added tests for the new feature, and `yarn test` passes.
- [x] I have detailed the new feature in the relevant documentation.
- [x] I have added this feature to 'Pending' in the `RELEASE_NOTES.md` file (if one exists).
- [x] If this is a breaking change I've explained why.

<!-- For some Graphile projects the documentation is the README.md file, for
      others please see https://github.com/graphile/graphile.github.io -->
