### PR TITLE
fix: add EHOSTUNREACH to list of recoverable errors

### DIFF
--- a/src/lib.ts
+++ b/src/lib.ts
@@ -486,6 +486,7 @@ const RETRYABLE_ERROR_CODES = [
   { code: "40001", backoffMS: 50 }, // serialization_failure
   { code: "40P01", backoffMS: 50 }, // deadlock_detected
   { code: "57P03", backoffMS: 3000 }, // cannot_connect_now
+  { code: "EHOSTUNREACH", backoffMS: 3000 }, // no connection to the server
 ];
 const MAX_RETRIES = 100;
 


### PR DESCRIPTION

## Description

dds EHOSTUNREACH to list of recoverable errors-

i am not sure yet what caused this error to appear, but since patching the new error code we had another failure and it was just a one-off error - the next retry worked again.

## Performance impact

none

## Security impact

none

## Checklist

<!-- If this PR is work in progress, please open it as a "Draft PR". -->
<!-- To tick a checkbox, change it from `[ ]` to `[x]` -->

- [x] My code matches the project's code style and `yarn lint:fix` passes.
- [ ] I've added tests for the new feature, and `yarn test` passes.
- [ ] I have detailed the new feature in the relevant documentation.
- [ ] I have added this feature to 'Pending' in the `RELEASE_NOTES.md` file (if one exists).
- [ ] If this is a breaking change I've explained why.

<!-- For some Graphile projects the documentation is the README.md file, for
      others please see https://github.com/graphile/graphile.github.io -->
