### PR TITLE
Handle errors on stdout/stderr

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -23,6 +23,8 @@ Read more:
 
 - Fix bug in `workerUtils.cleanup()` where queues would not be cleaned up if
   there existed any job that was not in a queue
+- If errors happen writing to stdout/stderr (e.g. `SIGPIPE`), we'll trigger a
+  graceful shutdown (and swallow further errors)
 
 ## v0.16.5
 

--- a/src/signals.ts
+++ b/src/signals.ts
@@ -2,7 +2,7 @@ export type Signal =
   | "SIGUSR2"
   | "SIGINT"
   | "SIGTERM"
-  // | "SIGPIPE"
+  | "SIGPIPE"
   | "SIGHUP"
   | "SIGABRT";
 


### PR DESCRIPTION
Fixes #440

Specifically if we have any issues writing to stdout/stderr we trigger a graceful shutdown (and then ignore any further stdout/stderr errors because we can't really do anything about them).