### PR TITLE
Docs: Clarify usage of queueName in addJob()

### DIFF
--- a/website/docs/library/add-job.md
+++ b/website/docs/library/add-job.md
@@ -27,7 +27,8 @@ The `addJob` arguments are as follows:
 - `payload`: an optional JSON-compatible object to give the task more context on
   what it is doing, or a list of these objects in &ldquo;batch job&rdquo; mode
 - `options`: an optional object specifying:
-  - `queueName`: if you want certain tasks to run one at a time, add them to the same named queue (defaults to null)
+  - `queueName`: if you want certain jobs to run one at a time, add them to the
+    same named queue (defaults to null which enables parallelization)
   - `runAt`: a `Date` to schedule this task to run in the future
   - `maxAttempts`: the maximum number of attempts we'll give the job
     (Default: 25)

--- a/website/docs/library/add-job.md
+++ b/website/docs/library/add-job.md
@@ -14,13 +14,20 @@ parameter describing how to connect to the database.
 
 :::
 
+:::note
+
+The `addJob()` JavaScript method simply defers to the underlying [`addJob`](../sql-add-job.md) SQL 
+function.
+
+:::
+
 The `addJob` arguments are as follows:
 
 - `identifier`: the name of the task to be executed
 - `payload`: an optional JSON-compatible object to give the task more context on
   what it is doing, or a list of these objects in &ldquo;batch job&rdquo; mode
 - `options`: an optional object specifying:
-  - `queueName`: the queue to run this task under
+  - `queueName`: if you want certain tasks to run one at a time, add them to the same named queue (defaults to null)
   - `runAt`: a `Date` to schedule this task to run in the future
   - `maxAttempts`: the maximum number of attempts we'll give the job
     (Default: 25)

--- a/website/docs/library/add-job.md
+++ b/website/docs/library/add-job.md
@@ -16,8 +16,8 @@ parameter describing how to connect to the database.
 
 :::note
 
-The `addJob()` JavaScript method simply defers to the underlying [`addJob`](../sql-add-job.md) SQL 
-function.
+The `addJob()` JavaScript method simply defers to the underlying
+[`addJob`](../sql-add-job.md) SQL function.
 
 :::
 


### PR DESCRIPTION
## Description

Specifying a `queueName` argument in `addJob()` (library mode) will cause jobs to be processed sequentially, one by one. This happens even if you set a value for `concurrency` in `RunnerOptions`.  The documentation for adding jobs via SQL explicitly clarifies this behavior, but it's not readily apparent when using `queueName` in library mode.

## Performance impact

None

## Security impact

None

## Checklist

- [x] My code matches the project's code style and `yarn lint:fix` passes.
- [x] I've added tests for the new feature, and `yarn test` passes.
- [x] I have detailed the new feature in the relevant documentation.
- [x] I have added this feature to 'Pending' in the `RELEASE_NOTES.md` file (if one exists).
- [x] If this is a breaking change I've explained why.

<!-- For some Graphile projects the documentation is the README.md file, for
      others please see https://github.com/graphile/graphile.github.io -->
