### PR TITLE
Use poolId rather than workerId when locking/unlocking jobs

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -19,6 +19,13 @@ to make sure the system as a whole remains consistent.
 Read more:
 [Worker Pro Migration](https://worker.graphile.org/docs/pro/migration).
 
+## Pending
+
+- BREAKING: Jobs and queues are now `locked_by` their `WorkerPool`'s id rather
+  than the `workerId`. Be sure to upgrade
+  [Worker Pro](https://worker.graphile.org/docs/pro) at the same time if you're
+  using it!
+
 ## v0.16.6
 
 - Fix bug in `workerUtils.cleanup()` where queues would not be cleaned up if

--- a/__tests__/main.runTaskListOnce.test.ts
+++ b/__tests__/main.runTaskListOnce.test.ts
@@ -663,7 +663,7 @@ test("runs jobs asynchronously", () =>
         expect(q.job_count).toEqual(1);
         expect(+q.locked_at).toBeGreaterThanOrEqual(+start);
         expect(+q.locked_at).toBeLessThanOrEqual(+new Date());
-        expect(q.locked_by).toEqual(worker.workerId);
+        expect(q.locked_by).toEqual(worker.workerPool.id);
       }
 
       jobPromise!.resolve();

--- a/__tests__/resetLockedAt.test.ts
+++ b/__tests__/resetLockedAt.test.ts
@@ -32,7 +32,7 @@ test("main will execute jobs as they come up, and exits cleanly", () =>
       `\
 update ${ESCAPED_GRAPHILE_WORKER_SCHEMA}._private_jobs as jobs
 set
-  locked_by = 'some_worker_id',
+  locked_by = 'some_pool_id',
   locked_at = now() - (
     case payload->>'id'
     when 'locked_recently' then interval '5 minutes'

--- a/__tests__/workerUtils.forceUnlockWorkers.test.ts
+++ b/__tests__/workerUtils.forceUnlockWorkers.test.ts
@@ -29,24 +29,24 @@ test("unlocks jobs for the given workers, leaves others unaffected", () =>
     });
 
     const jobs: Job[] = [];
-    const WORKER_ID_1 = "worker1";
-    const WORKER_ID_2 = "worker2";
-    const WORKER_ID_3 = "worker3";
+    const POOL_ID_1 = "pool-1";
+    const POOL_ID_2 = "pool-2";
+    const POOL_ID_3 = "pool-3";
     let a = 0;
     const date = new Date();
     const specs = [
-      [WORKER_ID_1, null],
-      [WORKER_ID_1, "test"],
-      [WORKER_ID_2, null],
-      [WORKER_ID_2, "test2"],
-      [WORKER_ID_2, "test3"],
-      [WORKER_ID_3, null],
+      [POOL_ID_1, null],
+      [POOL_ID_1, "test"],
+      [POOL_ID_2, null],
+      [POOL_ID_2, "test2"],
+      [POOL_ID_2, "test3"],
+      [POOL_ID_3, null],
       [null, null],
       [null, "test"],
       [null, "test2"],
       [null, "test3"],
     ] as const;
-    for (const [workerId, queueName] of specs) {
+    for (const [poolId, queueName] of specs) {
       date.setMinutes(date.getMinutes() - 1);
       const job = await utils.addJob(
         "job3",
@@ -58,7 +58,7 @@ test("unlocks jobs for the given workers, leaves others unaffected", () =>
 update ${ESCAPED_GRAPHILE_WORKER_SCHEMA}._private_jobs as jobs
 set locked_at = $1, locked_by = $2
 where id = $3`,
-        [workerId ? date.toISOString() : null, workerId, job.id],
+        [poolId ? date.toISOString() : null, poolId, job.id],
       );
       jobs.push(job);
     }
@@ -69,7 +69,7 @@ set locked_at = jobs.locked_at, locked_by = jobs.locked_by
 from ${ESCAPED_GRAPHILE_WORKER_SCHEMA}._private_jobs as jobs
 where jobs.job_queue_id = job_queues.id;`,
     );
-    await utils.forceUnlockWorkers([WORKER_ID_2, WORKER_ID_3]);
+    await utils.forceUnlockWorkers([POOL_ID_2, POOL_ID_3]);
 
     const remaining = await getJobs(pgClient);
     remaining.sort((a, z) => Number(a.id) - Number(z.id));
@@ -79,7 +79,7 @@ where jobs.job_queue_id = job_queues.id;`,
       const job = jobs[i];
       const updatedJob = remaining[i];
       expect(updatedJob.id).toEqual(job.id);
-      if (spec[0] === WORKER_ID_2 || spec[0] === WORKER_ID_3) {
+      if (spec[0] === POOL_ID_2 || spec[0] === POOL_ID_3) {
         expect(updatedJob.locked_by).toBeNull();
         expect(updatedJob.locked_at).toBeNull();
       } else if (spec[0]) {
@@ -97,7 +97,7 @@ where jobs.job_queue_id = job_queues.id;`,
     expect(lockedQueues).toEqual([
       expect.objectContaining({
         queue_name: "test",
-        locked_by: WORKER_ID_1,
+        locked_by: POOL_ID_1,
       }),
     ]);
   }));

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -1157,3 +1157,7 @@ export interface WorkerPluginContext {
   hooks: AsyncHooks<GraphileConfig.WorkerHooks>;
   resolvedPreset: ResolvedWorkerPreset;
 }
+export type GetJobFunction = (
+  workerId: string,
+  flagsToSkip: string[] | null,
+) => Promise<Job | undefined>;

--- a/src/main.ts
+++ b/src/main.ts
@@ -687,7 +687,7 @@ export function _runTaskList(
           const cancelledJobs = await failJobs(
             compiledSharedOptions,
             withPgClient,
-            workerIds,
+            workerPool.id,
             jobsToRelease,
             message,
           );
@@ -761,7 +761,7 @@ export function _runTaskList(
           const cancelledJobs = await failJobs(
             compiledSharedOptions,
             withPgClient,
-            workerIds,
+            workerPool.id,
             jobsInProgress,
             message,
           );

--- a/src/sql/completeJob.ts
+++ b/src/sql/completeJob.ts
@@ -4,7 +4,7 @@ import { CompiledSharedOptions } from "../lib";
 export async function completeJob(
   compiledSharedOptions: CompiledSharedOptions,
   withPgClient: EnhancedWithPgClient,
-  workerId: string,
+  poolId: string,
   job: DbJob,
 ): Promise<void> {
   const {
@@ -29,7 +29,7 @@ update ${escapedWorkerSchema}._private_job_queues as job_queues
 set locked_by = null, locked_at = null
 from j
 where job_queues.id = j.job_queue_id and job_queues.locked_by = $2::text;`,
-        values: [job.id, workerId],
+        values: [job.id, poolId],
         name: !preparedStatements
           ? undefined
           : `complete_job_q/${workerSchema}`,

--- a/src/sql/failJob.ts
+++ b/src/sql/failJob.ts
@@ -4,7 +4,7 @@ import { CompiledSharedOptions } from "../lib";
 export async function failJob(
   compiledSharedOptions: CompiledSharedOptions,
   withPgClient: EnhancedWithPgClient,
-  workerId: string,
+  poolId: string,
   job: DbJob,
   message: string,
   replacementPayload: undefined | unknown[],
@@ -40,7 +40,7 @@ where job_queues.id = j.job_queue_id and job_queues.locked_by = $3::text;`,
         values: [
           job.id,
           message,
-          workerId,
+          poolId,
           replacementPayload != null
             ? JSON.stringify(replacementPayload)
             : null,
@@ -63,7 +63,7 @@ where id = $1::bigint and locked_by = $3::text;`,
         values: [
           job.id,
           message,
-          workerId,
+          poolId,
           replacementPayload != null
             ? JSON.stringify(replacementPayload)
             : null,

--- a/src/sql/getJob.ts
+++ b/src/sql/getJob.ts
@@ -15,7 +15,7 @@ export async function getJob(
   compiledSharedOptions: CompiledSharedOptions,
   withPgClient: EnhancedWithPgClient,
   tasks: TaskList,
-  workerId: string,
+  poolId: string,
   flagsToSkip: string[] | null,
 ): Promise<Job | undefined> {
   const {
@@ -172,7 +172,7 @@ with j as (
   // TODO: breaking change; change this to more optimal:
   // `RETURNING id, job_queue_id, task_id, payload`,
   const values = [
-    workerId,
+    poolId,
     taskDetails.taskIds,
     ...(hasFlags ? [flagsToSkip!] : []),
     ...(useNodeTime ? [new Date().toISOString()] : []),

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -169,7 +169,7 @@ export function makeNewWorker(
       }
 
       events.emit("worker:getJob:start", { worker });
-      const jobRow = await getJob(workerId, flagsToSkip);
+      const jobRow = await getJob(workerPool.id, flagsToSkip);
 
       // `doNext` cannot be executed concurrently, so we know this is safe.
       // eslint-disable-next-line require-atomic-updates
@@ -339,7 +339,7 @@ export function makeNewWorker(
         await failJob(
           compiledSharedOptions,
           withPgClient,
-          workerId,
+          workerPool.id,
           job,
           message,
           // "Batch jobs": copy through only the unsuccessful parts of the payload
@@ -368,7 +368,12 @@ export function makeNewWorker(
           );
         }
 
-        await completeJob(compiledSharedOptions, withPgClient, workerId, job);
+        await completeJob(
+          compiledSharedOptions,
+          withPgClient,
+          workerPool.id,
+          job,
+        );
       }
       events.emit("job:complete", { worker, job, error: err });
     } catch (fatalError) {

--- a/website/docs/jobs-view.md
+++ b/website/docs/jobs-view.md
@@ -49,7 +49,7 @@ performance issues!
 - `updated_at` - when the job was last updated
 - `key` - the `job_key` of the job, if any
 - `locked_at` - when the job was locked, if locked
-- `locked_by` - the worker id that the job was locked by, if locked
+- `locked_by` - the WorkerPool id that the job was locked by, if locked
 - `revision` - the revision number of the job, bumped each time the record is
   updated
 - `flags` - the [forbidden flags](/docs/forbidden-flags) associated with this

--- a/website/docs/pro/migration.md
+++ b/website/docs/pro/migration.md
@@ -57,7 +57,7 @@ where locked_by is not null and locked_by not in (
 commit;
 ```
 
-For Graphile Worker v0.16.0+ it would be:
+For Graphile Worker v0.16.x it would be:
 
 ```sql
 begin;
@@ -70,6 +70,23 @@ update graphile_worker._private_job_queues as job_queues
 set locked_at = null, locked_by = null
 where locked_by is not null and locked_by not in (
   select worker_id from graphile_worker._private_pro_workers
+);
+commit;
+```
+
+For Graphile Worker v0.17.x+ it would be:
+
+```sql
+begin;
+update graphile_worker._private_jobs as jobs
+set locked_at = null, locked_by = null
+where locked_by is not null and locked_by not in (
+  select pool_id from graphile_worker._private_pro_pools
+);
+update graphile_worker._private_job_queues as job_queues
+set locked_at = null, locked_by = null
+where locked_by is not null and locked_by not in (
+  select pool_id from graphile_worker._private_pro_pools
 );
 commit;
 ```


### PR DESCRIPTION
## Description

Using the workerId is severely limiting, and doesn't give us many advantages. By switching to using the poolId we can lay the groundwork for batched processing of jobs.

One major issue with this is that `force_unlock_workers` is now poorly named; it should be `force_unlock_pools`.

## Performance impact

None.

## Security impact

None known.

## Checklist

- [x] My code matches the project's code style and `yarn lint:fix` passes.
- [x] I've added tests for the new feature, and `yarn test` passes.
- [x] I have detailed the new feature in the relevant documentation.
- [x] I have added this feature to 'Pending' in the `RELEASE_NOTES.md` file (if one exists).
- [x] If this is a breaking change I've explained why.

<!-- For some Graphile projects the documentation is the README.md file, for
      others please see https://github.com/graphile/graphile.github.io -->
