### PR TITLE
doc: document usage of a limited postgresql user

### DIFF
--- a/src/migrate.ts
+++ b/src/migrate.ts
@@ -34,7 +34,7 @@ export async function installSchema(
   (event as Writeable<GraphileWorker.MigrateEvent>).postgresVersion =
     await fetchAndCheckPostgresVersion(event.client);
   await hooks.process("prebootstrap", event);
-
+  // Change to this query should be reflected in website/docs/schema.md
   await event.client.query(`
     create schema if not exists ${escapedWorkerSchema};
     create table if not exists ${escapedWorkerSchema}.migrations(

--- a/website/docs/schema.md
+++ b/website/docs/schema.md
@@ -58,3 +58,19 @@ schema in which you can store additional details.
    row from your task code. This is particularly useful to keep the end user
    abreast of the progress of their various background jobs, but is also useful
    for tracking completed jobs (which Graphile Worker will delete on success).
+
+## Use a postgresql user with restricted rights
+
+If you want to use a postgresql user with restricted rights on the
+`graphile_worker` schema in your database you can use the following trick
+describe in this [issue](https://github.com/graphile/worker/issues/132). Create
+the following table as your limited user. You'll avoid the error of missing
+create right on the `graphile_worker` schema
+
+```
+create table graphile_worker.migrations(
+  id int primary key,
+  ts timestamptz default now() not null,
+  breaking bool
+);
+```

--- a/website/docs/schema.md
+++ b/website/docs/schema.md
@@ -61,16 +61,16 @@ schema in which you can store additional details.
 
 ## Use a postgresql user with restricted rights
 
-If you want to use a postgresql user with restricted rights on the
+If you want to use a PostgreSQL user with restricted rights on the
 `graphile_worker` schema in your database you can use the following trick
-describe in this [issue](https://github.com/graphile/worker/issues/132). Create
+describe in [issue #132](https://github.com/graphile/worker/issues/132). Create
 the following table as your limited user. You'll avoid the error of missing
 create right on the `graphile_worker` schema
 
-```
-create table graphile_worker.migrations(
+```sql
+create table graphile_worker.migrations (
   id int primary key,
   ts timestamptz default now() not null,
-  breaking bool
+  breaking bool default false not null
 );
 ```

--- a/website/docs/schema.md
+++ b/website/docs/schema.md
@@ -59,7 +59,7 @@ schema in which you can store additional details.
    abreast of the progress of their various background jobs, but is also useful
    for tracking completed jobs (which Graphile Worker will delete on success).
 
-## Use a PostgreSQL user with restricted rights
+## Using a PostgreSQL user with restricted rights
 
 Graphile Worker expects to execute as the database owner (not superuser) role.
 If you want to use a PostgreSQL user with limited permissions instead, you will

--- a/website/docs/schema.md
+++ b/website/docs/schema.md
@@ -59,15 +59,23 @@ schema in which you can store additional details.
    abreast of the progress of their various background jobs, but is also useful
    for tracking completed jobs (which Graphile Worker will delete on success).
 
-## Use a postgresql user with restricted rights
+## Use a PostgreSQL user with restricted rights
 
-If you want to use a PostgreSQL user with restricted rights on the
-`graphile_worker` schema in your database you can use the following trick
-describe in [issue #132](https://github.com/graphile/worker/issues/132). Create
-the following table as your limited user. You'll avoid the error of missing
-create right on the `graphile_worker` schema
+Graphile Worker expects to execute as the database owner (not superuser) role.
+If you want to use a PostgreSQL user with limited permissions instead, you will
+need to make some adjustments.
+
+For example, if you want to create the `graphile_worker` schema yourself then
+you can follow the technique described in
+[issue #132](https://github.com/graphile/worker/issues/132) to avoid errors
+about the worker role missing the privileges required to create the
+`graphile_worker` schema. Worker determines whether to create the schema or not
+based on whether or not the migrations table in the schema exists, so by
+creating the migrations table in addition to the `graphile_worker` schema Worker
+should be able to move on to the next step without raising an error.
 
 ```sql
+create schema graphile_worker;
 create table graphile_worker.migrations (
   id int primary key,
   ts timestamptz default now() not null,


### PR DESCRIPTION
## Description
This PR add doc for using a postgresql with limited user (no create rights on database) with graphile-worker

## Performance impact

None

## Security impact

unknown

## Checklist

- [X] My code matches the project's code style and `yarn lint:fix` passes.
- [X] I've added tests for the new feature, and `yarn test` passes.
- [X] I have detailed the new feature in the relevant documentation.
- [X] I have added this feature to 'Pending' in the `RELEASE_NOTES.md` file (if one exists).
- [X] If this is a breaking change I've explained why.

<!-- For some Graphile projects the documentation is the README.md file, for
      others please see https://github.com/graphile/graphile.github.io -->
