### PR TITLE
Docs: Fix add_job param order

### DIFF
--- a/website/docs/sql-add-job.md
+++ b/website/docs/sql-add-job.md
@@ -83,8 +83,8 @@ SELECT graphile_worker.add_job(
   $1,
   payload := $2,
   queue_name := $3,
-  max_attempts := $4,
-  run_at := NOW() + ($5 * INTERVAL '1 second')
+  run_at := NOW() + ($4 * INTERVAL '1 second'),
+  max_attempts := $5
 );
 ```
 


### PR DESCRIPTION
## Description

Hi there,
I think I found a mistake in the docs regarding `add_job` via SQL:
https://worker.graphile.org/docs/sql-add-job

In the top the order of parameters is described as `run_at` is just before `max_attempts`.

However, a little below in the "TIP" example it is used in reverse.
I think this is wrong so I fixed it.

## Performance impact
None

## Security impact
None

## Checklist
- [x] My code matches the project's code style and `yarn lint:fix` passes.
- [x] I've added tests for the new feature, and `yarn test` passes.
- [x] I have detailed the new feature in the relevant documentation.
- [x] I have added this feature to 'Pending' in the `RELEASE_NOTES.md` file (if one exists).
- [x] If this is a breaking change I've explained why.
