### PR TITLE
Update doc ('pattern' -> 'match')

### DIFF
--- a/website/docs/cron.md
+++ b/website/docs/cron.md
@@ -232,8 +232,8 @@ has the following properties:
   (same as the first argument to `add_job`)
 - `match` (required): a cron pattern (e.g. `* * * * *`) describing when to run,
   or a callback function passed a TimestampDigest and returning a boolean
-  whether the cron should fire for this timestamp (true) or not (false)
-  this task
+  whether the cron should fire for this timestamp (true) or not (false) this
+  task
 - `options`: optional options influencing backfilling, etc
   - `backfillPeriod`: how long (in milliseconds) to backfill (see above)
   - `maxAttempts`: the maximum number of attempts we'll give the job

--- a/website/docs/cron.md
+++ b/website/docs/cron.md
@@ -230,7 +230,9 @@ has the following properties:
 
 - `task` (required): the string identifier of the task that should be executed
   (same as the first argument to `add_job`)
-- `match` (required): a cron pattern (e.g. `* * * * *`) describing when to run
+- `match` (required): a cron pattern (e.g. `* * * * *`) describing when to run,
+  or a callback function passed a TimestampDigest and returning a boolean
+  whether the cron should fire for this timestamp (true) or not (false)
   this task
 - `options`: optional options influencing backfilling, etc
   - `backfillPeriod`: how long (in milliseconds) to backfill (see above)

--- a/website/docs/cron.md
+++ b/website/docs/cron.md
@@ -230,7 +230,7 @@ has the following properties:
 
 - `task` (required): the string identifier of the task that should be executed
   (same as the first argument to `add_job`)
-- `pattern` (required): a cron pattern (e.g. `* * * * *`) describing when to run
+- `match` (required): a cron pattern (e.g. `* * * * *`) describing when to run
   this task
 - `options`: optional options influencing backfilling, etc
   - `backfillPeriod`: how long (in milliseconds) to backfill (see above)


### PR DESCRIPTION
The 0.14 release renamed "pattern" to "match", and the doc didn't get the memo.

It looks like the new "match" field can also take a `CronMatcher`, but I'm not sure how that works.

https://github.com/graphile/worker/blob/414b11cb2a7eff0459462fd5d788d821b33f406b/src/interfaces.ts#L370