### PR TITLE
Move localQueue options into their own object

### DIFF
--- a/perfTest/graphile.config.js
+++ b/perfTest/graphile.config.js
@@ -15,7 +15,9 @@ const preset = {
     fileExtensions: [".js", ".cjs", ".mjs"],
     // fileExtensions: [".js", ".cjs", ".mjs", ".ts", ".cts", ".mts"],
     gracefulShutdownAbortTimeout: 2500,
-    localQueueSize: -1,
+    localQueue: {
+      size: -1,
+    },
     completeJobBatchDelay: -1,
     failJobBatchDelay: -1,
   },

--- a/src/index.ts
+++ b/src/index.ts
@@ -155,31 +155,33 @@ declare global {
 
       events?: WorkerEvents;
 
-      /**
-       * To enable processing jobs in batches, set this to an integer larger
-       * than 1. This will result in jobs being fetched by the pool rather than
-       * the worker, the pool will fetch (and lock!) `localQueueSize` jobs up
-       * front, and each time a worker requests a job it will be served from
-       * this list until the list is exhausted, at which point a new set of
-       * jobs will be fetched (and locked).
-       *
-       * This setting can help reduce the load on your database from looking
-       * for jobs, but is only really effective when there are often many jobs
-       * queued and ready to go, and can increase the latency of job execution
-       * because a single worker may lock jobs into its queue leaving other
-       * workers idle.
-       *
-       * @default `-1`
-       */
-      localQueueSize?: number;
+      localQueue?: {
+        /**
+         * To enable processing jobs in batches, set this to an integer larger
+         * than 1. This will result in jobs being fetched by the pool rather than
+         * the worker, the pool will fetch (and lock!) `localQueue.size` jobs up
+         * front, and each time a worker requests a job it will be served from
+         * this list until the list is exhausted, at which point a new set of
+         * jobs will be fetched (and locked).
+         *
+         * This setting can help reduce the load on your database from looking
+         * for jobs, but is only really effective when there are often many jobs
+         * queued and ready to go, and can increase the latency of job execution
+         * because a single worker may lock jobs into its queue leaving other
+         * workers idle.
+         *
+         * @default `-1`
+         */
+        size: number;
 
-      /**
-       * How long should jobs sit in the local queue before they are returned
-       * to the database? Defaults to 5 minutes.
-       *
-       * @default `300000`
-       */
-      localQueueTtl?: number;
+        /**
+         * How long should jobs sit in the local queue before they are returned
+         * to the database? Defaults to 5 minutes.
+         *
+         * @default `300000`
+         */
+        ttl?: number;
+      };
 
       /**
        * The time in milliseconds to wait after a `completeJob` call to see if

--- a/src/localQueue.ts
+++ b/src/localQueue.ts
@@ -23,8 +23,8 @@ const RELEASED = "RELEASED";
  * relieving the workers of this responsibility.
  *
  * The local queue trades latency for throughput: jobs may sit in the local
- * queue for a longer time (maximum `localQueueSize` jobs waiting maximum
- * `localQueueTTL` milliseconds), but fewer requests to the database are made
+ * queue for a longer time (maximum `localQueue.size` jobs waiting maximum
+ * `localQueue.ttl` milliseconds), but fewer requests to the database are made
  * for jobs since more jobs are fetched at once, enabling the worker to reach
  * higher levels of performance (and reducing read stress on the DB).
  *
@@ -107,7 +107,7 @@ export class LocalQueue {
     private readonly continuous: boolean,
   ) {
     this.ttl =
-      compiledSharedOptions.resolvedPreset.worker.localQueueTtl ?? 5 * MINUTE;
+      compiledSharedOptions.resolvedPreset.worker.localQueue?.ttl ?? 5 * MINUTE;
     this.pollInterval =
       compiledSharedOptions.resolvedPreset.worker.pollInterval ?? 2 * SECOND;
     this.setModePolling();

--- a/src/localQueue.ts
+++ b/src/localQueue.ts
@@ -11,6 +11,7 @@ import { GetJobFunction, Job, TaskList, WorkerPool } from "./interfaces";
 import { getJob as baseGetJob } from "./sql/getJob";
 import { returnJob } from "./sql/returnJob";
 
+const STARTING = "STARTING";
 const POLLING = "POLLING";
 const WAITING = "WAITING";
 const TTL_EXPIRED = "TTL_EXPIRED";
@@ -30,18 +31,24 @@ const RELEASED = "RELEASED";
  *
  * The local queue is always in one of these modes:
  *
+ * - STARTING mode
  * - POLLING mode
  * - WAITING mode
  * - TTL_EXPIRED mode
  * - RELEASED mode
  *
+ * ## STARTING mode
+ *
+ * STARTING mode is the initial state of the local queue.
+ *
+ * Immediately move to POLLING mode.
+ *
  * ## POLLING mode
  *
- * POLLING mode is the initial state of the local queue. The queue will only be
- * in POLLING mode when it contains no cached jobs.
+ * The queue will only be in POLLING mode when it contains no cached jobs.
  *
- * When the queue enters POLLING mode (and when it starts) it will trigger a
- * fetch of jobs from the database.
+ * When the queue enters POLLING mode it will trigger a fetch of jobs from the
+ * database.
  *
  * If no jobs were returned then it will wait `pollInterval` ms and then fetch
  * again.
@@ -94,7 +101,12 @@ export class LocalQueue {
   // Set true to fetch immediately after a fetch completes; typically only used
   // when the queue is pulsed during a fetch.
   fetchAgain = false;
-  mode: typeof POLLING | typeof WAITING | typeof TTL_EXPIRED | typeof RELEASED;
+  mode:
+    | typeof STARTING
+    | typeof POLLING
+    | typeof WAITING
+    | typeof TTL_EXPIRED
+    | typeof RELEASED = STARTING;
   private promise = defer();
   private backgroundCount = 0;
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -536,7 +536,7 @@ export function _runTaskList(
       worker: {
         concurrentJobs: baseConcurrency,
         gracefulShutdownAbortTimeout,
-        localQueueSize = -1,
+        localQueue: { size: localQueueSize = -1 } = {},
         completeJobBatchDelay = -1,
         failJobBatchDelay = -1,
       },

--- a/src/main.ts
+++ b/src/main.ts
@@ -660,7 +660,7 @@ export function _runTaskList(
     },
     nudge(this: WorkerPool, count: number) {
       if (localQueue) {
-        localQueue.pulse();
+        localQueue.pulse(count);
       } else {
         let n = count;
         // Nudge up to `n` workers


### PR DESCRIPTION
This is a PR into #474 to add a new feature to reduce load on the database when the jobs table is somewhat empty but jobs are still trickling in at a high enough rate to cause the queues to want to keep pinging the database.