### PR TITLE
Fix race condition when multiple workers initiate database

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -29,6 +29,8 @@ Read more:
   removing CLI defaults)
 - Fix bug where executable tasks had their stdout/stderr ignored; this is now
   output via logging (thanks @wineTGH).
+- Fix race condition when multiple workers attempt to initialise the database at
+  the same time
 
 ## v0.16.6
 

--- a/__tests__/helpers.ts
+++ b/__tests__/helpers.ts
@@ -34,7 +34,10 @@ export {
   sleepUntil,
   WEEK,
 } from "jest-time-helpers";
-import { setupFakeTimers as realSetupFakeTimers } from "jest-time-helpers";
+import {
+  setupFakeTimers as realSetupFakeTimers,
+  sleepUntil,
+} from "jest-time-helpers";
 
 let fakeTimers: ReturnType<typeof realSetupFakeTimers> | null = null;
 export function setupFakeTimers() {
@@ -117,9 +120,18 @@ export async function reset(
   options: WorkerPoolOptions,
 ) {
   const promise = _reset(pgPoolOrClient, options);
-  if (fakeTimers) {
+  if (fakeTimers != null) {
+    let done = false;
+    promise.then(
+      () => {
+        done = true;
+      },
+      () => {
+        done = true;
+      },
+    );
     // Force time to tick by, so that migrations can run
-    fakeTimers.setTime(Date.now() + 2000, 50);
+    sleepUntil(() => done, 2000);
   }
   return promise;
 }

--- a/__tests__/helpers.ts
+++ b/__tests__/helpers.ts
@@ -169,7 +169,7 @@ export async function jobCount(
 
 export async function getKnown(pgPool: pg.Pool) {
   const { rows } = await pgPool.query<KnownCrontab>(
-    `select * from ${ESCAPED_GRAPHILE_WORKER_SCHEMA}._private_known_crontabs as known_crontabs`,
+    `select * from ${ESCAPED_GRAPHILE_WORKER_SCHEMA}._private_known_crontabs as known_crontabs order by known_since asc, identifier asc`,
   );
   return rows;
 }

--- a/__tests__/helpers.ts
+++ b/__tests__/helpers.ts
@@ -60,6 +60,7 @@ export async function withPgPool<T>(
 ): Promise<T> {
   const pool = new pg.Pool({
     connectionString: TEST_CONNECTION_STRING,
+    max: 100,
   });
   try {
     return await cb(pool);

--- a/__tests__/migrate.test.ts
+++ b/__tests__/migrate.test.ts
@@ -8,7 +8,6 @@ import {
   ESCAPED_GRAPHILE_WORKER_SCHEMA,
   getJobs,
   GRAPHILE_WORKER_SCHEMA,
-  sleep,
   withPgClient,
   withPgPool,
 } from "./helpers";
@@ -68,7 +67,6 @@ test("migration installs schema; second migration does no harm", async () => {
 });
 
 test("multiple concurrent installs of the schema is fine", async () => {
-  const compiledSharedOptions = processSharedOptions(options);
   await withPgClient(async (pgClient) => {
     await pgClient.query(
       `drop schema if exists ${ESCAPED_GRAPHILE_WORKER_SCHEMA} cascade;`,
@@ -86,6 +84,7 @@ test("multiple concurrent installs of the schema is fine", async () => {
         promises.push(
           (async () => {
             // Perform migration
+            const compiledSharedOptions = processSharedOptions(options);
             await migrate(compiledSharedOptions, clients[i]);
           })(),
         );

--- a/__tests__/migrate.test.ts
+++ b/__tests__/migrate.test.ts
@@ -38,7 +38,7 @@ test("migration installs schema; second migration does no harm", async () => {
 
     // Assert migrations table exists and has relevant entries
     const { rows: migrationRows } = await pgClient.query(
-      `select * from ${ESCAPED_GRAPHILE_WORKER_SCHEMA}.migrations`,
+      `select * from ${ESCAPED_GRAPHILE_WORKER_SCHEMA}.migrations order by id asc`,
     );
     expect(migrationRows).toHaveLength(18);
     const migration = migrationRows[0];
@@ -97,7 +97,7 @@ test("multiple concurrent installs of the schema is fine", async () => {
   await withPgClient(async (pgClient) => {
     // Assert migrations table exists and has relevant entries
     const { rows: migrationRows } = await pgClient.query(
-      `select * from ${ESCAPED_GRAPHILE_WORKER_SCHEMA}.migrations`,
+      `select * from ${ESCAPED_GRAPHILE_WORKER_SCHEMA}.migrations order by id asc`,
     );
     expect(migrationRows).toHaveLength(18);
     const migration = migrationRows[0];
@@ -145,7 +145,7 @@ insert into ${ESCAPED_GRAPHILE_WORKER_SCHEMA}.migrations (id) values (1);
 
     // Assert migrations table exists and has relevant entries
     const { rows: migrationRows } = await pgClient.query(
-      `select * from ${ESCAPED_GRAPHILE_WORKER_SCHEMA}.migrations`,
+      `select * from ${ESCAPED_GRAPHILE_WORKER_SCHEMA}.migrations order by id asc`,
     );
     expect(migrationRows.length).toBeGreaterThanOrEqual(18);
     const migration2 = migrationRows[1];

--- a/__tests__/resetLockedAt.test.ts
+++ b/__tests__/resetLockedAt.test.ts
@@ -78,7 +78,7 @@ where task_id = (select id from ${ESCAPED_GRAPHILE_WORKER_SCHEMA}._private_tasks
     expect(states).toEqual(["started", "success"]);
     await sleep(20);
     const { rows: jobs } = await pgPool.query(
-      `select * from ${ESCAPED_GRAPHILE_WORKER_SCHEMA}._private_jobs as jobs`,
+      `select * from ${ESCAPED_GRAPHILE_WORKER_SCHEMA}._private_jobs as jobs order by id asc`,
     );
     expect(jobs.length).toEqual(3);
     const unlocked = jobs.find((j) => j.payload.id === "unlocked");

--- a/__tests__/workerUtils.cleanup.test.ts
+++ b/__tests__/workerUtils.cleanup.test.ts
@@ -53,7 +53,7 @@ test("cleanup with DELETE_PERMAFAILED_JOBS", () =>
 
     await utils.cleanup({ tasks: ["DELETE_PERMAFAILED_JOBS"] });
     const { rows } = await pgClient.query<DbJob>(
-      `select * from ${ESCAPED_GRAPHILE_WORKER_SCHEMA}._private_jobs`,
+      `select * from ${ESCAPED_GRAPHILE_WORKER_SCHEMA}._private_jobs order by id asc`,
     );
     const jobIds = rows
       .map((r) => r.id)

--- a/__tests__/workerUtils.forceUnlockWorkers.test.ts
+++ b/__tests__/workerUtils.forceUnlockWorkers.test.ts
@@ -91,7 +91,7 @@ where jobs.job_queue_id = job_queues.id;`,
       }
     }
     const { rows: lockedQueues } = await pgClient.query(
-      `select * from ${ESCAPED_GRAPHILE_WORKER_SCHEMA}._private_job_queues as job_queues where locked_at is not null`,
+      `select * from ${ESCAPED_GRAPHILE_WORKER_SCHEMA}._private_job_queues as job_queues where locked_at is not null order by id asc`,
     );
 
     expect(lockedQueues).toEqual([

--- a/src/migrate.ts
+++ b/src/migrate.ts
@@ -2,7 +2,7 @@ import { PoolClient } from "pg";
 
 import { migrations } from "./generated/sql";
 import { WorkerSharedOptions, Writeable } from "./interfaces";
-import { BREAKING_MIGRATIONS, CompiledSharedOptions } from "./lib";
+import { BREAKING_MIGRATIONS, CompiledSharedOptions, sleep } from "./lib";
 
 function checkPostgresVersion(versionString: string) {
   const postgresVersion = parseInt(versionString, 10);
@@ -127,13 +127,25 @@ export async function migrate(
       latestMigration = row.id;
       latestBreakingMigration = row.biggest_breaking_id;
       event.postgresVersion = checkPostgresVersion(row.server_version_num);
+      break;
     } catch (e) {
       if (attempts === 0 && (e.code === "42P01" || e.code === "42703")) {
-        await installSchema(compiledSharedOptions, event);
+        try {
+          await installSchema(compiledSharedOptions, event);
+        } catch (e2) {
+          if (e2.code === "23505") {
+            // Another instance installed this concurrently? Go around again.
+          } else {
+            throw e2;
+          }
+        }
       } else {
         throw e;
       }
     }
+    // Need to wait at least a couple hundred ms for the connection to catch
+    // up, then a random extra amount to avoid more conflicts
+    await sleep(400 + Math.random() * 200);
   }
 
   await hooks.process("premigrate", event);

--- a/src/migrate.ts
+++ b/src/migrate.ts
@@ -132,6 +132,7 @@ export async function migrate(
       if (attempts === 0 && (e.code === "42P01" || e.code === "42703")) {
         try {
           await installSchema(compiledSharedOptions, event);
+          break;
         } catch (e2) {
           if (e2.code === "23505") {
             // Another instance installed this concurrently? Go around again.


### PR DESCRIPTION
## Description

Something most people would generally only hit if running multiple workers in CI, if at all.

## Performance impact

Marginal cost on initial migration.

## Security impact

None known.

## Checklist

- [x] My code matches the project's code style and `yarn lint:fix` passes.
- [x] I've added tests for the new feature, and `yarn test` passes.
- [ ] I have detailed the new feature in the relevant documentation.
- [x] I have added this feature to 'Pending' in the `RELEASE_NOTES.md` file (if one exists).
- [ ] If this is a breaking change I've explained why.

