### PR TITLE
Make error handling more explicit, and warn user if they haven't

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -31,6 +31,8 @@ Read more:
   clearer that it's for use in one-off locations (some felt the "quick" referred
   to the speed it executed, rather than the amount of effort required from the
   programmer)
+- We'll now warn you if you haven't installed error handlers on the pool, and
+  will only install them ourself if needed
 - Fixes bug where CLI defaults override `graphile.config.js` settings (by
   removing CLI defaults)
 - Fix bug where executable tasks had their stdout/stderr ignored; this is now

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -332,7 +332,6 @@ function makeNewPool(
   releasers.push(() => {
     pgPool.end();
   });
-
   installErrorHandlers(compiledSharedOptions, releasers, pgPool);
   return pgPool;
 }
@@ -380,8 +379,6 @@ function installErrorHandlers(
     pgPool.removeListener("error", handlePoolError);
     pgPool.removeListener("connect", handlePoolConnect);
   });
-
-  return pgPool;
 }
 
 export type Release = () => PromiseOrDirect<void>;

--- a/website/src/pages/errors/peh.md
+++ b/website/src/pages/errors/peh.md
@@ -1,0 +1,43 @@
+# Pool error handling
+
+You're likely here because you received an error such as:
+
+```
+Your pool doesn't have error handlers! See: https://err.red/wpeh
+```
+
+This means you've passed your own
+[pg.Pool instance](https://node-postgres.com/apis/pool) to Graphile Worker, but
+that pool did not have error handling installed.
+
+If an error occurs on the pool and there is no event handler installed Node
+would exit
+[as described in the Node.js docs](https://nodejs.org/api/events.html#error-events).
+You get a network interruption, and your Worker might crash!
+
+Don't worry, we've installed error handlers for you, but that's not ideal - you
+should be handling this yourself. To do so, use code like this:
+
+```ts
+// Handle errors on the pool directly
+pgPool.on("error", (err) => {
+  console.error(`PostgreSQL idle client generated error: ${err.message}`);
+});
+// Handle errors on the client when it's checked out of the pool but isn't
+// actively being used
+pgPool.on("connect", (client) => {
+  client.on("error", (err) => {
+    console.error(`PostgreSQL active client generated error: ${err.message}`);
+  });
+});
+```
+
+Your code just needs to make sure the 'error' events on pool and client have
+handlers installed; the handlers don't actually have to _do_ anything - they
+could be NO-OPs.
+
+Typically these kinds of errors would occur when e.g. the connection between
+Node.js and PostgreSQL is interrupted (including when the PostgreSQL server
+shuts down). In these cases since the client is likely not actively being
+`await`-ed the error will have no handler, and will result in a process exit if
+unhandled.


### PR DESCRIPTION
## Description

If you pass a pool to Graphile Worker, that pool _ought_ to have error handlers. We've done this for you in the past, but that can result in adding lots of error handlers to the pool. Now we only add the error handlers if there aren't already any, plus we tell you that you should be doing it yourself.

## Performance impact

Negligible startup cost.

## Security impact

Improvement: encouraging users to handle their own errors.

## Checklist

- [x] My code matches the project's code style and `yarn lint:fix` passes.
- [ ] I've added tests for the new feature, and `yarn test` passes.
- [x] I have detailed the new feature in the relevant documentation.
- [x] I have added this feature to 'Pending' in the `RELEASE_NOTES.md` file (if one exists).
- [x] If this is a breaking change I've explained why.

<!-- For some Graphile projects the documentation is the README.md file, for
      others please see https://github.com/graphile/graphile.github.io -->
