### PR TITLE
Add `abortPromise` as a helper alongside `abortSignal`

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -39,6 +39,10 @@ Read more:
   output via logging (thanks @wineTGH).
 - Fix race condition when multiple workers attempt to initialise the database at
   the same time
+- `helpers.abortSignal` is no longer typed as `| undefined`. It is still
+  experimental!
+- `helpers.abortPromise` added; will reject when `abortSignal` aborts (useful
+  for `Promise.race()`)
 
 ## v0.16.6
 

--- a/__tests__/getTasks.test.ts
+++ b/__tests__/getTasks.test.ts
@@ -10,6 +10,12 @@ import { makeMockJob, withPgClient } from "./helpers";
 
 const options: WorkerSharedOptions = {};
 
+const neverAbortController = new AbortController();
+const abortSignal = neverAbortController.signal;
+const abortPromise = new Promise<void>((_, reject) => {
+  abortSignal.addEventListener("abort", reject);
+});
+
 describe("commonjs", () => {
   test("gets tasks from folder", () =>
     withPgClient(async (client) => {
@@ -32,8 +38,8 @@ Array [
           withPgClient: makeEnhancedWithPgClient(
             makeWithPgClientFromClient(client),
           ),
-          abortSignal: undefined,
-          abortPromise: undefined,
+          abortSignal,
+          abortPromise,
         },
       );
       expect(await tasks.wouldyoulike!(helpers.job.payload, helpers)).toEqual(
@@ -69,8 +75,8 @@ Array [
           withPgClient: makeEnhancedWithPgClient(
             makeWithPgClientFromClient(client),
           ),
-          abortSignal: undefined,
-          abortPromise: undefined,
+          abortSignal,
+          abortPromise,
         },
       );
       expect(await tasks.task1!(helpers.job.payload, helpers)).toEqual("hi");
@@ -100,8 +106,8 @@ Array [
           withPgClient: makeEnhancedWithPgClient(
             makeWithPgClientFromClient(client),
           ),
-          abortSignal: undefined,
-          abortPromise: undefined,
+          abortSignal,
+          abortPromise,
         },
       );
       expect(await tasks.task1!(helpers.job.payload, helpers)).toEqual("hi");
@@ -130,8 +136,8 @@ Array [
         withPgClient: makeEnhancedWithPgClient(
           makeWithPgClientFromClient(client),
         ),
-        abortSignal: undefined,
-        abortPromise: undefined,
+        abortSignal,
+        abortPromise,
       });
       expect(await tasks.t1!(helpers.job.payload, helpers)).toEqual(
         "come with me",
@@ -161,8 +167,8 @@ Array [
         withPgClient: makeEnhancedWithPgClient(
           makeWithPgClientFromClient(client),
         ),
-        abortSignal: undefined,
-        abortPromise: undefined,
+        abortSignal,
+        abortPromise,
       });
       expect(await tasks.t1!(helpers.job.payload, helpers)).toEqual(
         "come with me, TS",
@@ -196,8 +202,8 @@ Array [
           withPgClient: makeEnhancedWithPgClient(
             makeWithPgClientFromClient(client),
           ),
-          abortSignal: undefined,
-          abortPromise: undefined,
+          abortSignal,
+          abortPromise,
         },
       );
       expect(await tasks.wouldyoulike!(helpers.job.payload, helpers)).toEqual(
@@ -230,8 +236,8 @@ Array [
           withPgClient: makeEnhancedWithPgClient(
             makeWithPgClientFromClient(client),
           ),
-          abortSignal: undefined,
-          abortPromise: undefined,
+          abortSignal,
+          abortPromise,
         },
       );
       expect(await tasks.task1!(helpers.job.payload, helpers)).toEqual("hi");
@@ -258,8 +264,8 @@ Array [
         withPgClient: makeEnhancedWithPgClient(
           makeWithPgClientFromClient(client),
         ),
-        abortSignal: undefined,
-        abortPromise: undefined,
+        abortSignal,
+        abortPromise,
       });
       expect(await tasks.t1!(helpers.job.payload, helpers)).toEqual(
         "come with me",

--- a/__tests__/getTasks.test.ts
+++ b/__tests__/getTasks.test.ts
@@ -33,6 +33,7 @@ Array [
             makeWithPgClientFromClient(client),
           ),
           abortSignal: undefined,
+          abortPromise: undefined,
         },
       );
       expect(await tasks.wouldyoulike!(helpers.job.payload, helpers)).toEqual(
@@ -69,6 +70,7 @@ Array [
             makeWithPgClientFromClient(client),
           ),
           abortSignal: undefined,
+          abortPromise: undefined,
         },
       );
       expect(await tasks.task1!(helpers.job.payload, helpers)).toEqual("hi");
@@ -99,6 +101,7 @@ Array [
             makeWithPgClientFromClient(client),
           ),
           abortSignal: undefined,
+          abortPromise: undefined,
         },
       );
       expect(await tasks.task1!(helpers.job.payload, helpers)).toEqual("hi");
@@ -128,6 +131,7 @@ Array [
           makeWithPgClientFromClient(client),
         ),
         abortSignal: undefined,
+        abortPromise: undefined,
       });
       expect(await tasks.t1!(helpers.job.payload, helpers)).toEqual(
         "come with me",
@@ -158,6 +162,7 @@ Array [
           makeWithPgClientFromClient(client),
         ),
         abortSignal: undefined,
+        abortPromise: undefined,
       });
       expect(await tasks.t1!(helpers.job.payload, helpers)).toEqual(
         "come with me, TS",
@@ -192,6 +197,7 @@ Array [
             makeWithPgClientFromClient(client),
           ),
           abortSignal: undefined,
+          abortPromise: undefined,
         },
       );
       expect(await tasks.wouldyoulike!(helpers.job.payload, helpers)).toEqual(
@@ -225,6 +231,7 @@ Array [
             makeWithPgClientFromClient(client),
           ),
           abortSignal: undefined,
+          abortPromise: undefined,
         },
       );
       expect(await tasks.task1!(helpers.job.payload, helpers)).toEqual("hi");
@@ -252,6 +259,7 @@ Array [
           makeWithPgClientFromClient(client),
         ),
         abortSignal: undefined,
+        abortPromise: undefined,
       });
       expect(await tasks.t1!(helpers.job.payload, helpers)).toEqual(
         "come with me",

--- a/__tests__/runner.runOnce.test.ts
+++ b/__tests__/runner.runOnce.test.ts
@@ -197,11 +197,13 @@ test("runs all available tasks and then exits", async () =>
     }
   }));
 
-test.only("gracefulShutdown", async () =>
+test("gracefulShutdown", async () =>
   withPgPool(async (pgPool) => {
+    let jobStarted = false;
     const options: RunnerOptions = {
       taskList: {
         job1(payload, helpers) {
+          jobStarted = true;
           return Promise.race([sleep(100000, true), helpers.abortPromise]);
         },
       },
@@ -220,6 +222,7 @@ test.only("gracefulShutdown", async () =>
     await sleepUntil(() => _allWorkerPools.length === 1);
     expect(_allWorkerPools).toHaveLength(1);
     const pool = _allWorkerPools[0];
+    await sleepUntil(() => jobStarted);
     await pool.gracefulShutdown();
     await promise;
     let jobs: Job[] = [];

--- a/__tests__/runner.runOnce.test.ts
+++ b/__tests__/runner.runOnce.test.ts
@@ -10,6 +10,7 @@ import {
   databaseDetails,
   getJobs,
   makeSelectionOfJobs,
+  reset,
   sleep,
   sleepUntil,
   withPgPool,
@@ -92,10 +93,13 @@ test("at least a connectionString, a pgPool, the DATABASE_URL or PGDATABASE envv
 });
 
 test("connectionString and a pgPool cannot provided a the same time", async () => {
+  const pgPool = new Pool();
+  pgPool.on("error", () => {});
+  pgPool.on("connect", () => {});
   const options: RunnerOptions = {
     taskList: { task: () => {} },
     connectionString: databaseDetails!.TEST_CONNECTION_STRING,
-    pgPool: new Pool(),
+    pgPool,
   };
   await runOnceErrorAssertion(
     options,
@@ -215,6 +219,7 @@ test("gracefulShutdown", async () =>
         },
       },
     };
+    await reset(pgPool, options);
     utils = await makeWorkerUtils(options);
     await utils.addJob("job1", { id: "test sleep" });
     expect(_allWorkerPools).toHaveLength(0);

--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "eslint_d": "^13.0.0",
     "graphile": "^5.0.0-beta.16",
     "jest": "^26.0.0",
-    "jest-time-helpers": "0.1.0",
+    "jest-time-helpers": "0.1.1",
     "juice": "5.2.0",
     "pg-connection-string": "^2.6.2",
     "postcss-nested": "^6.0.1",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "prettier:check": "prettier --cache --ignore-path .eslintignore --check '**/*.{js,jsx,ts,tsx,graphql,md,json}'",
     "test": "yarn prepack && yarn depcheck && yarn test:setupdb && yarn test:only",
     "test:setupdb": "./scripts/setup_template_db.sh",
-    "test:only": "node --experimental-vm-modules node_modules/.bin/jest",
+    "test:only": "NO_LOG_SUCCESS=1 node --experimental-vm-modules node_modules/.bin/jest",
     "depcheck": "depcheck --ignores='graphile-worker,faktory-worker,@google-cloud/tasks,bullmq,jest-environment-node,@docusaurus/*,@fortawesome/*,@mdx-js/*,@types/jest,clsx,eslint_d,graphile,juice,postcss-nested,prism-react-renderer,react,react-dom,svgo,ts-node,@types/debug,tslib'",
     "db:dump": "./scripts/dump_db",
     "perfTest": "cd perfTest && node ./run.js",

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -229,8 +229,8 @@ export function makeJobHelpers(
     logger: overrideLogger,
   }: {
     withPgClient: EnhancedWithPgClient;
-    abortSignal: AbortSignal | undefined;
-    abortPromise: Promise<void> | undefined;
+    abortSignal: AbortSignal;
+    abortPromise: Promise<void>;
     logger?: Logger;
   },
 ): JobHelpers {

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -229,8 +229,8 @@ export function makeJobHelpers(
     logger: overrideLogger,
   }: {
     withPgClient: EnhancedWithPgClient;
-    abortSignal: AbortSignal;
-    abortPromise: Promise<void>;
+    abortSignal: AbortSignal | undefined;
+    abortPromise: Promise<void> | undefined;
     logger?: Logger;
   },
 ): JobHelpers {

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -225,10 +225,12 @@ export function makeJobHelpers(
   {
     withPgClient,
     abortSignal,
+    abortPromise,
     logger: overrideLogger,
   }: {
     withPgClient: EnhancedWithPgClient;
-    abortSignal: AbortSignal | undefined;
+    abortSignal: AbortSignal;
+    abortPromise: Promise<void>;
     logger?: Logger;
   },
 ): JobHelpers {
@@ -240,6 +242,7 @@ export function makeJobHelpers(
   });
   const helpers: JobHelpers = {
     abortSignal,
+    abortPromise,
     job,
     getQueueName(queueId = job.job_queue_id) {
       return getQueueName(compiledSharedOptions, withPgClient, queueId);

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -739,7 +739,7 @@ export interface WorkerOptions extends WorkerSharedOptions {
    */
   workerId?: string;
 
-  abortSignal?: AbortSignal;
+  abortSignal: AbortSignal;
 
   workerPool: WorkerPool;
 

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -185,7 +185,14 @@ export interface JobHelpers extends Helpers {
    *
    * @experimental
    */
-  abortSignal?: AbortSignal;
+  abortSignal: AbortSignal | undefined;
+
+  /**
+   * A promise that rejects when the AbortSignal aborts.
+   *
+   * @experimental
+   */
+  abortPromise: Promise<void> | undefined;
 }
 
 export type CleanupTask =
@@ -509,8 +516,10 @@ export interface WorkerPool {
   gracefulShutdown: (message?: string) => Promise<void>;
   forcefulShutdown: (message: string) => Promise<void>;
   promise: Promise<void>;
-  /** @experimental */
+  /** Fires 'abort' when all running jobs should stop because worker is shutting down. @experimental */
   abortSignal: AbortSignal;
+  /** Rejects when the abortSignal aborts. @experimental */
+  abortPromise: Promise<void>;
   /** @internal */
   _shuttingDown: boolean;
   /** @internal */

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -185,14 +185,14 @@ export interface JobHelpers extends Helpers {
    *
    * @experimental
    */
-  abortSignal: AbortSignal | undefined;
+  abortSignal: AbortSignal;
 
   /**
    * A promise that rejects when the AbortSignal aborts.
    *
    * @experimental
    */
-  abortPromise: Promise<void> | undefined;
+  abortPromise: Promise<void>;
 }
 
 export type CleanupTask =

--- a/src/main.ts
+++ b/src/main.ts
@@ -584,8 +584,6 @@ export function _runTaskList(
   }
 
   const abortController = new AbortController();
-  // TODO: user-passed abortSignal should trigger our controller to abort
-
   const abortSignal = abortController.signal;
   const abortPromise = new Promise<void>((_resolve, reject) => {
     abortSignal.addEventListener("abort", () => {

--- a/src/main.ts
+++ b/src/main.ts
@@ -584,7 +584,16 @@ export function _runTaskList(
   }
 
   const abortController = new AbortController();
+  // TODO: user-passed abortSignal should trigger our controller to abort
+
   const abortSignal = abortController.signal;
+  const abortPromise = new Promise<void>((_resolve, reject) => {
+    abortSignal.addEventListener("abort", () => {
+      reject(abortSignal.reason);
+    });
+  });
+  // Make sure Node doesn't get upset about unhandled rejection
+  abortPromise.then(null, () => /* noop */ void 0);
 
   // This is a representation of us that can be interacted with externally
   const workerPool: WorkerPool = {
@@ -598,7 +607,8 @@ export function _runTaskList(
       return concurrency === 1 ? this._workers[0] ?? null : null;
     },
     abortSignal,
-    release: async () => {
+    abortPromise,
+    release() {
       logger.error(
         "DEPRECATED: You are calling `workerPool.release()`; please use `workerPool.gracefulShutdown()` instead.",
       );
@@ -848,6 +858,7 @@ export function _runTaskList(
       withPgClient,
       continuous,
       abortSignal,
+      abortPromise,
       workerPool,
       autostart,
       workerId,

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -24,6 +24,7 @@ export function makeNewWorker(
     withPgClient: EnhancedWithPgClient;
     continuous: boolean;
     abortSignal: AbortSignal;
+    abortPromise: Promise<void>;
     workerPool: WorkerPool;
     autostart?: boolean;
     workerId?: string;
@@ -35,6 +36,7 @@ export function makeNewWorker(
     withPgClient,
     continuous,
     abortSignal,
+    abortPromise,
     workerPool,
     autostart = true,
     workerId = `worker-${randomBytes(9).toString("hex")}`,
@@ -244,6 +246,7 @@ export function makeNewWorker(
           withPgClient,
           logger,
           abortSignal,
+          abortPromise,
         });
         result = await task(job.payload, helpers);
       } catch (error) {

--- a/website/docs/tasks.md
+++ b/website/docs/tasks.md
@@ -36,9 +36,13 @@ Each task function is passed two arguments:
     shouldn't need this
   - `getQueueName()` &mdash; get the name of the queue the job is in (may or may
     not return a promise - recommend you always `await` it)
-  - `abortSignal` &mdash; could be an `AbortSignal` or `undefined`; if set, use
-    this to abort your task early on graceful shutdown (can be passed to a
-    number of asynchronous Node.js methods)
+  - `abortSignal` &mdash; could be an `AbortSignal`, or `undefined` if not
+    supported by this release of worker; if set, use this to abort your task
+    early on graceful shutdown (can be passed to a number of asynchronous
+    Node.js methods)
+  - `abortPromise` &mdash; if present, a promise that will reject when
+    `abortSignal` aborts; convenient for exiting your task when the abortSignal
+    fires: `Promise.race([abortPromise, doYourThing()])`
   - `withPgClient` &mdash; a helper to use to get a database client
   - `query(sql, values)` &mdash; a convenience wrapper for
     `withPgClient(pgClient => pgClient.query(sql, values))`

--- a/yarn.lock
+++ b/yarn.lock
@@ -7714,10 +7714,10 @@ jest-snapshot@^26.6.2:
     pretty-format "^26.6.2"
     semver "^7.3.2"
 
-jest-time-helpers@0.1.0:
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/jest-time-helpers/-/jest-time-helpers-0.1.0.tgz#0d28164b4109035ce5010bfc5375b78700bfe793"
-  integrity sha512-rj3g5CPey4t1n/6HCEWL5epe7b33bPKurGOFmdDG7A6PoO6jtPfaCWNtRangFUCX7Z9aPr7D6nQfga635j1Fuw==
+jest-time-helpers@0.1.1:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/jest-time-helpers/-/jest-time-helpers-0.1.1.tgz#93a6ee318ccd50a27f27898460f62d987f431bc9"
+  integrity sha512-FJdTB98OTD16HYe0Y+98FLYPlfWAcU0lj8OZ4AUpKkWSbqX3lL4aLjYZaH9gvQG4KcG7/cpBFwV9MhGQ71MD4Q==
 
 jest-util@^26.1.0, jest-util@^26.6.2:
   version "26.6.2"


### PR DESCRIPTION
## Description

Still experimental; this allows you to `await Promise.race([helpers.abortPromise, doTheThing()])` in your jobs, and have the timeout/abort fire conveniently.

Extracted from #474 

## Performance impact

Negligible - we construct it up top and it's shared by all tasks (not created on a per-task basis).

## Security impact

None that I can think of :thinking: 

## Checklist

- [x] My code matches the project's code style and `yarn lint:fix` passes.
- [x] I've added tests for the new feature, and `yarn test` passes.
- [x] I have detailed the new feature in the relevant documentation.
- [x] I have added this feature to 'Pending' in the `RELEASE_NOTES.md` file (if one exists).
- [ ] If this is a breaking change I've explained why.

