### PR TITLE
Remove npm2yarn in contributing doc page

### DIFF
--- a/website/docs/contributing.md
+++ b/website/docs/contributing.md
@@ -68,6 +68,6 @@ docker run -e POSTGRES_HOST_AUTH_METHOD=trust -d -p 5432:5432 postgres:12
 
 then run
 
-```sh npm2yarn
-PGUSER=postgres PGHOST=localhost npm run db:dump
+```sh
+PGUSER=postgres PGHOST=localhost yarn run db:dump
 ```

--- a/website/docs/contributing.md
+++ b/website/docs/contributing.md
@@ -11,16 +11,16 @@ time!
 
 ## Development
 
-```sh npm2yarn
-npm install
-npm run watch
+```sh
+yarn install
+yarn run watch
 ```
 
 In another terminal:
 
-```sh npm2yarn
+```sh
 createdb graphile_worker_test
-npm test
+yarn test
 ```
 
 ### Using Docker to develop this module


### PR DESCRIPTION
## Description

The test command referenced in this doc page relies on the contributor using yarn. npm2yarn shows examples in npm and pnpm which suggests that npm and pnpm will work. They do not work, at least for me. It won't install successfully with npm. pnpm will install, but the test command fails.

```sh
npm install

npm error code ERESOLVE
npm error ERESOLVE unable to resolve dependency tree
npm error
npm error While resolving: graphile-worker@0.16.6
npm error Found: react@18.2.0
npm error node_modules/react
npm error   dev react@"^18.2.0" from the root project
npm error
npm error Could not resolve dependency:
npm error peer react@"^16.8.4 || ^17.0.0" from @docusaurus/core@2.4.3
npm error node_modules/@docusaurus/core
npm error   dev @docusaurus/core@"2.4.3" from the root project
npm error
npm error Fix the upstream dependency conflict, or retry
npm error this command with --force or --legacy-peer-deps
npm error to accept an incorrect (and potentially broken) dependency resolution.
```

```sh
pnpm test

> graphile-worker@0.16.6 test /Users/chandler/Documents/graphile/worker
> yarn prepack && yarn depcheck && yarn test:setupdb && yarn test:only

Internal Error: graphile-worker@workspace:.: This package doesn't seem to be present in your lockfile; run "yarn install" to update the lockfile
    at Xx.getCandidates (/Users/chandler/.volta/tools/image/yarn/4.1.0/bin/yarn.js:205:8149)
    at Dd.getCandidates (/Users/chandler/.volta/tools/image/yarn/4.1.0/bin/yarn.js:141:1311)
    at /Users/chandler/.volta/tools/image/yarn/4.1.0/bin/yarn.js:210:8409
    at Ky (/Users/chandler/.volta/tools/image/yarn/4.1.0/bin/yarn.js:140:53916)
    at Fe (/Users/chandler/.volta/tools/image/yarn/4.1.0/bin/yarn.js:210:8389)
    at async Promise.allSettled (index 0)
    at async Uc (/Users/chandler/.volta/tools/image/yarn/4.1.0/bin/yarn.js:140:53244)
    at async /Users/chandler/.volta/tools/image/yarn/4.1.0/bin/yarn.js:210:9140
    at async Qi.startProgressPromise (/Users/chandler/.volta/tools/image/yarn/4.1.0/bin/yarn.js:140:137284)
    at async Pt.resolveEverything (/Users/chandler/.volta/tools/image/yarn/4.1.0/bin/yarn.js:210:7138)
 ELIFECYCLE  Test failed. See above for more details.
```

This PR just updates the block to explicitly call for yarn.