### PR TITLE
make backfillPeriod optional in exported CronItem type

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -43,6 +43,9 @@ Read more:
   experimental!
 - `helpers.abortPromise` added; will reject when `abortSignal` aborts (useful
   for `Promise.race()`)
+- Loosen the CronItem.options.backfillPeriod type. `backfillPeriod` is now
+  optional and defaults to 0 when parsing js objects and when parsing crontab
+  strings.
 
 ## v0.16.6
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -43,9 +43,7 @@ Read more:
   experimental!
 - `helpers.abortPromise` added; will reject when `abortSignal` aborts (useful
   for `Promise.race()`)
-- Loosen the CronItem.options.backfillPeriod type. `backfillPeriod` is now
-  optional and defaults to 0 when parsing js objects and when parsing crontab
-  strings.
+- `backfillPeriod` is now marked as optional in TypeScript (defaults to 0).
 
 ## v0.16.6
 

--- a/__tests__/crontab.test.ts
+++ b/__tests__/crontab.test.ts
@@ -1,4 +1,4 @@
-import { $$isParsed, CronItemOptions, ParsedCronMatch } from "../src";
+import { CronItemOptions, ParsedCronMatch } from "../src";
 import { parseCronItem, parseCrontab } from "../src/crontab";
 
 // 0...59
@@ -250,7 +250,7 @@ describe("parses JS cron items correctly", () => {
   });
 
   test("validates match strings", () => {
-    const matchString = "foobar";
+    const matchString = "foo";
     expect(() =>
       parseCronItem({
         task: "task",

--- a/__tests__/crontab.test.ts
+++ b/__tests__/crontab.test.ts
@@ -257,8 +257,6 @@ describe("parses JS cron items correctly", () => {
         match: matchString,
         options: {},
       }),
-    ).toThrow(
-      `"Invalid cron pattern '${matchString}' in parseCronItem call"`,
-    );
+    ).toThrow(`Invalid cron pattern '${matchString}' in parseCronItem call`);
   });
 });

--- a/__tests__/crontab.test.ts
+++ b/__tests__/crontab.test.ts
@@ -257,7 +257,7 @@ describe("parses JS cron items correctly", () => {
         match: matchString,
         options: {},
       }),
-    ).toThrowErrorMatchingInlineSnapshot(
+    ).toThrow(
       `"Invalid cron pattern '${matchString}' in parseCronItem call"`,
     );
   });

--- a/__tests__/crontab.test.ts
+++ b/__tests__/crontab.test.ts
@@ -1,5 +1,5 @@
-import { CronItemOptions, ParsedCronMatch } from "../src";
-import { parseCrontab } from "../src/crontab";
+import { $$isParsed, CronItemOptions, ParsedCronMatch } from "../src";
+import { parseCronItem, parseCrontab } from "../src/crontab";
 
 // 0...59
 const ALL_MINUTES = Array.from(Array(60).keys());
@@ -234,6 +234,31 @@ describe("gives error on syntax error", () => {
 `),
     ).toThrowErrorMatchingInlineSnapshot(
       `"Failed to parse JSON5 payload on line 1 of crontab: JSON5: invalid character '=' at 1:13"`,
+    );
+  });
+});
+
+describe("parses JS cron items correctly", () => {
+  test("defaults backfillPeriod to 0", () => {
+    expect(
+      parseCronItem({
+        task: "task",
+        match: "* * * * *",
+        options: {},
+      }).options.backfillPeriod,
+    ).toEqual(0);
+  });
+
+  test("validates match strings", () => {
+    const matchString = "foobar";
+    expect(() =>
+      parseCronItem({
+        task: "task",
+        match: matchString,
+        options: {},
+      }),
+    ).toThrowErrorMatchingInlineSnapshot(
+      `"Invalid cron pattern '${matchString}' in parseCronItem call"`,
     );
   });
 });

--- a/src/crontab.ts
+++ b/src/crontab.ts
@@ -310,17 +310,10 @@ export const parseCronItem = (
     throw new Error("Invalid 'match' configuration");
   }
 
-  let parsedOptions: ParsedCronItemOptions;
-  if (!options) {
-    parsedOptions = { backfillPeriod: 0 };
-  } else if (options.backfillPeriod === undefined) {
-    parsedOptions = { ...options, backfillPeriod: 0 };
-  } else {
-    parsedOptions = {
-      ...options,
-      backfillPeriod: options.backfillPeriod,
-    };
-  }
+  const parsedOptions: ParsedCronItemOptions = {
+    ...options,
+    backfillPeriod: options?.backfillPeriod ?? 0,
+  };
 
   return {
     [$$isParsed]: true,

--- a/src/crontab.ts
+++ b/src/crontab.ts
@@ -20,6 +20,7 @@ import {
   CronItem,
   CronItemOptions,
   ParsedCronItem,
+  ParsedCronItemOptions,
 } from "./interfaces";
 import { coerceError } from "./lib";
 
@@ -60,7 +61,7 @@ const parseTimePhrase = (timePhrase: string): number => {
 const parseCrontabOptions = (
   lineNumber: number,
   optionsString: string | undefined,
-): { options: CronItemOptions; identifier: string | undefined } => {
+): { options: ParsedCronItemOptions; identifier: string | undefined } => {
   const parsed = optionsString != null ? parse(optionsString) : {};
   let backfillPeriod: number | undefined = undefined;
   let maxAttempts: number | undefined = undefined;
@@ -294,7 +295,7 @@ export const parseCronItem = (
   const {
     match: rawMatch,
     task,
-    options = {} as CronItemOptions,
+    options,
     payload = {},
     identifier = task,
   } = cronItem;
@@ -308,11 +309,24 @@ export const parseCronItem = (
   if (typeof match !== "function") {
     throw new Error("Invalid 'match' configuration");
   }
+
+  let parsedOptions: ParsedCronItemOptions;
+  if (!options) {
+    parsedOptions = { backfillPeriod: 0 };
+  } else if (options.backfillPeriod === undefined) {
+    parsedOptions = { ...options, backfillPeriod: 0 };
+  } else {
+    parsedOptions = {
+      ...options,
+      backfillPeriod: options.backfillPeriod,
+    };
+  }
+
   return {
     [$$isParsed]: true,
     match,
     task,
-    options,
+    options: parsedOptions,
     payload,
     identifier,
   };

--- a/src/crontab.ts
+++ b/src/crontab.ts
@@ -150,9 +150,8 @@ const parseCrontabOptions = (
     }
   });
 
-  if (!backfillPeriod) {
-    backfillPeriod = 0;
-  }
+  // Apply some sensible defaults
+  backfillPeriod ??= 0;
   if (!jobKeyMode && jobKey) {
     jobKeyMode = "replace";
   }

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -326,10 +326,14 @@ export interface WatchedCronItems {
   release: () => void;
 }
 
+export type CronItemOptions = {
+  [key in keyof ParsedCronItemOptions]?: ParsedCronItemOptions[key];
+};
+
 /**
  * a.k.a. `opts`, this allows you to change the behaviour when scheduling a cron task.
  */
-export interface CronItemOptions {
+export interface ParsedCronItemOptions {
   /** How far back (in milliseconds) should we backfill jobs when worker starts? (Only backfills since when the identifier was first used.) */
   backfillPeriod: number;
 
@@ -419,7 +423,7 @@ export interface ParsedCronItem {
   task: string;
 
   /** Options influencing backfilling and properties of the scheduled job */
-  options: CronItemOptions;
+  options: ParsedCronItemOptions;
 
   /** A payload object to merge into the default cron payload object for the scheduled job */
   payload: { [key: string]: unknown } | null;

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -326,16 +326,12 @@ export interface WatchedCronItems {
   release: () => void;
 }
 
-export type CronItemOptions = {
-  [key in keyof ParsedCronItemOptions]?: ParsedCronItemOptions[key];
-};
-
 /**
  * a.k.a. `opts`, this allows you to change the behaviour when scheduling a cron task.
  */
-export interface ParsedCronItemOptions {
+export interface CronItemOptions {
   /** How far back (in milliseconds) should we backfill jobs when worker starts? (Only backfills since when the identifier was first used.) */
-  backfillPeriod: number;
+  backfillPeriod?: number;
 
   /** Optionally override the default job max_attempts */
   maxAttempts?: number;
@@ -355,6 +351,10 @@ export interface ParsedCronItemOptions {
    * updated. (Default: 'replace')
    */
   jobKeyMode?: "replace" | "preserve_run_at";
+}
+
+export interface ParsedCronItemOptions extends CronItemOptions {
+  backfillPeriod: number;
 }
 
 /**


### PR DESCRIPTION
## Description

Addresses https://github.com/graphile/worker/issues/495

This allows users to not specify a backfill period, and worker will default it to zero. To support this, `parseCronItem()` also now defaults it to zero in addition to `parseCrontabOptions()`

This PR changes the external interface, but it should be backwards-compatible with existing usage.

## Performance impact

I don't expect there would be any performance impact. There is almost no runtime code changed.

## Security impact

Similarly, there should not be any impact to security considerations.

## Checklist

<!-- If this PR is work in progress, please open it as a "Draft PR". -->
<!-- To tick a checkbox, change it from `[ ]` to `[x]` -->

- [x] My code matches the project's code style and `yarn lint:fix` passes.
- [x] I've added tests for the new feature, and `yarn test` passes.
- [x] ~I have detailed the new feature in the relevant documentation.~ I do not plan to add this to documentation.
- [x] I have added this feature to 'Pending' in the `RELEASE_NOTES.md` file (if one exists).
- [x] If this is a breaking change I've explained why.
