### PR TITLE
contributing documentation overhaul

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,5 +1,6 @@
 FROM node:18-alpine
 RUN apk add --no-cache bash
+RUN apk add --no-cache postgresql-client
 
 ENTRYPOINT ["yarn"]
 CMD ["watch"]
@@ -14,8 +15,11 @@ COPY ./sql ./sql
 COPY ./src  ./src
 COPY ./scripts ./scripts
 COPY ./perfTest  ./perfTest
+COPY ./website  ./website
 COPY ./tsconfig.json ./
 COPY ./jest.config.js ./
-
+COPY ./.eslintrc.js ./
+COPY ./.prettierrc.js ./
+COPY ./.eslintignore ./
 
 RUN yarn prepack

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,5 +20,9 @@ services:
       - ./sql:/app/sql
       - ./src:/app/src
       - ./perfTest:/app/perfTest
+      - ./website:/app/website
     environment:
-      TEST_CONNECTION_STRING: "postgres://postgres:workerdev@db:5432/graphile_worker_test"
+      PGUSER: "postgres"
+      PGPASSWORD: "workerdev"
+      PGHOST: "db"
+      PGPORT: "5432"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: "3.4"
-
 services:
   db:
     image: postgres:12-alpine

--- a/package.json
+++ b/package.json
@@ -6,7 +6,6 @@
   "main": "dist/index.js",
   "scripts": {
     "build:sql": "node scripts/buildSqlModule.mjs",
-    "cli": "node dist/cli.js",
     "website:update": "node scripts/options.mjs",
     "prepack": "rm -Rf dist && npm run build:sql && tsc && chmod +x dist/cli.js",
     "watch": "mkdir -p dist && touch dist/cli.js && chmod +x dist/cli.js && npm run build:sql && tsc --watch",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,9 @@
     "perfTest": "cd perfTest && node ./run.js",
     "preversion": "grep '^### Pending' RELEASE_NOTES.md && echo \"⚠️ Cannot publish with 'Pending' in RELEASE_NOTES ⚠️\" && exit 1 || true",
     "version": "node scripts/postversion.mjs && git add src/version.ts",
-    "website": "cd website && yarn start"
+    "website": "cd website && yarn run",
+    "website:start": "yarn website start",
+    "website:deploy": "yarn website deploy"
   },
   "bin": {
     "graphile-worker": "./dist/cli.js"

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "main": "dist/index.js",
   "scripts": {
     "build:sql": "node scripts/buildSqlModule.mjs",
+    "cli": "node dist/cli.js",
     "website:update": "node scripts/options.mjs",
     "prepack": "rm -Rf dist && npm run build:sql && tsc && chmod +x dist/cli.js",
     "watch": "mkdir -p dist && touch dist/cli.js && chmod +x dist/cli.js && npm run build:sql && tsc --watch",
@@ -20,7 +21,7 @@
     "perfTest": "cd perfTest && node ./run.js",
     "preversion": "grep '^### Pending' RELEASE_NOTES.md && echo \"⚠️ Cannot publish with 'Pending' in RELEASE_NOTES ⚠️\" && exit 1 || true",
     "version": "node scripts/postversion.mjs && git add src/version.ts",
-    "website": "cd website && yarn run"
+    "website": "cd website && yarn start"
   },
   "bin": {
     "graphile-worker": "./dist/cli.js"

--- a/package.json
+++ b/package.json
@@ -105,7 +105,8 @@
     "sql"
   ],
   "engines": {
-    "node": ">=14.0.0"
+    "node": ">=14.0.0",
+    "yarn": "^1.22.22"
   },
   "browserslist": {
     "production": [

--- a/website/docs/contributing.md
+++ b/website/docs/contributing.md
@@ -194,6 +194,12 @@ The `docker-compose.yml` file starts a minimal setup with a `db` container
 containing a Postgres database and an `app` container that is similar to running
 in CLI mode.
 
+To rebuild the docker containers, run:
+
+```sh
+docker compose build
+```
+
 To run the `db` and `app` containers in the backround, run the following:
 
 ```sh

--- a/website/docs/contributing.md
+++ b/website/docs/contributing.md
@@ -11,7 +11,7 @@ time!
 
 ## Development
 
-Graphile worker is developed using yarn 1.x
+Graphile Worker is developed using yarn 1.x
 
 ```sh
 yarn install

--- a/website/docs/contributing.md
+++ b/website/docs/contributing.md
@@ -11,6 +11,8 @@ time!
 
 ## Development
 
+Graphile worker is developed using yarn 1.x
+
 ```sh
 yarn install
 yarn run watch
@@ -28,32 +30,32 @@ yarn test
 Start the dev db and app in the background
 
 ```sh
-docker-compose up -d
+docker compose up -d
 ```
 
 Run the tests
 
 ```sh
-docker-compose exec app yarn jest -i
+docker compose exec app yarn jest -i
 ```
 
 Reset the test db
 
 ```sh
-cat __tests__/reset-db.sql | docker-compose exec -T db psql -U postgres -v GRAPHILE_WORKER_SCHEMA=graphile_worker graphile_worker_test
+cat __tests__/reset-db.sql | docker compose exec -T db psql -U postgres -v GRAPHILE_WORKER_SCHEMA=graphile_worker graphile_worker_test
 ```
 
 Run the perf tests
 
 ```sh
-docker-compose exec app node ./perfTest/run.js
+docker compose exec app node ./perfTest/run.js
 ```
 
 monitor the container logs
 
 ```sh
-docker-compose logs -f db
-docker-compose logs -f app
+docker compose logs -f db
+docker compose logs -f app
 ```
 
 ### Database migrations

--- a/website/docs/contributing.md
+++ b/website/docs/contributing.md
@@ -69,10 +69,10 @@ See the [CLI documentation](./cli/run.md) for more information about CLI mode.
 
 When Graphile Worker users run in library mode, they use the functions exported
 in `src/index.ts`. The scrappiest thing you can do to run your local version of
-Graphile Worker similarly is to create a file, `src/temp.ts` that runs functions
+Graphile Worker similarly is to create a Typescript file that runs functions
 imported from `.`.
 
-```ts
+```ts title="src/temp.ts"
 import { run } from ".";
 
 async function main() {

--- a/website/docs/contributing.md
+++ b/website/docs/contributing.md
@@ -73,16 +73,21 @@ Graphile Worker similarly is to create a Typescript file that runs functions
 imported from `.`.
 
 ```ts title="src/temp.ts"
-import { run } from ".";
+import { run, WorkerPreset } from ".";
 
 async function main() {
   const runner = await run({
-    connectionString: "postgres:///my_db",
     taskList: {
       hello: async (_, helpers) => {
         helpers.logger.info("Hello, world!");
       },
     },
+    preset: {
+      extends: [WorkerPreset],
+      worker: {
+        connectionString: "postgres:///my_db",
+      }
+    }
   });
 
   await runner.promise;

--- a/website/docs/contributing.md
+++ b/website/docs/contributing.md
@@ -3,73 +3,200 @@ title: "Contributing"
 sidebar_position: 170
 ---
 
-We love contributions from the community; but please: if you&apos;re planning to
-do something big, talk to us first. Graphile Worker is quite opinionated and
-prioritizes performance over many other things, so there&apos;s a risk that we
-may not want your feature in core, and we don&apos;t want you to waste your
-time!
+We love contributions from the community; but please: if you are planning to do
+something big, talk to us first. Graphile Worker is quite opinionated and
+prioritizes performance over many other things, so there is a risk that we may
+not want your feature in core, and we do not want you to waste your time!
 
 ## Development
 
-Graphile Worker is developed using yarn 1.x
+### Setup
+
+1. Install yarn 1.x via the method of your choice.
+2. Fork and clone the (Graphile Worker git
+   repository)[https://github.com/graphile/worker]
+3. From the root of your local Graphile Worker repository, run `yarn install`
+
+### Automated Functional Testing
+
+Graphile Worker leans on its automated tests to prevent regressions in
+functionality and performance. After making any change to the source code, you
+should run the test suite to ensure that you did not introduce any regressions.
+Any edit to the expected behavior should also include an accompanying additon to
+the test suite to prevent future regressions.
+
+You must have a running Postgres database to run the tests. The test framework
+creates a template database. Each test clones the template database on demand.
+This allows the tests to run in parallel.
+
+For now, the database used for testing must be available at localhost:5432 with
+no username and password. The tests may be updated in the future to support
+arbitrary database connection information.
+
+Run `yarn test:setupdb` to setup the template database.
+
+Then, you can run `yarn test:only` to run the tests. The tests can be rerun as
+much as you want without rerunning `test:setupdb`.
+
+:::note
+
+If you have any files in `./tasks`, some tests will fail.
+
+:::
+
+### Running in CLI Mode
+
+When Graphile Worker users run in CLI mode, they run the script defined in
+`package.json` at `bin.graphile-worker`. To run your local version of Graphile
+Worker similarly, compile the package and run `cli.js`.
 
 ```sh
-yarn install
-yarn run watch
+yarn prepack
+yarn cli -c "postgres:///my_db"
 ```
 
-In another terminal:
+:::note
+
+The command above will fail to start if you don't have any tasks defined.
+`./tasks/` is included in the .gitignore, so you can add a simple hello world
+task there if you don't have any tasks yet.
+
+:::
+
+See the [CLI documentation](./cli/run.md) for more information about CLI mode.
+
+### Running in Library Mode
+
+When Graphile Worker users run in library mode, they use the functions exported
+in `src/index.ts`. The scrappiest thing you can do to run your local version of
+Graphile Worker similarly is to create a file, `src/temp.ts` that runs functions
+imported from `.`.
+
+```ts
+import { run } from ".";
+
+async function main() {
+  const runner = await run({
+    connectionString: "postgres:///my_db",
+    taskList: {
+      hello: async (_, helpers) => {
+        helpers.logger.info("Hello, world!");
+      },
+    },
+  });
+
+  await runner.promise;
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});
+```
+
+Then you can run `temp.ts` with `ts-node`:
 
 ```sh
-createdb graphile_worker_test
-yarn test
+yarn run ts-node src/temp.ts
 ```
 
-### Using Docker to develop this module
+You have to remember not to commit `src/temp.ts`, so a cleaner way to achieve
+this would be using `yarn link`. In the root of your local Graphile Worker
+repository run the following:
 
-Start the dev db and app in the background
+```sh
+yarn link
+```
+
+Create another node.js project with yarn that imports from `graphile-worker`
+like it would if it was using the published package. In that directory, run the
+following:
+
+```sh
+yarn link graphile-worker
+```
+
+Note that once you link, you still need to compile your local graphile-worker
+package any time you make a change in the package that you want to test. You can
+compile with the following command:
+
+```sh
+yarn prepack
+```
+
+If you're making frequent changes, you may want to automatically recompile any
+time there is a change. You can do so with the following command:
+
+```sh
+yarn watch
+```
+
+See the [yarn link](https://classic.yarnpkg.com/lang/en/docs/cli/link/) docs for
+more information about how linking works, including instructions for unlinking.
+
+### Docker Compose
+
+Some people run their Graphile Worker development environments in Docker. The
+`docker-compose.yml` file starts a minimal setup with a `db` container
+containing a Postgres database and an `app` container that is similar to running
+in CLI mode.
+
+To run the `db` and `app` containers in the backround, run the following:
 
 ```sh
 docker compose up -d
 ```
 
-Run the tests
+The tests currently rely on a database being available at localhost:5432. Thus,
+you cannot currently run the tests in the Docker Compose setup.
 
-```sh
-docker compose exec app yarn jest -i
-```
-
-Reset the test db
-
-```sh
-cat __tests__/reset-db.sql | docker compose exec -T db psql -U postgres -v GRAPHILE_WORKER_SCHEMA=graphile_worker graphile_worker_test
-```
-
-Run the perf tests
-
-```sh
-docker compose exec app node ./perfTest/run.js
-```
-
-monitor the container logs
+Tail the containers' logs the with the following command:
 
 ```sh
 docker compose logs -f db
 docker compose logs -f app
 ```
 
-### Database migrations
+### Authoring Database Migrations
 
-New database migrations must be accompanied by an updated db dump. This can be
-generated using the command `yarn db:dump`, and requires a running postgres 12
-server. Using docker:
+New database migrations must be accompanied by an updated db dump. Before
+generating a new dump, ensure the following:
+
+1. You have a Postgres db running at localhost:5432.
+2. You have `pg_dump`, and the version of `pg_dump` is the same major version of
+   your Postgres database.
+
+To check your `pg_dump` version, run the following:
 
 ```sh
-docker run -e POSTGRES_HOST_AUTH_METHOD=trust -d -p 5432:5432 postgres:12
+pg_dump --version
 ```
 
-then run
+To check the version of Postgres running at localhost:5432, run the following:
 
 ```sh
-PGUSER=postgres PGHOST=localhost yarn run db:dump
+psql postgres:///my_db -c "SELECT version();"
 ```
+
+To update the db dump, run the following command:
+
+```sh
+yarn db:dump
+```
+
+### Developing With Windows Machines
+
+The maintainer does not have access to a Windows development machine, so he
+cannot ensure that the development environment works.
+
+[This comment](https://github.com/graphile/worker/pull/316#issuecomment-1427173046)
+suggests that at least one change needs to be made to support contributing from
+a Windows machine. If you use Windows and want to help here, please do!
+
+## Contributing to the Documentation
+
+The docs are maintained in the
+[main Graphile Worker Repository](https://github.com/graphile/worker/tree/main/website/docs).
+See the
+[Website README](https://github.com/graphile/worker/blob/main/website/README.md)
+for more info on the website.


### PR DESCRIPTION
## Description

Did an overhaul on Contributing docs to make them up-to-date with the latest changes and provide info on the things I had to figure out myself.

I also fixed the `yarn website` script, which was not working, and I added the `yarn cli` script. I'm not deeply opinionated about having yarn cli, so if you think it's not useful enough to add to package.json scripts, I'm happy to update it and update the docs.

Also, when I ran docker compose I got this warning, so I removed the version line as instructed.

```
WARN[0000] /path/to/graphile/worker/docker-compose.yml: the attribute `version` is obsolete, it will be ignored, please remove it to avoid potential confusion 
```

## Checklist

- [x] My code matches the project's code style and `yarn lint:fix` passes.