### PR TITLE
tweaks to tasks documentation for clarity and consistency

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -129,8 +129,8 @@ declare global {
 
       /**
        * A list of file extensions (in priority order) that Graphile Worker
-       * should attempt to import directly when loading task executors from the
-       * file system.
+       * should attempt to import as Node modules when loading task executors from
+       * the file system.
        *
        * @defaultValue `[".js", ".cjs", ".mjs"]`
        */

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -181,8 +181,8 @@ export interface JobHelpers extends Helpers {
   ): Promise<QueryResult<R>>;
 
   /**
-   * A Node `AbortSignal` that will be triggered when the job should exit. It is
-   * used, for example, for a graceful shutdown request.
+   * An `AbortSignal` that will be triggered when the job should exit. It is used,
+   * for example, for a graceful shutdown request.
    *
    * @experimental
    */

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -134,7 +134,7 @@ export type AddJobsFunction = <TSpecs extends readonly AddJobsJobSpec[]>(
 
 export interface Helpers {
   /**
-   * A Logger instance.
+   * A `Logger` instance.
    */
   logger: Logger;
 
@@ -145,30 +145,30 @@ export interface Helpers {
   withPgClient: WithPgClient;
 
   /**
-   * Adds a job into our queue.
+   * Adds a job into the Graphile Worker queue.
    */
   addJob: AddJobFunction;
 
   /**
-   * Adds multiple jobs into our queue.
+   * Adds multiple jobs into the Graphile Worker queue.
    */
   addJobs: AddJobsFunction;
 }
 
 export interface JobHelpers extends Helpers {
   /**
-   * A Logger instance, scoped to this job.
+   * A `Logger` instance, scoped to this job.
    */
   logger: Logger;
 
   /**
-   * The currently executing job.
+   * The whole, currently executing job.
    */
   job: Job;
 
   /**
-   * Get the queue name of the give queue ID (or the currently executing job if
-   * no queue id is specified).
+   * Get the queue name of the given queue ID (or of the currently executing job
+   * if no queue ID is specified).
    */
   getQueueName(queueId?: number | null): PromiseOrDirect<string | null>;
 
@@ -181,7 +181,8 @@ export interface JobHelpers extends Helpers {
   ): Promise<QueryResult<R>>;
 
   /**
-   * An AbortSignal that will be triggered when the job should exit.
+   * A Node `AbortSignal` that will be triggered when the job should exit. It is
+   * used, for example, for a graceful shutdown request.
    *
    * @experimental
    */

--- a/website/docs/config.md
+++ b/website/docs/config.md
@@ -177,6 +177,10 @@ Here are the options under the `worker` key as defined by
 }
 ```
 
+See the
+[Graphile Worker source](https://github.com/jcgsville/worker/blob/85c36ac4e684a3a782fc528dca95c8ba6177fa8a/src/config.ts#L13)
+for the default `worker` options set by the default Worker Preset.
+
 ### worker.concurrentJobs
 
 Type: `number | undefined`
@@ -211,7 +215,8 @@ resolved.)
 Type: `string[] | undefined`
 
 A list of file extensions (in priority order) that Graphile Worker should
-attempt to import directly when loading task executors from the file system.
+attempt to import as Node modules when loading task executors from the file
+system.
 
 ### worker.getQueueNameBatchDelay
 

--- a/website/docs/tasks.md
+++ b/website/docs/tasks.md
@@ -87,7 +87,7 @@ the extension) joined with `/` characters:
 How the file is loaded as a task executor will depend on the specific file and
 the plugins you have loaded.
 
-## Loading JavaScript task executors
+## Loading JavaScript files
 
 With the default preset, Graphile Worker will load `.js`, `.cjs` and `.mjs`
 files as task executors using the `import()` function. If the file is a CommonJS
@@ -100,7 +100,7 @@ at the source code of
 [`LoadTaskFromJsPlugin.ts`](https://github.com/graphile/worker/blob/main/src/plugins/LoadTaskFromJsPlugin.ts)
 for inspiration.
 
-### Loading TypeScript task executors
+### Loading TypeScript files
 
 :::tip
 
@@ -154,9 +154,9 @@ Worker will see this as success. All other exit codes are seen as failure.
 ### Environment variables
 
 - `GRAPHILE_WORKER_PAYLOAD_FORMAT` &mdash; the encoding that Graphile Worker
-  used to pass the payload to the binary. Currently this will always be the
-  string `json`, but you should check this before processing the payload in case
-  the format changes.
+  used to pass the payload to the binary. Currently this will be the string
+  `json`, but you should check this before processing the payload in case the
+  format changes.
 - `GRAPHILE_WORKER_TASK_IDENTIFIER` &mdash; the identifier for the task this
   file represents (useful if you want multiple task identifiers to be served by
   the same binary file, e.g. via symlinks)
@@ -191,15 +191,19 @@ promises &mdash; i.e. the successful entries will be removed.
 
 ### `helpers.abortPromise`
 
+**Experimental**
+
 This is a promise that will reject when [`abortSignal`](#helpersabortsignal)
 aborts. This makes it convenient for exiting your task when the abortSignal
 fires: `Promise.race([abortPromise, doYourAsyncThing()])`.
 
 ### `helpers.abortSignal`
 
-This is a Node `AbortSignal`. Use this to be notified that you should abort your
-task early due to a graceful shutdown request. `AbortSignal`s can be passed to a
-number of asynchronous Node.js methods like
+**Experimental**
+
+This is a Node `AbortSignal` that will be triggered when the job should exit
+early. It is used, for example, for a graceful shutdown request. `AbortSignal`s
+can be passed to a number of asynchronous Node.js methods like
 [`http.request()`](https://nodejs.org/api/http.html#httprequesturl-options-callback).
 
 ### `helpers.addJob()`
@@ -212,17 +216,17 @@ See [`addJobs`](/library/add-job.md#add-jobs).
 
 ### `helpers.getQueueName()`
 
-Get the name of the queue the job is in, or the queue name of the provided queue
-ID. This function may or may not return a promise. We recommend that you always
-`await` it.
+Get the queue name of the given queue ID (or of the currently executing job if
+no queue ID is specified). This function may or may not return a promise. We
+recommend that you always `await` it.
 
 ### `helpers.job`
 
-The whole job, including `uuid`, `attempts`, etc.
+The whole, currently executing job, including `uuid`, `attempts`, etc.
 
 ### `helpers.logger`
 
-See [Logger](./library/logger)
+A logger instance scoped to this job. See [Logger](./library/logger)
 
 ### `helpers.query()`
 

--- a/website/docs/tasks.md
+++ b/website/docs/tasks.md
@@ -151,6 +151,11 @@ the file with the relevant environment variables and pass in the payload
 according to the encoding. If the executable exits with code `0` then Graphile
 Worker will see this as success. All other exit codes are seen as failure.
 
+This feature is added via the
+[LoadTaskFromExecutableFilePlugin plugin](https://github.com/graphile/worker/blob/main/src/plugins/LoadTaskFromExecutableFilePlugin.ts)
+in the default
+[Worker Preset](https://github.com/graphile/worker/blob/main/src/preset.ts).
+
 ### Environment variables
 
 - `GRAPHILE_WORKER_PAYLOAD_FORMAT` &mdash; the encoding that Graphile Worker
@@ -201,9 +206,9 @@ fires: `Promise.race([abortPromise, doYourAsyncThing()])`.
 
 **Experimental**
 
-This is a Node `AbortSignal` that will be triggered when the job should exit
-early. It is used, for example, for a graceful shutdown request. `AbortSignal`s
-can be passed to a number of asynchronous Node.js methods like
+This is a `AbortSignal` that will be triggered when the job should exit early.
+It is used, for example, for a graceful shutdown request. `AbortSignal`s can be
+passed to a number of asynchronous Node.js methods like
 [`http.request()`](https://nodejs.org/api/http.html#httprequesturl-options-callback).
 
 ### `helpers.addJob()`
@@ -236,9 +241,10 @@ This is a convenience wrapper for
 
 ### `helpers.withPgClient()`
 
-`withPgClient` gets a `pgClient` from the pool, calls
-`await callback(pgClient)`, and finally releases the client and returns the
-result of `callback`. This workflow can make testing your tasks easier.
+`withPgClient` gets a `pgClient` from the pool that Graphile Worker uses. It
+calls `await callback(pgClient)`, and finally releases the client and returns
+the result of `callback`. This workflow can make testing your tasks easier by
+making it easier to mock `pgClient`.
 
 Example:
 

--- a/website/docs/tasks.md
+++ b/website/docs/tasks.md
@@ -244,8 +244,7 @@ This is a convenience wrapper for
 
 `withPgClient` gets a `pgClient` from the pool that Graphile Worker uses. It
 calls `await callback(pgClient)`, and finally releases the client and returns
-the result of `callback`. This workflow can make testing your tasks easier by
-making it easier to mock `pgClient`.
+the result of `callback`. This workflow can make testing your tasks easier.
 
 Example:
 

--- a/website/docs/tasks.md
+++ b/website/docs/tasks.md
@@ -118,9 +118,10 @@ one way is to do the following:
    `NODE_OPTIONS="--loader ts-node/esm"` set.
 
 ```ts title="Example graphile.config.ts"
-import type {} from "graphile-worker";
+import { WorkerPreset } from "graphile-worker";
 
 const preset: GraphileConfig.Preset = {
+  extends: [WorkerPreset],
   worker: {
     connectionString: process.env.DATABASE_URL,
     concurrentJobs: 5,


### PR DESCRIPTION
Also including a couple small followups to the config documentation tweaks

- [x] My code matches the project's code style and `yarn lint:fix` passes.