### PR TITLE
Change bin script name to avoid conflicts with another version of graphile-worker

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "website:deploy": "yarn website deploy"
   },
   "bin": {
-    "graphile-worker": "./dist/cli.js"
+    "graphile-worker-v2": "./dist/cli.js"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Resolving a conflict between two version of graphile side-by-side in an app