### PR TITLE
Add nested folder capability for crontab tasks

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -44,6 +44,8 @@ Read more:
 - `helpers.abortPromise` added; will reject when `abortSignal` aborts (useful
   for `Promise.race()`)
 - `backfillPeriod` is now marked as optional in TypeScript (defaults to 0).
+- Support for loading tasks from nested folders in crontab.
+  - (`* * * * * nested/folder/task ?jobKey=my_key&jobKeyMode=preserve_run_at`)
 
 ## v0.16.6
 

--- a/__tests__/__snapshots__/crontab.test.ts.snap
+++ b/__tests__/__snapshots__/crontab.test.ts.snap
@@ -143,5 +143,35 @@ Array [
     "task": "with_key_and_mode",
     Symbol(isParsed): true,
   },
+  Object {
+    "identifier": "nested/task",
+    "match": [Function],
+    "options": Object {
+      "backfillPeriod": 0,
+      "jobKey": "my_key",
+      "jobKeyMode": "preserve_run_at",
+      "maxAttempts": undefined,
+      "priority": undefined,
+      "queueName": undefined,
+    },
+    "payload": null,
+    "task": "nested/task",
+    Symbol(isParsed): true,
+  },
+  Object {
+    "identifier": "nested/folder/task",
+    "match": [Function],
+    "options": Object {
+      "backfillPeriod": 0,
+      "jobKey": "my_key",
+      "jobKeyMode": "preserve_run_at",
+      "maxAttempts": undefined,
+      "priority": undefined,
+      "queueName": undefined,
+    },
+    "payload": null,
+    "task": "nested/folder/task",
+    Symbol(isParsed): true,
+  },
 ]
 `;

--- a/__tests__/crontab.test.ts
+++ b/__tests__/crontab.test.ts
@@ -188,7 +188,7 @@ test("parses crontab file correctly", () => {
     .parsedCronMatch as ParsedCronMatch;
   expect(parsedCronMatch10.minutes).toEqual(ALL_MINUTES);
   expect(parsedCronMatch10.hours).toEqual(ALL_HOURS);
-  
+
   expect(parsed).toMatchSnapshot();
 });
 

--- a/__tests__/crontab.test.ts
+++ b/__tests__/crontab.test.ts
@@ -44,6 +44,8 @@ test("parses crontab file correctly", () => {
     *     *      *       *       *      lots_of_spaces     
 * * * * * with_key ?jobKey=my_key
 * * * * * with_key_and_mode ?jobKey=my_key&jobKeyMode=preserve_run_at
+* * * * * nested/task ?jobKey=my_key&jobKeyMode=preserve_run_at
+* * * * * nested/folder/task ?jobKey=my_key&jobKeyMode=preserve_run_at
 `;
   const parsed = parseCrontab(exampleCrontab);
 
@@ -173,6 +175,20 @@ test("parses crontab file correctly", () => {
   });
   expect(parsed[8].payload).toEqual(null);
 
+  expect(parsed[9].task).toEqual("nested/task");
+  expect(parsed[9].identifier).toEqual("nested/task");
+  const parsedCronMatch9 = (parsed[9].match as any)
+    .parsedCronMatch as ParsedCronMatch;
+  expect(parsedCronMatch9.minutes).toEqual(ALL_MINUTES);
+  expect(parsedCronMatch9.hours).toEqual(ALL_HOURS);
+
+  expect(parsed[10].task).toEqual("nested/folder/task");
+  expect(parsed[10].identifier).toEqual("nested/folder/task");
+  const parsedCronMatch10 = (parsed[10].match as any)
+    .parsedCronMatch as ParsedCronMatch;
+  expect(parsedCronMatch10.minutes).toEqual(ALL_MINUTES);
+  expect(parsedCronMatch10.hours).toEqual(ALL_HOURS);
+  
   expect(parsed).toMatchSnapshot();
 });
 

--- a/src/cronConstants.ts
+++ b/src/cronConstants.ts
@@ -28,7 +28,7 @@ export const CRONTAB_WILDCARD = /^\*(?:\/([0-9]+))?$/;
 // The command from the crontab line
 /** Splits the command from the crontab line into the task, options and payload. */
 export const CRONTAB_COMMAND =
-  /^([_a-zA-Z][_a-zA-Z0-9:\/_-]*)(?:\s+\?([^\s]+))?(?:\s+(\{.*\}))?$/
+  /^([_a-zA-Z][_a-zA-Z0-9:/_-]*)(?:\s+\?([^\s]+))?(?:\s+(\{.*\}))?$/;
 
 // Crontab command options
 /** Matches the id=UID option, capturing the unique identifier */

--- a/src/cronConstants.ts
+++ b/src/cronConstants.ts
@@ -28,7 +28,7 @@ export const CRONTAB_WILDCARD = /^\*(?:\/([0-9]+))?$/;
 // The command from the crontab line
 /** Splits the command from the crontab line into the task, options and payload. */
 export const CRONTAB_COMMAND =
-  /^([_a-zA-Z][_a-zA-Z0-9:_-]*)(?:\s+\?([^\s]+))?(?:\s+(\{.*\}))?$/;
+  /^([_a-zA-Z][_a-zA-Z0-9:\/_-]*)(?:\s+\?([^\s]+))?(?:\s+(\{.*\}))?$/
 
 // Crontab command options
 /** Matches the id=UID option, capturing the unique identifier */


### PR DESCRIPTION
## Description

Implementation of the #542, allow nested folder task declarations in the crontab.


## Performance impact

unkown

## Security impact

unknown

## Checklist

- [x] My code matches the project's code style and `yarn lint:fix` passes.
- [x] I've added tests for the new feature, and `yarn test` passes.
- [ ] I have detailed the new feature in the relevant documentation.
- [x] I have added this feature to 'Pending' in the `RELEASE_NOTES.md` file (if one exists).
- [ ] If this is a breaking change I've explained why.