### PR TITLE
Cron error recovery

### DIFF
--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -568,9 +568,9 @@ export interface WorkerPool {
 
 export interface Runner {
   /** Attempts to cleanly shut down the runner */
-  stop: () => Promise<void>;
+  stop: (reason?: string) => Promise<void>;
   /** Use .stop() instead, unless you know what you're doing */
-  kill: () => Promise<void>;
+  kill: (reason?: string) => Promise<void>;
   addJob: AddJobFunction;
   promise: Promise<void>;
   events: WorkerEvents;


### PR DESCRIPTION
Currently if cron is running and the database connection goes away, it's likely that cron will bring down the entire worker instance from the inside on the next minute tickover.

This PR changes this, cron now handles its own errors via exponential backoff. This does mean that if there are bugs in cron then those errors will be logged but won't cause the system to exit, but it's necessary to be resilient to connection failure.

In future we should filter errors on expected connection error codes but enumerating those is quite tough:

- ENOENT (unix socket doesn't exist)
- ECONNREFUSED
- ETIMEDOUT
- EHOSTUNREACH
- EAI_AGAIN
- ECONNRESET
- EPIPE
- errors relating to SSL
- Regular PG errors relating to system administration (e.g. `57P03` for recovery, `53300` for too many connections, etc)
- etc

For now, just retrying infinitely seems like the best approach.