### PR TITLE
docs: document array payload merging behavior with job_key

### DIFF
--- a/website/docs/job-key.md
+++ b/website/docs/job-key.md
@@ -118,7 +118,7 @@ payloads merged together. With the default `replace` job_key_mode, each new
 event would push the `run_at` forward, creating a rolling/debounce window
 instead.
 
-:::caution[Both payloads must be arrays for merging to occur]
+:::caution Both payloads must be arrays for merging to occur
 
 If **either** payload is not an array (e.g., one is an object, as is the default
 if no payload is specified), the standard replace behavior applies and the old

--- a/website/docs/tasks.md
+++ b/website/docs/tasks.md
@@ -193,7 +193,7 @@ any of these promises reject, then the job will be re-enqueued, but the payload
 will be overwritten to only contain the entries associated with the rejected
 promises &mdash; i.e. the successful entries will be removed.
 
-:::tip[Accumulating batch payloads with job_key]
+:::tip Accumulating batch payloads with job_key
 
 You can use [`job_key`](./job-key.md#array-payload-merging) with array payloads
 to accumulate multiple events into a single batch job. When both the existing


### PR DESCRIPTION
## Summary

Documents the undocumented array payload merging behavior when using `job_key` to update existing jobs.

When both the existing job's payload and the new payload are JSON arrays, Graphile Worker concatenates them rather than replacing. This enables batching patterns, including when combined with `preserve_run_at` for fixed batching windows.

## Changes

- Add "Array payload merging" section to `job-key.md` with SQL example
- Add cross-reference tip in `tasks.md` batch jobs section  
- Document the caution that non-array payloads trigger standard replace behavior

## Context

The feature is implemented in `add_jobs()`:

```sql
payload =
  case
  when json_typeof(jobs.payload) = 'array' and json_typeof(excluded.payload) = 'array' then
    (jobs.payload::jsonb || excluded.payload::jsonb)::json
  else
    excluded.payload
  end,
```

This is useful but hard to discover without reading the source code.

🤖 Generated with [Claude Code](https://claude.ai/code)


Note that the above is AI generated and I might be misunderstanding things, apologies if this is noise and thank you for this project!