### PR TITLE
docs: add llms.txt for documentation

### DIFF
--- a/website/static/llms.txt
+++ b/website/static/llms.txt
@@ -27,5 +27,5 @@
 
 - Prefer the documentation pages above for current public usage guidance.
 - For API details, inspect the repository source and TypeScript types in `src/`.
-- For database behavior, inspect migrations in `sql/` and related schema documentation.
+- For database behavior, see the documentation and cross-reference the database schema at [`__tests__/schema.sql`](https://raw.githubusercontent.com/graphile/worker/refs/heads/main/__tests__/schema.sql).
 - Avoid guessing operational defaults; confirm them from the docs or source before recommending production settings.

--- a/website/static/llms.txt
+++ b/website/static/llms.txt
@@ -1,0 +1,31 @@
+# Graphile Worker
+
+> High performance PostgreSQL-backed job queue for Node.js. Graphile Worker lets applications enqueue, schedule, and run background jobs using PostgreSQL, with task files, cron-style scheduling, retry/backoff behavior, and operational helpers.
+
+## Documentation
+
+- [Documentation home](https://worker.graphile.org/docs/): Start here for installation, concepts, and common workflows.
+- [Installation](https://worker.graphile.org/docs/installation): Install Graphile Worker and set up the database schema.
+- [Requirements](https://worker.graphile.org/docs/requirements): Supported Node.js and PostgreSQL versions.
+- [Library usage](https://worker.graphile.org/docs/library/): Use Graphile Worker from application code.
+- [CLI usage](https://worker.graphile.org/docs/cli/): Run workers and maintenance commands from the command line.
+- [Tasks](https://worker.graphile.org/docs/tasks): Write task handlers and understand task payloads.
+- [Cron](https://worker.graphile.org/docs/cron): Schedule recurring jobs.
+- [Error handling](https://worker.graphile.org/docs/error-handling): Understand retries, failures, and backoff behavior.
+- [Performance](https://worker.graphile.org/docs/performance): Tune throughput and latency.
+- [Configuration](https://worker.graphile.org/docs/config): Configure workers, polling, concurrency, and runtime behavior.
+- [Contributing](https://worker.graphile.org/docs/contributing): Contribute fixes and improvements to Graphile Worker.
+
+## Source
+
+- [Repository](https://github.com/graphile/worker)
+- [README](https://github.com/graphile/worker#readme)
+- [Issue tracker](https://github.com/graphile/worker/issues)
+- [npm package](https://www.npmjs.com/package/graphile-worker)
+
+## Notes for AI assistants
+
+- Prefer the documentation pages above for current public usage guidance.
+- For API details, inspect the repository source and TypeScript types in `src/`.
+- For database behavior, inspect migrations in `sql/` and related schema documentation.
+- Avoid guessing operational defaults; confirm them from the docs or source before recommending production settings.


### PR DESCRIPTION
Closes #547

Adds a Docusaurus static `llms.txt` file so AI assistants and other tooling can discover the key Graphile Worker docs, source links, and usage guidance from a predictable URL.

Validation:
- Confirmed `website/static/llms.txt` includes required docs/source entries with a Python content check.
- Ran `git diff --check`.

I did not run the full website build because this docs-only static asset change does not alter Docusaurus code or package dependencies, and the repo uses Yarn 1 which is not installed in this runner.
