### PR TITLE
You might not need ts-node

### DIFF
--- a/.prettierrc.js
+++ b/.prettierrc.js
@@ -1,4 +1,4 @@
-module.exports = {
+export default {
   trailingComma: "all",
   proseWrap: "always",
 };

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,7 +1,8 @@
-const js = require("@eslint/js");
-const { FlatCompat } = require("@eslint/eslintrc");
-const { readFileSync } = require("node:fs");
+import js from "@eslint/js";
+import { FlatCompat } from "@eslint/eslintrc";
+import { readFileSync } from "node:fs";
 
+const __dirname = import.meta.dirname;
 const compat = new FlatCompat({
   baseDirectory: __dirname,
   recommendedConfig: js.configs.recommended,
@@ -22,7 +23,7 @@ const ignores = readFileSync(`${__dirname}/.lintignore`, "utf8")
   })
   .filter((l) => l != null);
 
-module.exports = [
+export default [
   {
     ignores: [...ignores, "eslint.config.js", ".prettierrc.js"],
   },

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "graphile-worker",
   "version": "0.17.2",
-  "type": "commonjs",
+  "type": "module",
   "description": "Job queue for PostgreSQL",
   "main": "dist/index.js",
   "scripts": {

--- a/scripts/dump_db
+++ b/scripts/dump_db
@@ -6,7 +6,7 @@ dropuser graphile_worker_role || true
 psql template1 -c "CREATE USER graphile_worker_role WITH SUPERUSER PASSWORD 'password';"
 createdb graphile_worker_dump -O graphile_worker_role
 yarn prepack
-PGUSER=graphile_worker_role PGPASSWORD=password PGHOST=127.0.0.1 node --experimental-strip-types dist/cli.js -c postgres:///graphile_worker_dump --schema-only
+PGUSER=graphile_worker_role PGPASSWORD=password PGHOST=127.0.0.1 node dist/cli.js -c postgres:///graphile_worker_dump --schema-only
 pg_dump --schema-only --no-owner graphile_worker_dump | sed -E -e '/^--/d' -e '/^\s*$/d' -e '/^[\\](un)?restrict/d' -e '/^SET /d' -e 's/EXECUTE FUNCTION/EXECUTE PROCEDURE/g' -e '/^(REVOKE|GRANT) .* ON SCHEMA public (FROM|TO) PUBLIC;$/d' > __tests__/schema.sql
 pg_dump --data-only --no-owner graphile_worker_dump --table=graphile_worker.migrations --table=graphile_worker._private_pro_migrations | sed -E -e '/^--/d' -e '/^\s*$/d' -e '/^[\\](un)?restrict/d' -e 's/\b2[0-9]{3}-[0-9]{2}-[0-9]{2}\s[0-9]{2}:[0-9]{2}:[0-9]{2}\.[0-9]{1,6}\+[0-9]+/1970-01-01 00:00:00.000000+00/g'  -e '/^SET /d' >> __tests__/schema.sql
 dropdb graphile_worker_dump

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 import { loadConfig } from "graphile-config/load";
-import * as yargs from "yargs";
+import yargs from "yargs";
 
 import { assertCleanupTasks, cleanup } from "./cleanup.ts";
 import { getCronItemsInternal } from "./getCronItems.ts";
@@ -9,7 +9,7 @@ import { getUtilsAndReleasersFromOptions } from "./lib.ts";
 import { EMPTY_PRESET, WorkerPreset } from "./preset.ts";
 import { runInternal, runOnceInternal } from "./runner.ts";
 
-const argv = yargs
+const argv = yargs()
   .parserConfiguration({
     "boolean-negation": false,
   })

--- a/src/index.ts
+++ b/src/index.ts
@@ -24,7 +24,7 @@ import type { CompiledSharedOptions } from "./lib.ts";
 export { parseCronItem, parseCronItems, parseCrontab } from "./crontab.ts";
 export * from "./interfaces.ts";
 export type { LogFunctionFactory } from "./logger.ts";
-export { consoleLogFactory, Logger, LogLevel } from "./logger.ts";
+export { consoleLogFactory, Logger } from "./logger.ts";
 export { runTaskList, runTaskListOnce } from "./main.ts";
 export { WorkerPreset } from "./preset.ts";
 export { run, runMigrations, runOnce } from "./runner.ts";

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -6,7 +6,6 @@ if (process.env.GRAPHILE_WORKER_DEBUG) {
 import type { LogFunctionFactory as GraphileLogFunctionFactory } from "@graphile/logger";
 import {
   Logger as GraphileLogger,
-  LogLevel,
   makeConsoleLogFactory,
 } from "@graphile/logger";
 
@@ -16,8 +15,6 @@ export interface LogScope {
   taskIdentifier?: string;
   jobId?: string;
 }
-
-export { LogLevel };
 
 // For backwards compatibility
 export class Logger extends GraphileLogger<LogScope> {}

--- a/website/docs/contributing.md
+++ b/website/docs/contributing.md
@@ -112,13 +112,16 @@ See the [CLI documentation](./cli/run.md) for more information about CLI mode.
 
 ### Running in Library Mode
 
-When Graphile Worker users run in library mode, they use the functions exported
-from `src/index.ts`. The scrappiest thing you can do to run your local version
-of Graphile Worker similarly is to create a Typescript file that runs functions
-imported from `.`.
+#### In the Graphile Worker repo
 
-```ts title="src/temp.ts"
-import { run, WorkerPreset } from ".";
+When Graphile Worker users run in library mode, they use the functions exported
+from `src/index.ts`, which is compiled to `dist/index.js`. To run your local
+version of Graphile Worker similarly you can create a `.mts` Typescript file
+that runs functions imported from `./dist/index.js` (this uses Node.js' built in
+type stripping):
+
+```ts title="temp.mts"
+import { run, WorkerPreset } from "./dist/index.js";
 
 async function main() {
   const runner = await run({
@@ -144,21 +147,23 @@ main().catch((err) => {
 });
 ```
 
-Then you can run `temp.ts` with `ts-node`:
+Then you can run `temp.mts` by first compiling Graphile Worker then running your
+file with `node`:
 
 ```sh
-yarn run ts-node src/temp.ts
+yarn prepack && node temp.mts
 ```
 
-You have to remember not to commit `src/temp.ts`, so a cleaner way to achieve
-this would be using `yarn link`. In the root of your local Graphile Worker
-repository run the following:
+#### In your own repo
+
+To try out your Graphile Worker version in your own repository, use `yarn link`.
+In the root of your local Graphile Worker repository run the following:
 
 ```sh
 yarn link
 ```
 
-Create another node.js project with yarn that imports from `graphile-worker`
+Create another Node.js project with yarn that imports from `graphile-worker`
 like it would if it was using the published package. In that directory, run the
 following:
 

--- a/website/docs/contributing.md
+++ b/website/docs/contributing.md
@@ -115,13 +115,13 @@ See the [CLI documentation](./cli/run.md) for more information about CLI mode.
 #### In the Graphile Worker repo
 
 When Graphile Worker users run in library mode, they use the functions exported
-from `src/index.ts`, which is compiled to `dist/index.js`. To run your local
-version of Graphile Worker similarly you can create a `.mts` Typescript file
-that runs functions imported from `./dist/index.js` (this uses Node.js' built in
-type stripping):
+from `src/index.ts` (which is compiled to `dist/index.js`, but thanks to Node's
+native type stripping you don't need to worry about that). To run your local
+version of Graphile Worker similarly you can create a `.ts` Typescript file that
+runs functions imported from `./src/index.ts`:
 
-```ts title="temp.mts"
-import { run, WorkerPreset } from "./dist/index.js";
+```ts title="temp.ts"
+import { run, type WorkerPreset } from "./src/index.ts";
 
 async function main() {
   const runner = await run({
@@ -147,11 +147,11 @@ main().catch((err) => {
 });
 ```
 
-Then you can run `temp.mts` by first compiling Graphile Worker then running your
+Then you can run `temp.ts` by first compiling Graphile Worker then running your
 file with `node`:
 
 ```sh
-yarn prepack && node temp.mts
+node temp.ts
 ```
 
 #### In your own repo

--- a/website/docs/tasks.md
+++ b/website/docs/tasks.md
@@ -102,6 +102,13 @@ for inspiration.
 
 ### Loading TypeScript files
 
+:::info
+
+You might not need to use ts-node anymore since Node.js has native type
+stripping support. These docs need to be updated.
+
+:::
+
 :::tip
 
 For performance and memory usage reasons, we recommend that you compile


### PR DESCRIPTION
Yarn berry work has been extracted to other PRs. What remains is docs updates for ts-node.

TODO:

- [ ] Make it so Worker can run type-strippable TS code directly by default (or at least easily...)