### PR TITLE
Make LogLevel verbatim syntax safe (breaking)

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -28,6 +28,8 @@ Read more:
   reach the end of the scope. (Primarily useful for tests.)
 - Maintenance work: upgrade to latest TypeScript, Jest, eliminate ts-node, fix
   yargs, use erasable syntax only for type-stripping support,
+- `LogLevel` export is now type only - a string union rather than a TypeScript
+  const enum.
 
 ## v0.17.2
 

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
   },
   "homepage": "https://github.com/graphile/worker#readme",
   "dependencies": {
-    "@graphile/logger": "^0.2.0",
+    "@graphile/logger": "^0.3.0",
     "@types/debug": "^4.1.10",
     "@types/pg": "^8.10.5",
     "cosmiconfig": "^8.3.6",

--- a/src/index.ts
+++ b/src/index.ts
@@ -23,8 +23,8 @@ import type {
 import type { CompiledSharedOptions } from "./lib.ts";
 export { parseCronItem, parseCronItems, parseCrontab } from "./crontab.ts";
 export * from "./interfaces.ts";
-export type { LogFunctionFactory } from "./logger.ts";
-export { consoleLogFactory, Logger, LogLevel } from "./logger.ts";
+export type { LogFunctionFactory, LogLevel } from "./logger.ts";
+export { consoleLogFactory, Logger } from "./logger.ts";
 export { runTaskList, runTaskListOnce } from "./main.ts";
 export { WorkerPreset } from "./preset.ts";
 export { run, runMigrations, runOnce } from "./runner.ts";

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -3,10 +3,12 @@ if (process.env.GRAPHILE_WORKER_DEBUG) {
   process.env.GRAPHILE_LOGGER_DEBUG = process.env.GRAPHILE_WORKER_DEBUG;
 }
 
-import type { LogFunctionFactory as GraphileLogFunctionFactory } from "@graphile/logger";
+import type {
+  LogFunctionFactory as GraphileLogFunctionFactory,
+  LogLevel,
+} from "@graphile/logger";
 import {
   Logger as GraphileLogger,
-  LogLevel,
   makeConsoleLogFactory,
 } from "@graphile/logger";
 
@@ -17,7 +19,7 @@ export interface LogScope {
   jobId?: string;
 }
 
-export { LogLevel };
+export type { LogLevel };
 
 // For backwards compatibility
 export class Logger extends GraphileLogger<LogScope> {}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2450,10 +2450,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@graphile/logger@npm:^0.2.0":
-  version: 0.2.0
-  resolution: "@graphile/logger@npm:0.2.0"
-  checksum: 10/0b080871c8c3698371ae5ce9633597ff636cf8be1227cf640c1effb70e2fa4d7aa7fb90e72da3f990076951a38511a2b6ab82c276a791644bec164966a38d000
+"@graphile/logger@npm:^0.3.0":
+  version: 0.3.0
+  resolution: "@graphile/logger@npm:0.3.0"
+  checksum: 10/2eff71dcc68eaf37fea241c6122219bd03c490688aab160f89db46c478dd86ea7e7165ce49c1a510587a785a2774825d9396b6a277ab860c4889e9e25e5beee7
   languageName: node
   linkType: hard
 
@@ -8013,7 +8013,7 @@ __metadata:
     "@fortawesome/free-regular-svg-icons": "npm:^6.5.1"
     "@fortawesome/free-solid-svg-icons": "npm:^6.5.1"
     "@fortawesome/react-fontawesome": "npm:^0.2.0"
-    "@graphile/logger": "npm:^0.2.0"
+    "@graphile/logger": "npm:^0.3.0"
     "@jest/globals": "npm:^30.2.0"
     "@mdx-js/react": "npm:^1.6.22"
     "@tsconfig/node-ts": "npm:^23.6.4"


### PR DESCRIPTION
Previously `@graphile/logger` had LogLevel as a `const enum` type - which meant it had both value and type behavior. We've updated to the latest logger which now exposes `LogLevel` as a simple string union type, and we now expose this type only.