### PR TITLE
docs(interfaces): clarify that `attempts` is 1-indexed during a run

### DIFF
--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -475,11 +475,17 @@ export interface DbJob {
   priority: number;
   /** When it was due to run */
   run_at: Date;
-  /** How many times it has been attempted */
+  /**
+   * The number of attempts made so far, including any attempt currently in
+   * progress. Incremented atomically each time the job is locked for execution,
+   * so during a running handler this counts the in-flight attempt:
+   * `attempts === 1` on the first run and `attempts === max_attempts` on the
+   * final run.
+   */
   attempts: number;
   /** The limit for the number of times it should be attempted */
   max_attempts: number;
-  /** If attempts > 0, why did it fail last? */
+  /** The error message from the previous failed attempt, if any (null on the first run). */
   last_error: string | null;
   created_at: Date;
   updated_at: Date;


### PR DESCRIPTION
`attempts` is incremented when a job is locked for execution, so a running handler sees `attempts === 1` on the first run and `attempts === max_attempts` on the final run. The previous wording ("How many times it has been attempted") is easy to misread as "prior failures", which leads to off-by-one final-attempt checks. Spell out the semantics on `attempts` and refine the related `last_error` comment, which read as inaccurate for the first in-flight attempt.

## Description

<!-- If this PR adds a feature, what does it add and what was the motivation for it? -->
<!-- If this PR fixes an issue, what is the issue? -->
<!-- Please link to the relevant GitHub issues/Discord discussion/etc as appropriate -->

## Performance impact

<!-- Detail any impact on performance of this PR, or put 'unknown' if not known -->

## Security impact

<!-- Detail any impact on security of this PR, or put 'unknown' if not known -->

## Checklist

<!-- If this PR is work in progress, please open it as a "Draft PR". -->
<!-- To tick a checkbox, change it from `[ ]` to `[x]` -->

- [x] My code matches the project's code style and `yarn lint:fix` passes.
- [ ] I've added tests for the new feature, and `yarn test` passes.
- [ ] I have detailed the new feature in the relevant documentation.
- [ ] I have added this feature to 'Pending' in the `RELEASE_NOTES.md` file (if one exists).
- [ ] If this is a breaking change I've explained why.

<!-- For some Graphile projects the documentation is the README.md file, for
      others please see https://github.com/graphile/graphile.github.io -->
