### PR TITLE
Fix localQueue running jobs from the same named queue concurrently

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -46,6 +46,10 @@ Read more:
   yargs, use erasable syntax only for type-stripping support.
 - `LogLevel` export is now type only - a string union rather than a TypeScript
   const enum.
+- Fix issue where enabling `localQueue` could cause jobs from the same named
+  queue to run concurrently (violating the serial execution guarantee for named
+  queues): a single batch fetch could lock multiple jobs belonging to one named
+  queue. Batch fetches now return at most one job per named queue (#621).
 
 ## v0.17.3
 

--- a/__tests__/main.runTaskList.test.ts
+++ b/__tests__/main.runTaskList.test.ts
@@ -140,3 +140,106 @@ test("gracefulShutdown", async () =>
     const [job] = jobs;
     expect(job.last_error).toBeTruthy();
   }));
+
+test("jobs in the same named queue run serially even when the local queue is enabled", () =>
+  withPgPool(async (pgPool) => {
+    await reset(pgPool, options);
+
+    const jobPromises: Deferred[] = [];
+    try {
+      const job1: Task<"job1"> = jest.fn(() => {
+        const jobPromise = deferred();
+        jobPromises.push(jobPromise);
+        return jobPromise;
+      });
+      const tasks: TaskList = {
+        job1,
+      };
+
+      // A backlog of 5 jobs in the same named queue, before the pool starts
+      for (let i = 0; i < 5; i++) {
+        await addJob(pgPool, i);
+      }
+
+      const workerPool = runTaskList(
+        {
+          concurrency: 4,
+          preset: { worker: { localQueue: { size: 5 }, pollInterval: 10 } },
+        },
+        tasks,
+        pgPool,
+      );
+
+      for (let i = 0; i < 5; i++) {
+        await sleepUntil(() => jobPromises.length >= i + 1);
+        // Give the pool a chance to (incorrectly) hand more jobs from the
+        // same queue to the other, idle workers
+        await sleep(50);
+        expect(jobPromises).toHaveLength(i + 1);
+
+        // Complete this job, on to the next one
+        jobPromises[i].resolve();
+      }
+
+      await workerPool.gracefulShutdown();
+      await expectJobCount(pgPool, 0);
+    } finally {
+      jobPromises.forEach((p) => p.resolve());
+    }
+  }));
+
+test("jobs in different named queues run in parallel when the local queue is enabled", () =>
+  withPgPool(async (pgPool) => {
+    await reset(pgPool, options);
+
+    const started: string[] = [];
+    const jobPromisesById: Record<string, Deferred> = {};
+    try {
+      const job1: Task<"job1"> = jest.fn(({ id }) => {
+        const jobPromise = deferred();
+        jobPromisesById[id] = jobPromise;
+        started.push(id);
+        return jobPromise;
+      });
+      const tasks: TaskList = {
+        job1,
+      };
+
+      const addJobToQueue = (id: string, queueName: string) =>
+        pgPool.query(
+          `select ${ESCAPED_GRAPHILE_WORKER_SCHEMA}.add_job('job1', json_build_object('id', $1::text), $2::text)`,
+          [id, queueName],
+        );
+      await addJobToQueue("a1", "queue_a");
+      await addJobToQueue("b1", "queue_b");
+      await addJobToQueue("a2", "queue_a");
+      await addJobToQueue("b2", "queue_b");
+
+      const workerPool = runTaskList(
+        {
+          concurrency: 4,
+          preset: { worker: { localQueue: { size: 5 }, pollInterval: 10 } },
+        },
+        tasks,
+        pgPool,
+      );
+
+      // The first job of each queue should run concurrently...
+      await sleepUntil(() => started.length >= 2);
+      await sleep(50);
+      expect([...started].sort()).toEqual(["a1", "b1"]);
+
+      // ...but each queue's second job must wait for its first to complete
+      jobPromisesById["a1"].resolve();
+      jobPromisesById["b1"].resolve();
+      await sleepUntil(() => started.length >= 4);
+      expect([...started].sort()).toEqual(["a1", "a2", "b1", "b2"]);
+      jobPromisesById["a2"].resolve();
+      jobPromisesById["b2"].resolve();
+
+      await workerPool.gracefulShutdown();
+      await expectJobCount(pgPool, 0);
+    } finally {
+      Object.values(jobPromisesById).forEach((p) => p.resolve());
+    }
+  }));

--- a/src/sql/getJobs.ts
+++ b/src/sql/getJobs.ts
@@ -155,8 +155,36 @@ q as (
     where job_queues.id = j.job_queue_id
 )`;
 
+  /**
+   * A batch (`batchSize > 1`) may select multiple jobs from the same named
+   * queue: `queueClause` locks each eligible queue row only once, but then
+   * every job belonging to that queue passes the eligibility check, so a
+   * single statement can lock several jobs from one queue. Those jobs would
+   * then run concurrently, breaking the serial execution guarantee for named
+   * queues (and once the first of them completes, `completeJobs`/`returnJobs`
+   * would unlock the queue while its siblings are still running, letting
+   * other pools claim yet more jobs from the same queue).
+   *
+   * To prevent this, keep only the first job per named queue and discard the
+   * rest. The discarded rows' `for update` locks release when the
+   * transaction ends and their `locked_at`/`locked_by` were never set, so
+   * they remain available; they cannot be picked up early because their
+   * queue stays locked (via `q` below) until the job we did keep completes.
+   * Jobs that aren't in a named queue are unaffected.
+   */
+  const dedupeClause =
+    batchSize > 1
+      ? `,
+j as (
+  select distinct on (job_queue_id, case when job_queue_id is null then id end)
+      job_queue_id, priority, run_at, id
+    from j_raw
+    order by job_queue_id, case when job_queue_id is null then id end, priority asc, run_at asc
+)`
+      : "";
+
   const text = `\
-with j as (
+with ${batchSize > 1 ? "j_raw" : "j"} as (
   select jobs.job_queue_id, jobs.priority, jobs.run_at, jobs.id
     from ${escapedWorkerSchema}._private_jobs as jobs
     where jobs.is_available = true
@@ -168,7 +196,7 @@ with j as (
     limit ${batchSize}
     for update
     skip locked
-)${updateQueue}
+)${dedupeClause}${updateQueue}
   update ${escapedWorkerSchema}._private_jobs as jobs
     set
       attempts = jobs.attempts + 1,


### PR DESCRIPTION
## Description

Fixes #621.

With `localQueue` enabled, jobs from the same named queue could run concurrently, violating the documented serial execution guarantee for named queues. A batch fetch (`batchSize > 1`) could lock multiple jobs belonging to the same named queue in a single statement: the queue eligibility subquery locks each available queue row once, but every job in that queue then passes the `in` membership check, so `limit batchSize` could take several of them. The local queue would hand these out to idle workers concurrently, making per-queue concurrency `min(localQueue.size, concurrentJobs)` instead of `1`. And once the first of those sibling jobs completed, `completeJobs` would unlock the queue row while the rest were still running, so other pools could lock yet more jobs from the same queue.

This PR makes batch fetches keep only the first job (by `priority`, `run_at`) per named queue and discard the rest. The discarded rows never get `locked_at`/`locked_by` set and their row locks release when the statement completes, while the queue row remains locked until the one kept job completes — restoring the invariant that a locked queue has exactly one job in flight, which `completeJobs`, `returnJobs`, and the `batchSize = 1` fetch already rely on. Jobs that aren't in a named queue are unaffected, and the `batchSize = 1` query text is byte-for-byte unchanged.

The reproduction script from #621 now reports `1` concurrent job (previously `4`), and the 12 jobs execute in insertion order.

Two new tests in `__tests__/main.runTaskList.test.ts` (the suite previously had no test exercising `localQueue`):

- jobs in the same named queue run serially even when the local queue is enabled — fails on `main`;
- jobs in different named queues run in parallel when the local queue is enabled — also fails on `main` (all four jobs start at once there), and guards against over-serialising the batch.

## Performance impact

- `localQueue` disabled (`batchSize = 1`): none — the query text is unchanged.
- Batch fetches: the added `distinct on` processes at most `batchSize` already-locked rows, which is negligible.
- Because the deduplication applies after `limit batchSize`, a fetch returns fewer than `batchSize` jobs whenever several of the selected rows share a named queue. The worst case is a backlog whose highest-precedence jobs all belong to one named queue while its tasks complete faster than `pollInterval`: each poll's fetch then selects that queue's jobs again and discards the duplicates, yielding a single job, so the pool works that queue at roughly one job per `pollInterval` and other ready jobs wait despite idle workers until the queue's backlog drains below the batch window. The effect is bounded by fetch timing: if the queue's job is still running at fetch time, its queue row is locked, its jobs are excluded, and the batch fills with jobs from other queues and unqueued jobs; a "new job" notification also triggers an immediate fetch with the same effect.
- Users of `localQueue.refetchDelay` with a non-zero `threshold` may see the refetch delay engage more often in workloads dominated by a few named queues.

## Security impact

None.

## Checklist

<!-- If this PR is work in progress, please open it as a "Draft PR". -->
<!-- To tick a checkbox, change it from `[ ]` to `[x]` -->

- [x] My code matches the project's code style and `yarn lint:fix` passes.
- [x] I've added tests for the new feature, and `yarn test` passes.
- [x] ~I have detailed the new feature in the relevant documentation.~ Bug fix — the documentation already describes the (serial) behaviour this PR restores.
- [x] I have added this feature to 'Pending' in the `RELEASE_NOTES.md` file (if one exists).
- [x] If this is a breaking change I've explained why. — Not a breaking change: it only removes undocumented concurrency that contradicted the documented behaviour.
